### PR TITLE
Cleanup REST API

### DIFF
--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -837,7 +837,7 @@ void register_server_tflite_uri(httpd_handle_t server)
     camuri.user_ctx  = (void*) "Light Off";
     httpd_register_uri_handler(server, &camuri);
 
-    camuri.uri       = "/cputemp";
+    camuri.uri       = "/cpu_temperature";
     camuri.handler   = handler_cputemp;
     camuri.user_ctx  = (void*) "Light Off"; 
     httpd_register_uri_handler(server, &camuri);  

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -818,7 +818,7 @@ void register_server_tflite_uri(httpd_handle_t server)
 
     camuri.uri       = "/doflow";
     camuri.handler   = handler_doflow;
-    camuri.user_ctx  = (void*) "Light Off"; 
+    camuri.user_ctx  = (void*) "Light Off";  
     httpd_register_uri_handler(server, &camuri);
 
     camuri.uri       = "/statusflow.html";
@@ -866,14 +866,14 @@ void register_server_tflite_uri(httpd_handle_t server)
 
     camuri.uri       = "/value";
     camuri.handler   = handler_wasserzaehler;
-    camuri.user_ctx  = (void*) "Value";
-    httpd_register_uri_handler(server, &camuri);
+    camuri.user_ctx  = (void*) "Value"; 
+    httpd_register_uri_handler(server, &camuri);  
 
     // Legacy API => New: "/value"
     camuri.uri       = "/wasserzaehler.html";
     camuri.handler   = handler_wasserzaehler;
-    camuri.user_ctx  = (void*) "Wasserzaehler";
-    httpd_register_uri_handler(server, &camuri);
+    camuri.user_ctx  = (void*) "Wasserzaehler"; 
+    httpd_register_uri_handler(server, &camuri);  
 
     camuri.uri       = "/json";
     camuri.handler   = handler_json;

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -846,7 +846,7 @@ void register_server_tflite_uri(httpd_handle_t server)
     camuri.uri       = "/rssi.html";
     camuri.handler   = handler_rssi;
     camuri.user_ctx  = (void*) "Light Off"; 
-    httpd_register_uri_handler(server, &camuri);
+    httpd_register_uri_handler(server, &camuri);  
 
     camuri.uri       = "/rssi";
     camuri.handler   = handler_rssi;

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -856,7 +856,7 @@ void register_server_tflite_uri(httpd_handle_t server)
     camuri.uri       = "/editflow.html";
     camuri.handler   = handler_editflow;
     camuri.user_ctx  = (void*) "EditFlow"; 
-    httpd_register_uri_handler(server, &camuri);    
+    httpd_register_uri_handler(server, &camuri);     
 
     // Legacy API => New: "/value"
     camuri.uri       = "/value.html";

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -819,37 +819,59 @@ void register_server_tflite_uri(httpd_handle_t server)
     camuri.uri       = "/doflow";
     camuri.handler   = handler_doflow;
     camuri.user_ctx  = (void*) "Light Off"; 
-    httpd_register_uri_handler(server, &camuri);  
+    httpd_register_uri_handler(server, &camuri);
 
-    camuri.uri       = "/statusflow.html";
+    // Legacy
+    // camuri.uri       = "/statusflow.html";
+    // camuri.handler   = handler_statusflow;
+    // camuri.user_ctx  = (void*) "Light Off"; 
+    // httpd_register_uri_handler(server, &camuri);
+
+    // camuri.uri       = "/cputemp.html";
+    // camuri.handler   = handler_cputemp;
+    // camuri.user_ctx  = (void*) "Light Off"; 
+    // httpd_register_uri_handler(server, &camuri);
+
+    // camuri.uri       = "/rssi.html";
+    // camuri.handler   = handler_rssi;
+    // camuri.user_ctx  = (void*) "Light Off"; 
+    // httpd_register_uri_handler(server, &camuri);
+
+    camuri.uri       = "/statusflow";
     camuri.handler   = handler_statusflow;
     camuri.user_ctx  = (void*) "Light Off"; 
-    httpd_register_uri_handler(server, &camuri);  
-    
-    camuri.uri       = "/cputemp.html";
+    httpd_register_uri_handler(server, &camuri);
+
+    camuri.uri       = "/cputemp";
     camuri.handler   = handler_cputemp;
     camuri.user_ctx  = (void*) "Light Off"; 
-    httpd_register_uri_handler(server, &camuri);  
+    httpd_register_uri_handler(server, &camuri);
 
-    camuri.uri       = "/rssi.html";
+    camuri.uri       = "/rssi";
     camuri.handler   = handler_rssi;
     camuri.user_ctx  = (void*) "Light Off"; 
-    httpd_register_uri_handler(server, &camuri);  
+    httpd_register_uri_handler(server, &camuri);
 
     camuri.uri       = "/editflow.html";
     camuri.handler   = handler_editflow;
-    camuri.user_ctx  = (void*) "EditFlow"; 
-    httpd_register_uri_handler(server, &camuri);     
-
-    camuri.uri       = "/value.html";
+    camuri.user_ctx  = (void*) "EditFlow";
+    httpd_register_uri_handler(server, &camuri);
+    
+    camuri.uri       = "/value";
     camuri.handler   = handler_wasserzaehler;
-    camuri.user_ctx  = (void*) "Value"; 
-    httpd_register_uri_handler(server, &camuri);  
+    camuri.user_ctx  = (void*) "Value";
+    httpd_register_uri_handler(server, &camuri);
 
-    camuri.uri       = "/wasserzaehler.html";
-    camuri.handler   = handler_wasserzaehler;
-    camuri.user_ctx  = (void*) "Wasserzaehler"; 
-    httpd_register_uri_handler(server, &camuri);  
+    // Legacy
+    // camuri.uri       = "/value.html";
+    // camuri.handler   = handler_wasserzaehler;
+    // camuri.user_ctx  = (void*) "Value";
+    // httpd_register_uri_handler(server, &camuri);
+
+    // camuri.uri       = "/wasserzaehler.html";
+    // camuri.handler   = handler_wasserzaehler;
+    // camuri.user_ctx  = (void*) "Wasserzaehler";
+    // httpd_register_uri_handler(server, &camuri);
 
     camuri.uri       = "/json";
     camuri.handler   = handler_json;

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -818,8 +818,8 @@ void register_server_tflite_uri(httpd_handle_t server)
 
     camuri.uri       = "/doflow";
     camuri.handler   = handler_doflow;
-    camuri.user_ctx  = (void*) "Light Off";  
-    httpd_register_uri_handler(server, &camuri);
+    camuri.user_ctx  = (void*) "Light Off"; 
+    httpd_register_uri_handler(server, &camuri);  
 
     camuri.uri       = "/statusflow.html";
     camuri.handler   = handler_statusflow;
@@ -840,7 +840,7 @@ void register_server_tflite_uri(httpd_handle_t server)
     camuri.uri       = "/cputemp";
     camuri.handler   = handler_cputemp;
     camuri.user_ctx  = (void*) "Light Off"; 
-    httpd_register_uri_handler(server, &camuri);
+    httpd_register_uri_handler(server, &camuri);  
 
     // Legacy API => New: "/rssi"
     camuri.uri       = "/rssi.html";
@@ -855,8 +855,8 @@ void register_server_tflite_uri(httpd_handle_t server)
 
     camuri.uri       = "/editflow.html";
     camuri.handler   = handler_editflow;
-    camuri.user_ctx  = (void*) "EditFlow";
-    httpd_register_uri_handler(server, &camuri);
+    camuri.user_ctx  = (void*) "EditFlow"; 
+    httpd_register_uri_handler(server, &camuri);    
 
     // Legacy API => New: "/value"
     camuri.uri       = "/value.html";

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -821,25 +821,20 @@ void register_server_tflite_uri(httpd_handle_t server)
     camuri.user_ctx  = (void*) "Light Off"; 
     httpd_register_uri_handler(server, &camuri);
 
-    // Legacy
-    // camuri.uri       = "/statusflow.html";
-    // camuri.handler   = handler_statusflow;
-    // camuri.user_ctx  = (void*) "Light Off"; 
-    // httpd_register_uri_handler(server, &camuri);
-
-    // camuri.uri       = "/cputemp.html";
-    // camuri.handler   = handler_cputemp;
-    // camuri.user_ctx  = (void*) "Light Off"; 
-    // httpd_register_uri_handler(server, &camuri);
-
-    // camuri.uri       = "/rssi.html";
-    // camuri.handler   = handler_rssi;
-    // camuri.user_ctx  = (void*) "Light Off"; 
-    // httpd_register_uri_handler(server, &camuri);
+    camuri.uri       = "/statusflow.html";
+    camuri.handler   = handler_statusflow;
+    camuri.user_ctx  = (void*) "Light Off";
+    httpd_register_uri_handler(server, &camuri);
 
     camuri.uri       = "/statusflow";
     camuri.handler   = handler_statusflow;
-    camuri.user_ctx  = (void*) "Light Off"; 
+    camuri.user_ctx  = (void*) "Light Off";
+    httpd_register_uri_handler(server, &camuri);
+
+    // Legacy API => New: "/cpu_temperature"
+    camuri.uri       = "/cputemp.html";
+    camuri.handler   = handler_cputemp;
+    camuri.user_ctx  = (void*) "Light Off";
     httpd_register_uri_handler(server, &camuri);
 
     camuri.uri       = "/cputemp";
@@ -847,31 +842,38 @@ void register_server_tflite_uri(httpd_handle_t server)
     camuri.user_ctx  = (void*) "Light Off"; 
     httpd_register_uri_handler(server, &camuri);
 
-    camuri.uri       = "/rssi";
+    // Legacy API => New: "/rssi"
+    camuri.uri       = "/rssi.html";
     camuri.handler   = handler_rssi;
     camuri.user_ctx  = (void*) "Light Off"; 
+    httpd_register_uri_handler(server, &camuri);
+
+    camuri.uri       = "/rssi";
+    camuri.handler   = handler_rssi;
+    camuri.user_ctx  = (void*) "Light Off";
     httpd_register_uri_handler(server, &camuri);
 
     camuri.uri       = "/editflow.html";
     camuri.handler   = handler_editflow;
     camuri.user_ctx  = (void*) "EditFlow";
     httpd_register_uri_handler(server, &camuri);
-    
+
+    // Legacy API => New: "/value"
+    camuri.uri       = "/value.html";
+    camuri.handler   = handler_wasserzaehler;
+    camuri.user_ctx  = (void*) "Value";
+    httpd_register_uri_handler(server, &camuri);
+
     camuri.uri       = "/value";
     camuri.handler   = handler_wasserzaehler;
     camuri.user_ctx  = (void*) "Value";
     httpd_register_uri_handler(server, &camuri);
 
-    // Legacy
-    // camuri.uri       = "/value.html";
-    // camuri.handler   = handler_wasserzaehler;
-    // camuri.user_ctx  = (void*) "Value";
-    // httpd_register_uri_handler(server, &camuri);
-
-    // camuri.uri       = "/wasserzaehler.html";
-    // camuri.handler   = handler_wasserzaehler;
-    // camuri.user_ctx  = (void*) "Wasserzaehler";
-    // httpd_register_uri_handler(server, &camuri);
+    // Legacy API => New: "/value"
+    camuri.uri       = "/wasserzaehler.html";
+    camuri.handler   = handler_wasserzaehler;
+    camuri.user_ctx  = (void*) "Wasserzaehler";
+    httpd_register_uri_handler(server, &camuri);
 
     camuri.uri       = "/json";
     camuri.handler   = handler_json;

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -823,8 +823,8 @@ void register_server_tflite_uri(httpd_handle_t server)
 
     camuri.uri       = "/statusflow.html";
     camuri.handler   = handler_statusflow;
-    camuri.user_ctx  = (void*) "Light Off";
-    httpd_register_uri_handler(server, &camuri);
+    camuri.user_ctx  = (void*) "Light Off"; 
+    httpd_register_uri_handler(server, &camuri);  
 
     camuri.uri       = "/statusflow";
     camuri.handler   = handler_statusflow;

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -811,7 +811,13 @@ void register_server_tflite_uri(httpd_handle_t server)
     camuri.user_ctx  = (void*) "Light On";    
     httpd_register_uri_handler(server, &camuri);
 
+    // Legacy API => New: "/setPreValue"
     camuri.uri       = "/setPreValue.html";
+    camuri.handler   = handler_prevalue;
+    camuri.user_ctx  = (void*) "Prevalue";    
+    httpd_register_uri_handler(server, &camuri);
+
+    camuri.uri       = "/setPreValue";
     camuri.handler   = handler_prevalue;
     camuri.user_ctx  = (void*) "Prevalue";    
     httpd_register_uri_handler(server, &camuri);

--- a/sd-card/html/prevalue_set.html
+++ b/sd-card/html/prevalue_set.html
@@ -84,7 +84,7 @@ function setprevalue() {
 	inputVal = inputVal.replace(",", ".");
   	var xhttp = new XMLHttpRequest();
     try {
-          url = basepath + "/setPreValue.html?value=" + inputVal + "&numbers=" + _number;     
+          url = basepath + "/setPreValue?value=" + inputVal + "&numbers=" + _number;     
           xhttp.open("GET", url, false);
           xhttp.send();
           response = xhttp.responseText;
@@ -102,7 +102,7 @@ function loadPrevalue(_basepath) {
 
      var xhttp = new XMLHttpRequest();
      try {
-          url = _basepath + '/setPreValue.html?numbers=' + _number;     
+          url = _basepath + '/setPreValue?numbers=' + _number;     
           xhttp.open("GET", url, false);
           xhttp.send();
           response = xhttp.responseText;

--- a/sd-card/html/wasserzaehler_roi.html
+++ b/sd-card/html/wasserzaehler_roi.html
@@ -111,7 +111,7 @@ function refresh() {
 	var basepath = "http://192.168.178.22"; 
 
 	function loadStatus() {
-		url = basepath + '/statusflow.html';     
+		url = basepath + '/statusflow';     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
@@ -125,7 +125,7 @@ function refresh() {
 	}
 
 	function loadCPUTemp() {
-		url = basepath + '/cputemp.html';     
+		url = basepath + '/cpu_temperature';     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
@@ -138,7 +138,7 @@ function refresh() {
 	}
 
 	function loadRSSI() {
-		url = basepath + '/rssi.html';     
+		url = basepath + '/rssi';     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {


### PR DESCRIPTION
Added new, consistent REST APIs:
- `value`, same as `value.html`
- `setPreValue`, same as `setPreValue.html`
- `statusflow`, same as `statusflow.html`
- `cpu_temperature`, same as `cputemp.html`
- `rssi`, same as `rssi.html`
- `statusflow`, same as `statusflow.html`