### PR TITLE
Fix precision problem of float variable (6-7 digits)

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
@@ -33,9 +33,9 @@ struct NumberPost {
     bool checkDigitIncreaseConsistency;
     time_t lastvalue;
     string timeStamp;
-    float FlowRateAct;          // m3 / min
-    float PreValue;             // letzter Wert, der gut ausgelesen wurde
-    float Value;                // letzer ausgelesener Wert, inkl. Korrekturen
+    double FlowRateAct;          // m3 / min
+    double PreValue;             // letzter Wert, der gut ausgelesen wurde
+    double Value;                // letzer ausgelesener Wert, inkl. Korrekturen
     string ReturnRateValue;      // RückgabewertRate
     string ReturnChangeAbsolute;      // RückgabewertRate
     string ReturnRawValue;      // Rohwert (mit N & führenden 0)    

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -818,7 +818,7 @@ string ClassFlowPostProcessing::getReadoutParam(bool _rawValue, bool _noerror, i
     return NUMBERS[_number]->ReturnValue;
 }
 
-string ClassFlowPostProcessing::RundeOutput(float _in, int _anzNachkomma){
+string ClassFlowPostProcessing::RundeOutput(double _in, int _anzNachkomma){
     std::stringstream stream;
     int _zw = _in;    
 //    printf("AnzNachkomma: %d\n", _anzNachkomma);

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -698,7 +698,7 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
         while ((NUMBERS[j]->ReturnValue.length() > 1) && (NUMBERS[j]->ReturnValue[0] == '0'))
             NUMBERS[j]->ReturnValue.erase(0, 1);
 
-        NUMBERS[j]->Value = std::stof(NUMBERS[j]->ReturnValue);
+        NUMBERS[j]->Value = std::stod(NUMBERS[j]->ReturnValue);
 
         if (NUMBERS[j]->checkDigitIncreaseConsistency)
         {

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
@@ -34,7 +34,7 @@ protected:
 
     string ErsetzteN(string, float _prevalue);
     float checkDigitConsistency(float input, int _decilamshift, bool _isanalog, float _preValue);
-    string RundeOutput(float _in, int _anzNachkomma);
+    string RundeOutput(double _in, int _anzNachkomma);
 
     void InitNUMBERS();
     void handleDecimalSeparator(string _decsep, string _value);


### PR DESCRIPTION
fix #1010 
The arbitrary number changes result in an insufficient digit precision of the float definition. With the new double we are at 15-16digits and now a bit better away from rounding effects  