### PR TITLE
fix: typo at config page -> mqtt section

### DIFF
--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -426,7 +426,7 @@ textarea {
 				<input type="text" id="MQTT_Uri_value1">
 			</td>
 			<td style="font-size: 80%;">
-				URI to the MQTT broker including port: http:\\IP-ADRESS:port
+				URI to the MQTT broker including port e.g.: mqtt://IP-Address:Port
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
the wrong sample for the mqtt broker irritated me during the installation 