### PR TITLE
Support meter clock over

### DIFF
--- a/FeatureRequest.md
+++ b/FeatureRequest.md
@@ -11,6 +11,12 @@
 
 ____
 
+#### #30 Support meter clock over
+
+* In case of meter clocking over, that is, reaching its max. value and starting over from 0,
+  accept the new value and calculate correctly the difference.
+  (see line 739 onwards in ClassFlowPostProcessing.cpp)
+
 #### ~~#29 Add favicon and use the hostname for the website~~- implemented v11.3.1
 
 ~~* https://github.com/jomjol/AI-on-the-edge-device/issues/927~~


### PR DESCRIPTION
In case of meter clocking over, that is, reaching its max. value and starting over from 0,
  accept the new value and calculate correctly the difference.
  (see line 739 onwards in ClassFlowPostProcessing.cpp)
  
I don't know enough C to take up the challenge but here is a mathematical approach I would suggest:
1. calculate the number of (rounded) digits of the previous value;
2. calculate the meter's max. value based of the nr. of digits (pow(10d, nrOfDigits));
3. substract previous value from the max value above;
4. add the substraction above to the new value => this will be the difference.