### PR TITLE
accept minor negative values if extended resolution is enabled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,11 +9,12 @@
 ### Changed
 
 -   Updated built environment to `espressif32@v5.2.0`
-
+-   [#1176](https://github.com/jomjol/AI-on-the-edge-device/discussions/1176) accept minor negative values (-0.2) if extended resolution is enabled
 ### Fixed
 
 -   [#1116](https://github.com/jomjol/AI-on-the-edge-device/issues/1116) precision problem at setting prevalue
 -   [#1119](https://github.com/jomjol/AI-on-the-edge-device/issues/1119) renamed `firmware.bin` not working in OTA
+-   [#1143](https://github.com/jomjol/AI-on-the-edge-device/issues/1143) changed postprocess for analog->digit (lowest digit processing)
 ### Removed
 
 -   n.a.

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -739,12 +739,18 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
 
         if (!NUMBERS[j]->AllowNegativeRates)
         {
-            if (NUMBERS[j]->Value < NUMBERS[j]->PreValue)
+            if ((NUMBERS[j]->Value < NUMBERS[j]->PreValue))
             {
-                NUMBERS[j]->ErrorMessageText = NUMBERS[j]->ErrorMessageText + "Neg. Rate - Read: " + zwvalue + " - Raw: " + NUMBERS[j]->ReturnRawValue + " - Pre: " + RundeOutput(NUMBERS[j]->PreValue, NUMBERS[j]->Nachkomma) + " "; 
-                NUMBERS[j]->Value = NUMBERS[j]->PreValue;
-                NUMBERS[j]->ReturnValue = "";
-                continue;
+                // Bei isExtendedResolution Ungenauigkeit von 0.2 mit einrechnen.
+                if (NUMBERS[j]->Value < (NUMBERS[j]->PreValue-0.2) && NUMBERS[j]->isExtendedResolution) {
+                    NUMBERS[j]->Value = NUMBERS[j]->PreValue;
+                } else {
+                    NUMBERS[j]->ErrorMessageText = NUMBERS[j]->ErrorMessageText + "Neg. Rate - Read: " + zwvalue + " - Raw: " + NUMBERS[j]->ReturnRawValue + " - Pre: " + RundeOutput(NUMBERS[j]->PreValue, NUMBERS[j]->Nachkomma) + " "; 
+                    NUMBERS[j]->Value = NUMBERS[j]->PreValue;
+                    NUMBERS[j]->ReturnValue = "";
+                    continue;
+                }
+                
             }
         }
         #ifdef SERIAL_DEBUG

--- a/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
@@ -427,7 +427,7 @@ void test_doFlow() {
         result = process_doFlow(analogs, digits, Digital100, false, true, 0);
         TEST_ASSERT_EQUAL_STRING(expected_extended, result.c_str());
 
-        // Fehler  V12.0.1 
+        // Fehler  V11.3.0 
         // https://github.com/jomjol/AI-on-the-edge-device/issues/1143#issue-1400807695
         digits = { 7.0, 4.0, 7.0, 2.0, 7.0, 5.4, 9.4};  // 7472.749 als falsches Ergebnis
         analogs = {};


### PR DESCRIPTION
- accepts 0.2 differences of negative value only if extended resolution is on (#1176)