### PR TITLE
Added issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_question.md
+++ b/.github/ISSUE_TEMPLATE/general_question.md
@@ -1,0 +1,10 @@
+---
+name: General  Question
+about: General Question => Open a discussion instead
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+If its not a bug, please open a discussion instead, see https://github.com/jomjol/AI-on-the-edge-device/discussions

--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Thank you for taking your time to report a bug.
+
+Before you proceed, please check:
+- Do you use the latest version? See https://github.com/jomjol/AI-on-the-edge-device/releases.
+- Is there already another similar issue? Check for open and closed Issue in https://github.com/jomjol/AI-on-the-edge-device/issues.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Version**
+Which version are you using? (See menu `System > Info`).
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,8 @@ Thank you for taking your time to report a bug.
 Before you proceed, please check:
 - Do you use the latest version? See https://github.com/jomjol/AI-on-the-edge-device/releases.
 - Is there already another similar issue? Check for open and closed Issue in https://github.com/jomjol/AI-on-the-edge-device/issues.
+- Are instructions in the readme solving your issue (https://github.com/jomjol/AI-on-the-edge-device/tree/master#readme)?
+- Are instructions in the wiki solving your issue? (https://github.com/jomjol/AI-on-the-edge-device/wiki)?
 
 **Describe the bug**
 A clear and concise description of what the bug is.


### PR DESCRIPTION
Provide issue templates so people easier can provide the needed information.

See working example in https://github.com/caco3/sandbox/issues/new/choose

@jomjol Needs to be in master to work