### PR TITLE
Clean up hardcoded IP addresses from gethost.js

### DIFF
--- a/sd-card/html/gethost.js
+++ b/sd-card/html/gethost.js
@@ -5,25 +5,9 @@ function gethost_Version(){
 
 
 function getbasepath(){
-    var host = window.location.hostname;
-    if (((host == "127.0.0.1") || (host == "localhost") || (host == "")) 
-//       && ((window.location.port == "80") || (window.location.port == ""))
-       )
-    
-    {
-//        host = "http://192.168.2.219";          // jomjol interner test
-//        host = "http://192.168.178.46";          // jomjol interner test
-        host = "http://192.168.178.34";          // jomjol interner Real
-//        host = "http://192.168.43.191";
-//        host = ".";                           // jomjol interner localhost   
-
-    }
-    else
-    {
-        host = "http://" + host;
-        if (window.location.port != "") {
-            host = host + ":" + window.location.port;
-        }
+    var host = window.location.protocol + "//" + window.location.hostname;
+    if (window.location.port != "") {
+        host = host + ":" + window.location.port;
     }
 
     return host;


### PR DESCRIPTION
Closes #769.

This lets me access the UI via an SSH tunnel as my device is connected to a protected network.