### PR TITLE
Release creation like CaCo3's update-ota2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -181,24 +181,30 @@ jobs:
           ./sd-card/html/version.txt
         key: ${{ github.run_number }}
 
+#########################################################################################
+## Prepare release
+#########################################################################################
+
     - name: Set Variables
       id: vars
       run: |
         echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
-    - name: Copy artifacts to firmware folder and create initial_esp32_setup.zip
+    - name: Prepare artifacts  for release
+      if: startsWith(github.ref, 'refs/tags/') 
       run: |
-        mkdir -p firmware
-        # copy builds to firmware folder for committing in next step
-        cp -f "./code/.pio/build/esp32cam/firmware.bin" "firmware/firmware.bin"
-        cp -f "./code/.pio/build/esp32cam/bootloader.bin" "firmware/bootloader.bin"
-        cp -f "./code/.pio/build/esp32cam/partitions.bin" "firmware/partitions.bin"
+        mkdir -p release
+        # copy builds to release folder
+        cp -f "./code/.pio/build/esp32cam/firmware.bin" "release/firmware.bin"
+        cp -f "./code/.pio/build/esp32cam/bootloader.bin" "release/bootloader.bin"
+        cp -f "./code/.pio/build/esp32cam/partitions.bin" "release/partitions.bin"
+        rm -rf ./release/*
         cd sd-card
-        rm -f ../firmware/html.zip
-        rm -f ../firmware/README.md
-        zip -r ../firmware/html.zip html
-        mkdir ../dist
+        zip -r ../release/html.zip html
+        # create a update.zip like "update__rolling"
         cd ../dist
+        zip -r ../release/update.zip .
+        
 
     - name: Upload initial_esp32_setup.zip artifact (Firmware + Bootloader + Partitions + Web UI + CNN)
       uses: actions/upload-artifact@v3
@@ -238,7 +244,7 @@ jobs:
         name:  ${{ steps.get_version.outputs.version-without-v }}
         body: ${{ steps.extract-release-notes.outputs.release_notes }}
         files: |
-          firmware/*   
+          release/*   
           
 
     # Commit&Push Changelog to master branch. Must be manually merged back to rolling

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@
 /sd-card/html/debug/
 /firmware/
 version.txt
-
+/dist/
+/dist_release/
+/dist_old_ota
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,20 +1,15 @@
 # Changelog
 
 ## [Unreleased]
-
-## [11.3.9] - 2022-09-20
-
 ### Added
 
--   auto release creation
-
-### Changed
-
--   something else
+- automatic release creation
+- newest firmware of rolling branch now uploaded to <https://github.com/jomjol/AI-on-the-edge-device/actions>
+- #1068 new safer and easier update mechanismn. Use only the update.zip of the release for firmware, html and new models. 
 
 ### Fixed
 
--   \#924 - fix of the Fix
+- #1029 wrong change of checkDigitConsistency now working like releases before 11.3.1 
 
 ## [10.6.2] - (2022-07-24)
 

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -49,8 +49,8 @@ extern "C" {
 
 /* Max size of an individual file. Make sure this
  * value is same as that set in upload_script.html */
-#define MAX_FILE_SIZE   (2000*1024) // 200 KB
-#define MAX_FILE_SIZE_STR "2000KB"
+#define MAX_FILE_SIZE   (8000*1024) // 8 MB
+#define MAX_FILE_SIZE_STR "8MB"
 
 
 /* Scratch buffer size */
@@ -489,7 +489,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 
     while (remaining > 0) {
 
-        ESP_LOGI(TAG_FILESERVER, "Remaining size : %d", remaining);
+        //ESP_LOGI(TAG_FILESERVER, "Remaining size : %d", remaining);
         /* Receive the file part by part into a buffer */
         if ((received = httpd_req_recv(req, buf, MIN(remaining, SCRATCH_BUFSIZE))) <= 0) {
             if (received == HTTPD_SOCK_ERR_TIMEOUT) {
@@ -757,7 +757,7 @@ std::string unzip_new(std::string _in_zip_file, std::string _target_zip, std::st
             p = mz_zip_reader_extract_file_to_heap(&zip_archive, archive_filename, &uncomp_size, 0);
             if (!p)
             {
-                printf("mz_zip_reader_extract_file_to_heap() failed!\n");
+                printf("mz_zip_reader_extract_file_to_heap() failed on file %s\n", archive_filename);
                 mz_zip_reader_end(&zip_archive);
                 return ret;
             }


### PR DESCRIPTION
- update.zip now like update-rolling
- used initial-setup.zip instead of standalone files
- initial-setup.zip contains now the complete sd-card directory
- updated the Changelog.md in Unreleased part
- suppress extracting of directories in OTA  update