### PR TITLE
Add optional IPv6 support (needs rebasing first)

### DIFF
--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -755,3 +755,19 @@ string getResetReason(void) {
 	}
     return reasonText;
 }
+
+bool
+strval_is_true(const char *val)
+{
+
+	if (val == NULL || *val == '\0')
+		return (false);
+
+	if (strcasecmp(val, "true") == 0 ||
+	    strcasecmp(val, "yes") == 0 ||
+	    strcasecmp(val, "ja") == 0 ||
+	    strcmp(val, "1") == 0)
+		return (true);
+
+	return (false);
+}

--- a/code/components/jomjol_helper/Helper.h
+++ b/code/components/jomjol_helper/Helper.h
@@ -43,6 +43,8 @@ void memCopyGen(uint8_t* _source, uint8_t* _target, int _size);
 
 std::vector<string> HelperZerlegeZeile(std::string input, std::string _delimiter);
 
+bool strval_is_true(const char *);
+
 ///////////////////////////
 size_t getInternalESPHeapSize();
 size_t getESPHeapSize();

--- a/code/components/jomjol_wlan/connect_wlan.h
+++ b/code/components/jomjol_wlan/connect_wlan.h
@@ -3,6 +3,7 @@
 
 #include <string>
 
+void wifi_init_sta(const char *_ssid, const char *_password, const char *_hostname, const char *_ipadr, const char *_gw,  const char *_netmask, const char *_dns, const char *_ipv6en);
 void wifi_init_sta(const char *_ssid, const char *_password, const char *_hostname, const char *_ipadr, const char *_gw,  const char *_netmask, const char *_dns);
 void wifi_init_sta(const char *_ssid, const char *_password, const char *_hostname);
 void wifi_init_sta(const char *_ssid, const char *_password);
@@ -13,5 +14,7 @@ int get_WIFI_RSSI();
 
 extern std::string hostname;
 extern std::string std_hostname;
+extern std::string ipv6en;
+extern std::string std_ipv6en;
 
 #endif

--- a/code/components/jomjol_wlan/read_wlanini.cpp
+++ b/code/components/jomjol_wlan/read_wlanini.cpp
@@ -40,7 +40,7 @@ std::vector<string> ZerlegeZeileWLAN(std::string input, std::string _delimiter =
 
 
 
-void LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_hostname, char *&_ipadr, char *&_gw,  char *&_netmask, char *&_dns)
+void LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_hostname, char *&_ipadr, char *&_gw,  char *&_netmask, char *&_dns, char *&_ipv6en)
 {
     std::string ssid = "";
     std::string passphrase = "";
@@ -52,6 +52,7 @@ void LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_ho
     std::string line = "";
     std::vector<string> zerlegt;
     hostname = std_hostname;
+    ipv6en = std_ipv6en;
 
     FILE* pFile;
     fn = FormatFileName(fn);
@@ -121,6 +122,12 @@ void LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_ho
             }
         }
 
+	if ((zerlegt.size() > 1) && (toUpper(zerlegt[0]) == "IPV6EN")){
+	    ipv6en = zerlegt[1];
+	    if ((ipv6en[0] == '"') && (ipv6en[ipv6en.length()-1] == '"')){
+		ipv6en = ipv6en.substr(1, ipv6en.length()-2);
+	    }
+	}
 
         if (fgets(zw, 1024, pFile) == NULL)
         {
@@ -134,9 +141,13 @@ void LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_ho
 
     fclose(pFile);
 
-    // Check if Hostname was empty in .ini if yes set to std_hostname
+    // Check if Hostname/IPv6en was empty in .ini and
+    // if yes set to std_hostname/std_ipv6en.
     if(hostname.length() == 0){
         hostname = std_hostname;
+    }
+    if (ipv6en.length() == 0){
+        ipv6en = std_ipv6en;
     }
 
     _hostname = new char[hostname.length() + 1];
@@ -179,6 +190,9 @@ void LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_ho
     }
     else
         _dns = NULL;
+
+    _ipv6en = new char[ipv6en.length() + 1];
+    strcpy(_ipv6en, ipv6en.c_str());
 }
 
 

--- a/code/components/jomjol_wlan/read_wlanini.h
+++ b/code/components/jomjol_wlan/read_wlanini.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-void LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_hostname, char *&_ipadr, char *&_gw,  char *&_netmask, char *&_dns);
+void LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_hostname, char *&_ipadr, char *&_gw,  char *&_netmask, char *&_dns, char *&_ipv6en);
 
 bool ChangeHostName(std::string fn, std::string _newhostname);
 

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -181,8 +181,8 @@ extern "C" void app_main(void)
 */
 
 
-    char *ssid = NULL, *passwd = NULL, *hostname = NULL, *ip = NULL, *gateway = NULL, *netmask = NULL, *dns = NULL;
-    LoadWlanFromFile("/sdcard/wlan.ini", ssid, passwd, hostname, ip, gateway, netmask, dns);
+    char *ssid = NULL, *passwd = NULL, *hostname = NULL, *ip = NULL, *gateway = NULL, *netmask = NULL, *dns = NULL, *ipv6en = NULL;
+    LoadWlanFromFile("/sdcard/wlan.ini", ssid, passwd, hostname, ip, gateway, netmask, dns, ipv6en);
 
     if (ssid != NULL && passwd != NULL)
 #ifdef __HIDE_PASSWORD
@@ -204,8 +204,14 @@ extern "C" void app_main(void)
     if (dns != NULL)
        ESP_LOGD(TAGMAIN, "DNS IP: %s", dns);
 
+#ifdef CONFIG_LWIP_IPV6
+    if (strval_is_true(ipv6en))
+       printf("Enabling IPv6 support\n");
+    else
+#endif
+       printf("No IPv6 support enabled\n");
 
-    wifi_init_sta(ssid, passwd, hostname, ip, gateway, netmask, dns);   
+    wifi_init_sta(ssid, passwd, hostname, ip, gateway, netmask, dns, ipv6en);
 
 
     xDelay = 2000 / portTICK_PERIOD_MS;

--- a/sd-card/wlan.ini
+++ b/sd-card/wlan.ini
@@ -10,3 +10,6 @@ hostname = "watermeter"
 
 ;in some cases you want to specify the DNS server as well (especially, if it is not identical to the gateway - this is optional for a fixed IP
 ;dns = "IP4-ADDRESS"
+
+;Some people love IPv6, give them a chance to use it (also needs to be compiled into image by enabling CONFIG_LWIP_IPV6).
+;ipv6en = "1"


### PR DESCRIPTION
Add the first cut add (optional) IPv6 support.
The main (invasive) logic will not be compiled in unless CONFIG_LWIP_IPV6 is on.