### PR TITLE
Update config-page info-text about MQTT topic structure (explain VALUE_NAME key)

### DIFF
--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -611,8 +611,12 @@ textarea {
 				<input type="text" id="MQTT_MainTopic_value1">
 			</td>
 			<td style="font-size: 80%;">
-				MQTT main topic, under which the counters are published. The single value will be published with the following key: MAINTOPIC/VALUE_NAME/PARAMETER <br>
-				where parameters are: value, rate, timestamp, error<br>
+				MQTT main topic, under which the counters are published. <br>
+				The single value will be published with the following key: MAINTOPIC/VALUE_NAME/PARAMETER where
+				<ul>
+					<li> VALUE_NAME is the name of the value (a meter might have more than one value) as defined during analog and digital ROI configuration (defaults to "main")</li>
+					<li> and PARAMETERS are: value, rate, timestamp, error</li>
+				</ul>
 				The general connection status can be found in MAINTOPIC/CONNECTION
 			</td>
 		</tr>


### PR DESCRIPTION
When I configured my ESP32 it took me quite some time to find out how to substitute the "VALUE_NAME" key in the topic until I was finally able to read the sensor values with HomeAssistant. That is why I added this info to the information column on the edit config.ini page (right before the "PARAMETER" key explanation).