### PR TITLE
Fix for image logging + file deletion routines

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowImage.cpp
@@ -65,7 +65,7 @@ void ClassFlowImage::LogImage(string logPath, string name, float *resultFloat, i
         else
         {
             sprintf(buf, "%.1f_", *resultFloat);
-            if (strcmp(buf, "10.0_"))
+            if (strcmp(buf, "10.0_") == 0)
                 sprintf(buf, "0.0_");
         }
             
@@ -119,14 +119,16 @@ void ClassFlowImage::RemoveOldLogs()
         string folderPath = LogImageLocation + "/" + entry->d_name;
 		if (entry->d_type == DT_DIR) {
 			//ESP_LOGI(logTag, "Compare %s %s", entry->d_name, folderName.c_str());	
-			if ((strlen(entry->d_name) == folderName.length()) && (strcmp(entry->d_name, folderName.c_str()) < 0)) {
-                deleted += removeFolder(folderPath.c_str(), logTag);
+			if ((strlen(entry->d_name) == folderName.length()) && (strcmp(entry->d_name, folderName.c_str()) == 0)) {
+                removeFolder(folderPath.c_str(), logTag);
+                deleted++;
 			} else {
                 notDeleted ++;
             }
 		}
     }
-    ESP_LOGI(logTag, "%d older log files deleted. %d current log files not deleted.", deleted, notDeleted);
+    ESP_LOGI(logTag, "%d image folder deleted. %d image folder not deleted.", deleted, notDeleted);
+    LogFile.WriteToFile("Image folder deleted: " + std::to_string(deleted) + ". Image folder not deleted: " + std::to_string(notDeleted));	
     closedir(dir);
 }
 

--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -319,7 +319,7 @@ string getDirectory(string filename)
 
 string getFileType(string filename)
 {
-	size_t lastpos = filename.find(".", 0);
+	size_t lastpos = filename.rfind(".", filename.length());
 	size_t neu_pos;
 	while ((neu_pos = filename.find(".", lastpos + 1)) > -1)
 	{

--- a/code/components/jomjol_logfile/ClassLogFile.cpp
+++ b/code/components/jomjol_logfile/ClassLogFile.cpp
@@ -176,7 +176,7 @@ void ClassLogFile::RemoveOld()
     while ((entry = readdir(dir)) != NULL) {
         if (entry->d_type == DT_REG) {
             //ESP_LOGI(TAG, "list log file : %s %s", entry->d_name, cmpfilename);
-            if ((strlen(entry->d_name) == strlen(cmpfilename)) && (strcmp(entry->d_name, cmpfilename) < 0)) {
+            if ((strlen(entry->d_name) == strlen(cmpfilename)) && (strcmp(entry->d_name, cmpfilename) == 0)) {
                 ESP_LOGI(TAG, "delete log file : %s", entry->d_name);
                 std::string filepath = logroot + "/" + entry->d_name; 
                 if (unlink(filepath.c_str()) == 0) {
@@ -189,7 +189,8 @@ void ClassLogFile::RemoveOld()
             }
         }
     }
-    ESP_LOGI(TAG, "%d older log files deleted. %d current log files not deleted.", deleted, notDeleted);
+    ESP_LOGI(TAG, "%d logfiles deleted. %d files not deleted (incl. leer.txt).", deleted, notDeleted);
+    LogFile.WriteToFile("logfiles deleted: " + std::to_string(deleted) + " files not deleted (incl. leer.txt): " + std::to_string(notDeleted));	
     closedir(dir);
 }
 


### PR DESCRIPTION
- File name with more than one dot (images: x.y_zzzz.jpg) filetype was not parsed correctly and therefore file was not saved.
- strcmp function return equal with 0 (== 0). Adapt functions to avoid wrong behaviour (image filename creation, file deletion)