### PR TITLE
Add tag to logfile write

### DIFF
--- a/code/components/jomjol_configfile/configFile.cpp
+++ b/code/components/jomjol_configfile/configFile.cpp
@@ -6,7 +6,7 @@
 #include "configFile.h"
 #include <esp_log.h>
 
-static const char *TAG = "configFile";
+static const char *TAG = "CONFIG";
 
 ConfigFile::ConfigFile(std::string filePath)
 {

--- a/code/components/jomjol_controlcamera/ClassControllCamera.cpp
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.cpp
@@ -68,7 +68,7 @@
 #define CAM_PIN_PCLK 22
 
 
-static const char *TAGCAMERACLASS = "server_part_camera"; 
+static const char *TAG = "CAM"; 
 
 static camera_config_t camera_config = {
     .pin_pwdn = CAM_PIN_PWDN,
@@ -249,7 +249,7 @@ void CCamera::SetQualitySize(int qual, framesize_t resol)
 
 void CCamera::EnableAutoExposure(int flashdauer)
 {
-    ESP_LOGD(TAGCAMERACLASS, "EnableAutoExposure");
+    ESP_LOGD(TAG, "EnableAutoExposure");
     LEDOnOff(true);
     if (flashdauer > 0)
         LightOnOff(true);
@@ -260,10 +260,10 @@ void CCamera::EnableAutoExposure(int flashdauer)
     esp_camera_fb_return(fb);
     fb = esp_camera_fb_get();
     if (!fb) {
-        ESP_LOGE(TAGCAMERACLASS, "Camera Capture Failed");
+        ESP_LOGE(TAG, "Camera Capture Failed");
         LEDOnOff(false);
         LightOnOff(false);
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Camera Capture Failed (Procedure 'EnableAutoExposure') --> Reboot! "
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Capture Failed (Procedure 'EnableAutoExposure') --> Reboot! "
                 "Check that your camera module is working and connected properly.");
         //doReboot();
     }
@@ -310,11 +310,11 @@ esp_err_t CCamera::CaptureToBasisImage(CImageBasis *_Image, int delay)
     esp_camera_fb_return(fb);        
     fb = esp_camera_fb_get();
     if (!fb) {
-        ESP_LOGE(TAGCAMERACLASS, "CaptureToBasisImage: Camera Capture Failed");
+        ESP_LOGE(TAG, "CaptureToBasisImage: Capture Failed");
         LEDOnOff(false);
         LightOnOff(false);
 
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Camera is not working anymore (CCamera::CaptureToBasisImage) - most probably caused by a hardware problem (instablility, ...). "
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "is not working anymore (CCamera::CaptureToBasisImage) - most probably caused by a hardware problem (instablility, ...). "
                 "System will reboot.");
         doReboot();
 
@@ -325,8 +325,8 @@ esp_err_t CCamera::CaptureToBasisImage(CImageBasis *_Image, int delay)
     zwischenspeicher = (uint8_t*) malloc(_size);
     if (!zwischenspeicher)
     {
-        ESP_LOGE(TAGCAMERACLASS, "Insufficient memory space for image in function CaptureToBasisImage()");
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Insufficient memory space for image in function CaptureToBasisImage()");
+        ESP_LOGE(TAG, "Insufficient memory space for image in function CaptureToBasisImage()");
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Insufficient memory space for image in function CaptureToBasisImage()");
     }
     for (int i = 0; i < _size; ++i)
         *(zwischenspeicher + i) = *(fb->buf + i);
@@ -363,7 +363,7 @@ esp_err_t CCamera::CaptureToBasisImage(CImageBasis *_Image, int delay)
 #ifdef DEBUG_DETAIL_ON
     std::string _zw = "Targetimage: " + std::to_string((int) _Image->rgb_image) + " Size: " + std::to_string(_Image->width) + ", " + std::to_string(_Image->height);
     _zw = _zw + " _zwImage: " + std::to_string((int) _zwImage.rgb_image)  + " Size: " + std::to_string(_zwImage.width) + ", " + std::to_string(_zwImage.height);
-    LogFile.WriteToFile(ESP_LOG_DEBUG, _zw);
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, _zw);
 #endif
 
     for (int x = 0; x < width; ++x)
@@ -407,10 +407,10 @@ esp_err_t CCamera::CaptureToFile(std::string nm, int delay)
     esp_camera_fb_return(fb);
     fb = esp_camera_fb_get();
     if (!fb) {
-        ESP_LOGE(TAGCAMERACLASS, "CaptureToFile: Camera Capture Failed");
+        ESP_LOGE(TAG, "CaptureToFile: Camera Capture Failed");
         LEDOnOff(false);
         LightOnOff(false);
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Camera Capture Failed (CCamera::CaptureToFile) --> Reboot! "
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Capture Failed (CCamera::CaptureToFile) --> Reboot! "
                 "Check that your camera module is working and connected properly.");
         //doReboot();
 
@@ -419,19 +419,19 @@ esp_err_t CCamera::CaptureToFile(std::string nm, int delay)
     LEDOnOff(false);    
 
 #ifdef DEBUG_DETAIL_ON    
-    ESP_LOGD(TAGCAMERACLASS, "w %d, h %d, size %d", fb->width, fb->height, fb->len);
+    ESP_LOGD(TAG, "w %d, h %d, size %d", fb->width, fb->height, fb->len);
 #endif
 
     nm = FormatFileName(nm);
 
 #ifdef DEBUG_DETAIL_ON
-    ESP_LOGD(TAGCAMERACLASS, "Save Camera to : %s", nm.c_str());
+    ESP_LOGD(TAG, "Save Camera to : %s", nm.c_str());
 #endif
 
     ftype = toUpper(getFileType(nm));
 
 #ifdef DEBUG_DETAIL_ON
-    ESP_LOGD(TAGCAMERACLASS, "Filetype: %s", ftype.c_str());
+    ESP_LOGD(TAG, "Filetype: %s", ftype.c_str());
 #endif
 
     uint8_t * buf = NULL;
@@ -449,7 +449,7 @@ esp_err_t CCamera::CaptureToFile(std::string nm, int delay)
             bool jpeg_converted = frame2jpg(fb, ActualQuality, &buf, &buf_len);
             converted = true;
             if(!jpeg_converted){
-                ESP_LOGE(TAGCAMERACLASS, "JPEG compression failed");
+                ESP_LOGE(TAG, "JPEG compression failed");
             }
         } else {
             buf_len = fb->len;
@@ -503,7 +503,7 @@ esp_err_t CCamera::CaptureToHTTP(httpd_req_t *req, int delay)
     esp_camera_fb_return(fb);
     fb = esp_camera_fb_get();
     if (!fb) {
-        ESP_LOGE(TAGCAMERACLASS, "Camera capture failed");
+        ESP_LOGE(TAG, "Camera capture failed");
         LEDOnOff(false);
         LightOnOff(false);
         httpd_resp_send_500(req);
@@ -533,7 +533,7 @@ esp_err_t CCamera::CaptureToHTTP(httpd_req_t *req, int delay)
     esp_camera_fb_return(fb);
     int64_t fr_end = esp_timer_get_time();
     
-    ESP_LOGI(TAGCAMERACLASS, "JPG: %uKB %ums", (uint32_t)(fb_len/1024), (uint32_t)((fr_end - fr_start)/1000));
+    ESP_LOGI(TAG, "JPG: %uKB %ums", (uint32_t)(fb_len/1024), (uint32_t)((fr_end - fr_start)/1000));
 
     if (delay > 0) 
     {
@@ -547,20 +547,20 @@ void CCamera::LightOnOff(bool status)
 {
     GpioHandler* gpioHandler = gpio_handler_get();
     if ((gpioHandler != NULL) && (gpioHandler->isEnabled())) {
-        ESP_LOGD(TAGCAMERACLASS, "Use gpioHandler flashLigh");
+        ESP_LOGD(TAG, "Use gpioHandler flashLigh");
         gpioHandler->flashLightEnable(status);
     }  else {
     #ifdef USE_PWM_LEDFLASH
         if (status)
         {
-            ESP_LOGD(TAGCAMERACLASS, "Internal Flash-LED turn on with PWM %d", led_intensity);
+            ESP_LOGD(TAG, "Internal Flash-LED turn on with PWM %d", led_intensity);
             ESP_ERROR_CHECK(ledc_set_duty(LEDC_MODE, LEDC_CHANNEL, led_intensity));
             // Update duty to apply the new value
             ESP_ERROR_CHECK(ledc_update_duty(LEDC_MODE, LEDC_CHANNEL));
         }
         else
         {
-            ESP_LOGD(TAGCAMERACLASS, "Internal Flash-LED turn off PWM");
+            ESP_LOGD(TAG, "Internal Flash-LED turn off PWM");
             ESP_ERROR_CHECK(ledc_set_duty(LEDC_MODE, LEDC_CHANNEL, 0));
             ESP_ERROR_CHECK(ledc_update_duty(LEDC_MODE, LEDC_CHANNEL));
         }
@@ -604,11 +604,11 @@ void CCamera::GetCameraParameter(httpd_req_t *req, int &qual, framesize_t &resol
 
     if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
     {
-        ESP_LOGD(TAGCAMERACLASS, "Query: %s", _query);
+        ESP_LOGD(TAG, "Query: %s", _query);
         if (httpd_query_key_value(_query, "size", _size, 10) == ESP_OK)
         {
 #ifdef DEBUG_DETAIL_ON   
-            ESP_LOGD(TAGCAMERACLASS, "Size: %s", _size);
+            ESP_LOGD(TAG, "Size: %s", _size);
 #endif
             if (strcmp(_size, "QVGA") == 0)
                 resol = FRAMESIZE_QVGA;       // 320x240
@@ -626,7 +626,7 @@ void CCamera::GetCameraParameter(httpd_req_t *req, int &qual, framesize_t &resol
         if (httpd_query_key_value(_query, "quality", _qual, 10) == ESP_OK)
         {
 #ifdef DEBUG_DETAIL_ON   
-            ESP_LOGD(TAGCAMERACLASS, "Quality: %s", _qual);
+            ESP_LOGD(TAG, "Quality: %s", _qual);
 #endif
             qual = atoi(_qual);
                 
@@ -659,7 +659,7 @@ framesize_t CCamera::TextToFramesize(const char * _size)
 CCamera::CCamera()
 {
 #ifdef DEBUG_DETAIL_ON    
-    ESP_LOGD(TAGCAMERACLASS, "CreateClassCamera");
+    ESP_LOGD(TAG, "CreateClassCamera");
 #endif
     brightness = -5;
     contrast = -5;
@@ -671,13 +671,13 @@ CCamera::CCamera()
 
 esp_err_t CCamera::InitCam()
 {
-    ESP_LOGD(TAGCAMERACLASS, "Init Camera");
+    ESP_LOGD(TAG, "Init Camera");
     ActualQuality = camera_config.jpeg_quality;
     ActualResolution = camera_config.frame_size;
     //initialize the camera
     esp_err_t err = esp_camera_init(&camera_config);
     if (err != ESP_OK) {
-        ESP_LOGE(TAGCAMERACLASS, "Camera Init Failed");
+        ESP_LOGE(TAG, "Camera Init Failed");
         return err;
     }
 
@@ -690,6 +690,6 @@ void CCamera::SetLEDIntensity(float _intrel)
     _intrel = max(_intrel, (float) 0);
     _intrel = _intrel / 100;
     led_intensity = (int) (_intrel * 8191);
-    ESP_LOGD(TAGCAMERACLASS, "Set led_intensity to %d of 8191", led_intensity);
+    ESP_LOGD(TAG, "Set led_intensity to %d of 8191", led_intensity);
 
 }

--- a/code/components/jomjol_controlcamera/server_camera.cpp
+++ b/code/components/jomjol_controlcamera/server_camera.cpp
@@ -15,11 +15,10 @@ static const char *TAG = "server_cam";
 char scratch2[SCRATCH_BUFSIZE2];
 
 //#define DEBUG_DETAIL_ON   
-static const char *TAGPARTCAMERA = "server_camera";
 
 
 void PowerResetCamera(){
-        ESP_LOGD(TAGPARTCAMERA, "Resetting camera by power down line");
+        ESP_LOGD(TAG, "Resetting camera by power down line");
         gpio_config_t conf;
         conf.intr_type = GPIO_INTR_DISABLE;
         conf.pin_bit_mask = 1LL << GPIO_NUM_32;
@@ -219,7 +218,7 @@ esp_err_t handler_capture_save_to_file(httpd_req_t *req)
 void register_server_camera_uri(httpd_handle_t server)
 {
 #ifdef DEBUG_DETAIL_ON   
-    ESP_LOGI(TAGPARTCAMERA, "server_part_camera - Registering URI handlers");
+    ESP_LOGI(TAG, "server_part_camera - Registering URI handlers");
 #endif
 
     httpd_uri_t camuri = { };

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -618,7 +618,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 /* Handler to upload a file onto the server */
 static esp_err_t upload_post_handler(httpd_req_t *req)
 {
-    //LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "upload_post_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "upload_post_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     struct stat file_stat;
@@ -761,7 +761,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 /* Handler to delete a file from the server */
 static esp_err_t delete_post_handler(httpd_req_t *req)
 {
-    //LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "delete_post_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "delete_post_handler");
     char filepath[FILE_PATH_MAX];
     struct stat file_stat;
 

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -45,7 +45,7 @@ extern "C" {
 #include "Helper.h"
 #include "miniz.h"
 
-static const char *TAG = "server_file";
+static const char *TAG = "OTA File";
 
 /* Max length a file path can have on storage */
 // #define FILE_PATH_MAX (ESP_VFS_PATH_MAX + CONFIG_SPIFFS_OBJ_NAME_LEN)
@@ -70,8 +70,6 @@ struct file_server_data {
     /* Scratch buffer for temporary storage during file transfer */
     char scratch[SCRATCH_BUFSIZE];
 };
-
-static const char *TAG_FILESERVER = "file_server";
 
 
 #include <iostream>
@@ -111,7 +109,7 @@ esp_err_t get_data_file_handler(httpd_req_t *req)
     size_t pos = 0;
     
     const char verz_name[] = "/sdcard/log/data";
-    ESP_LOGD(TAG, "Suche data files in /sdcard/log/data");
+    ESP_LOGD(TAG, "Suche TFLITE in /sdcard/log/data");
 
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
     httpd_resp_set_type(req, "text/plain");
@@ -134,7 +132,7 @@ esp_err_t get_data_file_handler(httpd_req_t *req)
 
         ESP_LOGD(TAG, " Extension: %s", _fileext.c_str());
 
-        if (_fileext == "csv")
+        if (_fileext == "txt")
         {
             _filename = _filename + "\t";
             httpd_resp_sendstr_chunk(req, _filename.c_str());
@@ -221,7 +219,7 @@ static esp_err_t http_resp_dir_html(httpd_req_t *req, const char *dirpath, const
     ESP_LOGD(TAG, "entrypath: <%s>", entrypath);
 
     if (!dir) {
-        ESP_LOGE(TAG_FILESERVER, "Failed to stat dir : %s", dirpath);
+        ESP_LOGE(TAG, "Failed to stat dir : %s", dirpath);
         /* Respond with 404 Not Found */
         httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Directory does not exist");
         return ESP_FAIL;
@@ -241,7 +239,7 @@ static esp_err_t http_resp_dir_html(httpd_req_t *req, const char *dirpath, const
             if (chunksize > 0){
                 if (httpd_resp_send_chunk(req, chunk, chunksize) != ESP_OK) {
                 fclose(fd);
-                ESP_LOGE(TAG_FILESERVER, "File sending failed!");
+                ESP_LOGE(TAG, "File sending failed!");
                 return ESP_FAIL;
                 }
             }
@@ -280,11 +278,11 @@ static esp_err_t http_resp_dir_html(httpd_req_t *req, const char *dirpath, const
             strlcpy(entrypath + dirpath_len, entry->d_name, sizeof(entrypath) - dirpath_len);
             ESP_LOGD(TAG, "Entrypath: %s", entrypath);
             if (stat(entrypath, &entry_stat) == -1) {
-                ESP_LOGE(TAG_FILESERVER, "Failed to stat %s : %s", entrytype, entry->d_name);
+                ESP_LOGE(TAG, "Failed to stat %s : %s", entrytype, entry->d_name);
                 continue;
             }
             sprintf(entrysize, "%ld", entry_stat.st_size);
-            ESP_LOGI(TAG_FILESERVER, "Found %s : %s (%s bytes)", entrytype, entry->d_name, entrysize);
+            ESP_LOGI(TAG, "Found %s : %s (%s bytes)", entrytype, entry->d_name, entrysize);
 
             /* Send chunk of HTML file containing table entries with file name and size */
             httpd_resp_sendstr_chunk(req, "<tr><td><a href=\"");
@@ -433,7 +431,7 @@ static esp_err_t send_datafile(httpd_req_t *req, bool send_full_file)
 
 static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "log_get_last_part_handler");
+    //LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "log_get_last_part_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     //struct stat file_stat;
@@ -448,7 +446,7 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 
     fd = OpenFileAndWait(currentfilename.c_str(), "r");
     if (!fd) {
-        ESP_LOGE(TAG_FILESERVER, "Failed to read existing file : %s", filepath);
+        ESP_LOGE(TAG, "Failed to read existing file : %s", filepath);
         /* Respond with 500 Internal Server Error */
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to read existing file");
         return ESP_FAIL;
@@ -456,23 +454,23 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
 
-//    ESP_LOGI(TAG_FILESERVER, "Sending file : %s (%ld bytes)...", &filename, file_stat.st_size);
+//    ESP_LOGI(TAG, "Sending file : %s (%ld bytes)...", &filename, file_stat.st_size);
     set_content_type_from_file(req, filename);
 
     if (!send_full_file) { // Send only last part of file
-        ESP_LOGD(TAG_FILESERVER, "Sending last %d bytes of the actual logfile!", LOGFILE_LAST_PART_BYTES);
+        ESP_LOGD(TAG, "Sending last %d bytes of the actual logfile!", LOGFILE_LAST_PART_BYTES);
 
         /* Adapted from https://www.geeksforgeeks.org/implement-your-own-tail-read-last-n-lines-of-a-huge-file/ */
         if (fseek(fd, 0, SEEK_END)) {
-            ESP_LOGE(TAG_FILESERVER, "Failed to get to end of file!");
+            ESP_LOGE(TAG, "Failed to get to end of file!");
             return ESP_FAIL;
         }
         else {
             long pos = ftell(fd); // Number of bytes in the file
-            ESP_LOGI(TAG_FILESERVER, "File contains %ld bytes", pos);
+            ESP_LOGI(TAG, "File contains %ld bytes", pos);
 
             if (fseek(fd, pos - std::min((long)LOGFILE_LAST_PART_BYTES, pos), SEEK_SET)) { // Go LOGFILE_LAST_PART_BYTES bytes back from EOF
-                ESP_LOGE(TAG_FILESERVER, "Failed to go back %ld bytes within the file!", std::min((long)LOGFILE_LAST_PART_BYTES, pos));
+                ESP_LOGE(TAG, "Failed to go back %ld bytes within the file!", std::min((long)LOGFILE_LAST_PART_BYTES, pos));
                 return ESP_FAIL;
             }
         }
@@ -495,7 +493,7 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
         /* Send the buffer contents as HTTP response chunk */
         if (httpd_resp_send_chunk(req, chunk, chunksize) != ESP_OK) {
             fclose(fd);
-            ESP_LOGE(TAG_FILESERVER, "File sending failed!");
+            ESP_LOGE(TAG, "File sending failed!");
             /* Abort sending file */
             httpd_resp_sendstr_chunk(req, NULL);
             /* Respond with 500 Internal Server Error */
@@ -508,7 +506,7 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 
     /* Close file after sending complete */
     fclose(fd);
-    ESP_LOGI(TAG_FILESERVER, "File sending complete");
+    ESP_LOGI(TAG, "File sending complete");
 
     /* Respond with an empty chunk to signal HTTP response completion */
     httpd_resp_send_chunk(req, NULL, 0);
@@ -519,7 +517,7 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 /* Handler to download a file kept on the server */
 static esp_err_t download_get_handler(httpd_req_t *req)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "download_get_handler");
+    //LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "download_get_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     struct stat file_stat;
@@ -535,7 +533,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 
 
     if (!filename) {
-        ESP_LOGE(TAG_FILESERVER, "Filename is too long");
+        ESP_LOGE(TAG, "Filename is too long");
         /* Respond with 500 Internal Server Error */
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Filename too long");
         return ESP_FAIL;
@@ -548,11 +546,11 @@ static esp_err_t download_get_handler(httpd_req_t *req)
         if (buf_len > 1) {
             char buf[buf_len];
             if (httpd_req_get_url_query_str(req, buf, buf_len) == ESP_OK) {
-                ESP_LOGI(TAG_FILESERVER, "Found URL query => %s", buf);
+                ESP_LOGI(TAG, "Found URL query => %s", buf);
                 char param[32];
                 /* Get value of expected key from query string */
                 if (httpd_query_key_value(buf, "readonly", param, sizeof(param)) == ESP_OK) {
-                    ESP_LOGI(TAG_FILESERVER, "Found URL query parameter => readonly=%s", param);
+                    ESP_LOGI(TAG, "Found URL query parameter => readonly=%s", param);
                     readonly = param && strcmp(param,"true")==0;
                 }
             }
@@ -568,7 +566,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 
         /* If file not present on SPIFFS check if URI
          * corresponds to one of the hardcoded paths */
-        ESP_LOGE(TAG_FILESERVER, "Failed to stat file : %s", filepath);
+        ESP_LOGE(TAG, "Failed to stat file : %s", filepath);
         /* Respond with 404 Not Found */
         httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "File does not exist");
         return ESP_FAIL;
@@ -576,7 +574,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 
     fd = OpenFileAndWait(filepath, "r");
     if (!fd) {
-        ESP_LOGE(TAG_FILESERVER, "Failed to read existing file : %s", filepath);
+        ESP_LOGE(TAG, "Failed to read existing file : %s", filepath);
         /* Respond with 500 Internal Server Error */
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to read existing file");
         return ESP_FAIL;
@@ -584,7 +582,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
 
-    ESP_LOGI(TAG_FILESERVER, "Sending file : %s (%ld bytes)...", filename, file_stat.st_size);
+    ESP_LOGI(TAG, "Sending file : %s (%ld bytes)...", filename, file_stat.st_size);
     set_content_type_from_file(req, filename);
 
     /* Retrieve the pointer to scratch buffer for temporary storage */
@@ -597,7 +595,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
         /* Send the buffer contents as HTTP response chunk */
         if (httpd_resp_send_chunk(req, chunk, chunksize) != ESP_OK) {
             fclose(fd);
-            ESP_LOGE(TAG_FILESERVER, "File sending failed!");
+            ESP_LOGE(TAG, "File sending failed!");
             /* Abort sending file */
             httpd_resp_sendstr_chunk(req, NULL);
             /* Respond with 500 Internal Server Error */
@@ -610,7 +608,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 
     /* Close file after sending complete */
     fclose(fd);
-    ESP_LOGI(TAG_FILESERVER, "File successfully sent");
+    ESP_LOGI(TAG, "File successfully sent");
 
     /* Respond with an empty chunk to signal HTTP response completion */
     httpd_resp_send_chunk(req, NULL, 0);
@@ -620,7 +618,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 /* Handler to upload a file onto the server */
 static esp_err_t upload_post_handler(httpd_req_t *req)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "upload_post_handler");
+    //LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "upload_post_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     struct stat file_stat;
@@ -637,13 +635,13 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 
     /* Filename cannot have a trailing '/' */
     if (filename[strlen(filename) - 1] == '/') {
-        ESP_LOGE(TAG_FILESERVER, "Invalid filename : %s", filename);
+        ESP_LOGE(TAG, "Invalid filename : %s", filename);
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Invalid filename");
         return ESP_FAIL;
     }
 
     if (stat(filepath, &file_stat) == 0) {
-        ESP_LOGE(TAG_FILESERVER, "File already exists : %s", filepath);
+        ESP_LOGE(TAG, "File already exists : %s", filepath);
         /* Respond with 400 Bad Request */
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "File already exists");
         return ESP_FAIL;
@@ -651,7 +649,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 
     /* File cannot be larger than a limit */
     if (req->content_len > MAX_FILE_SIZE) {
-        ESP_LOGE(TAG_FILESERVER, "File too large : %d bytes", req->content_len);
+        ESP_LOGE(TAG, "File too large : %d bytes", req->content_len);
         /* Respond with 400 Bad Request */
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
                             "File size must be less than "
@@ -663,13 +661,13 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 
     fd = OpenFileAndWait(filepath, "w");
     if (!fd) {
-        ESP_LOGE(TAG_FILESERVER, "Failed to create file : %s", filepath);
+        ESP_LOGE(TAG, "Failed to create file : %s", filepath);
         /* Respond with 500 Internal Server Error */
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to create file");
         return ESP_FAIL;
     }
 
-    ESP_LOGI(TAG_FILESERVER, "Receiving file : %s...", filename);
+    ESP_LOGI(TAG, "Receiving file : %s...", filename);
 
     /* Retrieve the pointer to scratch buffer for temporary storage */
     char *buf = ((struct file_server_data *)req->user_ctx)->scratch;
@@ -681,7 +679,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 
     while (remaining > 0) {
 
-        ESP_LOGI(TAG_FILESERVER, "Remaining size : %d", remaining);
+        ESP_LOGI(TAG, "Remaining size : %d", remaining);
         /* Receive the file part by part into a buffer */
         if ((received = httpd_req_recv(req, buf, MIN(remaining, SCRATCH_BUFSIZE))) <= 0) {
             if (received == HTTPD_SOCK_ERR_TIMEOUT) {
@@ -694,7 +692,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
             fclose(fd);
             unlink(filepath);
 
-            ESP_LOGE(TAG_FILESERVER, "File reception failed!");
+            ESP_LOGE(TAG, "File reception failed!");
             /* Respond with 500 Internal Server Error */
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to receive file");
             return ESP_FAIL;
@@ -707,7 +705,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
             fclose(fd);
             unlink(filepath);
 
-            ESP_LOGE(TAG_FILESERVER, "File write failed!");
+            ESP_LOGE(TAG, "File write failed!");
             /* Respond with 500 Internal Server Error */
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to write file to storage");
             return ESP_FAIL;
@@ -720,7 +718,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 
     /* Close file upon upload completion */
     fclose(fd);
-    ESP_LOGI(TAG_FILESERVER, "File reception complete");
+    ESP_LOGI(TAG, "File reception complete");
 
     std::string directory = std::string(filepath);
 	size_t zw = directory.find("/");
@@ -735,8 +733,10 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
     int start_fn = strlen(((struct file_server_data *)req->user_ctx)->base_path);
     ESP_LOGD(TAG, "Directory: %s, start_fn: %d, found: %d", directory.c_str(), start_fn, found);
 	directory = directory.substr(start_fn, found - start_fn + 1);
+    ESP_LOGD(TAG, "Directory danach 1: %s", directory.c_str());
+
     directory = "/fileserver" + directory;
-//    ESP_LOGD(TAG, "Directory danach 2: %s", directory.c_str());
+    ESP_LOGD(TAG, "Directory danach 2: %s", directory.c_str());
 
     /* Redirect onto root to see the updated file list */
     httpd_resp_set_status(req, "303 See Other");
@@ -761,7 +761,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 /* Handler to delete a file from the server */
 static esp_err_t delete_post_handler(httpd_req_t *req)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "delete_post_handler");
+    //LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "delete_post_handler");
     char filepath[FILE_PATH_MAX];
     struct stat file_stat;
 
@@ -826,19 +826,19 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
 
         /* Filename cannot have a trailing '/' */
         if (filename[strlen(filename) - 1] == '/') {
-            ESP_LOGE(TAG_FILESERVER, "Invalid filename : %s", filename);
+            ESP_LOGE(TAG, "Invalid filename : %s", filename);
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Invalid filename");
             return ESP_FAIL;
         }
 
         if (stat(filepath, &file_stat) == -1) {
-            ESP_LOGE(TAG_FILESERVER, "File does not exist : %s", filename);
+            ESP_LOGE(TAG, "File does not exist : %s", filename);
             /* Respond with 400 Bad Request */
             httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "File does not exist");
             return ESP_FAIL;
         }
 
-        ESP_LOGI(TAG_FILESERVER, "Deleting file : %s", filename);
+        ESP_LOGI(TAG, "Deleting file : %s", filename);
         /* Delete file */
         unlink(filepath);
 
@@ -855,6 +855,8 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
         int start_fn = strlen(((struct file_server_data *)req->user_ctx)->base_path);
         ESP_LOGD(TAG, "Directory: %s, start_fn: %d, found: %d", directory.c_str(), start_fn, found);
         directory = directory.substr(start_fn, found - start_fn + 1);
+        ESP_LOGD(TAG, "Directory danach 3: %s", directory.c_str());
+
         directory = "/fileserver" + directory;
         ESP_LOGD(TAG, "Directory danach 4: %s", directory.c_str());
     }
@@ -880,7 +882,7 @@ void delete_all_in_directory(std::string _directory)
     std::string filename;
 
     if (!dir) {
-        ESP_LOGE(TAG_FILESERVER, "Failed to stat dir : %s", _directory.c_str());
+        ESP_LOGE(TAG, "Failed to stat dir : %s", _directory.c_str());
         return;
     }
 
@@ -889,7 +891,7 @@ void delete_all_in_directory(std::string _directory)
         if (!(entry->d_type == DT_DIR)){
             if (strcmp("wlan.ini", entry->d_name) != 0){                    // auf wlan.ini soll nicht zugegriffen werden !!!
                 filename = _directory + "/" + std::string(entry->d_name);
-                ESP_LOGI(TAG_FILESERVER, "Deleting file : %s", filename.c_str());
+                ESP_LOGI(TAG, "Deleting file : %s", filename.c_str());
                 /* Delete file */
                 unlink(filename.c_str());    
             }
@@ -912,9 +914,9 @@ std::string unzip_new(std::string _in_zip_file, std::string _target_zip, std::st
 
     ESP_LOGD(TAG, "miniz.c version: %s", MZ_VERSION);
     ESP_LOGD(TAG, "Zipfile: %s", _in_zip_file.c_str());
-//    ESP_LOGD(TAG, "Target Dir ZIP: %s", _target_zip.c_str());
-//    ESP_LOGD(TAG, "Target Dir BIN: %s", _target_bin.c_str());
-//    ESP_LOGD(TAG, "Target Dir main: %s", _main.c_str());
+    ESP_LOGD(TAG, "Target Dir ZIP: %s", _target_zip.c_str());
+    ESP_LOGD(TAG, "Target Dir BIN: %s", _target_bin.c_str());
+    ESP_LOGD(TAG, "Target Dir main: %s", _main.c_str());
 
     // Now try to open the archive.
     memset(&zip_archive, 0, sizeof(zip_archive));
@@ -979,25 +981,13 @@ std::string unzip_new(std::string _in_zip_file, std::string _target_zip, std::st
             
                 string filename_zw = zw + SUFFIX_ZW;
 
-                ESP_LOGI(TAG, "Filename to extract: %s, Zwischenfilename: %s", zw.c_str(), filename_zw.c_str());
+                ESP_LOGD(TAG, "Filename to extract: %s, Zwischenfilename: %s", zw.c_str(), filename_zw.c_str());
 
                 // extrahieren in zwischendatei
                 DeleteFile(filename_zw);
                 FILE* fpTargetFile = OpenFileAndWait(filename_zw.c_str(), "wb");
-                uint writtenbytes = fwrite(p, 1, (uint)uncomp_size, fpTargetFile);
+                fwrite(p, 1, (uint)uncomp_size, fpTargetFile);
                 fclose(fpTargetFile);
-                
-                bool isokay = true;
-
-                if (writtenbytes == (uint)uncomp_size)
-                {
-                    isokay = true;
-                }
-                else
-                {
-                    isokay = false;
-                    ESP_LOGD(TAG, "ERROR in writting extracted file (function fwrite) extracted file \"%s\", size %u", archive_filename, (uint)uncomp_size);
-                }
 
                 if (!isokay)
                     ESP_LOGE(TAG, "ERROR in fwrite \"%s\", size %u", archive_filename, (uint)uncomp_size);
@@ -1008,13 +998,7 @@ std::string unzip_new(std::string _in_zip_file, std::string _target_zip, std::st
                 if (!isokay)
                     ESP_LOGE(TAG, "ERROR in Delete \"%s\"", filename_zw.c_str());
 
-                if (isokay)
-                    ESP_LOGI(TAG, "Successfully extracted file \"%s\", size %u", archive_filename, (uint)uncomp_size);
-                else
-                {
-                    ESP_LOGE(TAG, "ERROR in extracting file \"%s\", size %u", archive_filename, (uint)uncomp_size);
-                    ret = "ERROR";
-                }
+                // We're done.
                 mz_free(p);
             }
         }
@@ -1108,19 +1092,19 @@ void register_server_file_uri(httpd_handle_t server, const char *base_path)
     /* Validate file storage base path */
     if (!base_path) {
 //    if (!base_path || strcmp(base_path, "/spiffs") != 0) {
-        ESP_LOGE(TAG_FILESERVER, "File server base_path not set");
+        ESP_LOGE(TAG, "File server base_path not set");
 //        return ESP_ERR_INVALID_ARG;
     }
 
     if (server_data) {
-        ESP_LOGE(TAG_FILESERVER, "File server already started");
+        ESP_LOGE(TAG, "File server already started");
 //        return ESP_ERR_INVALID_STATE;
     }
 
     /* Allocate memory for server data */
     server_data = (file_server_data *) calloc(1, sizeof(struct file_server_data));
     if (!server_data) {
-        ESP_LOGE(TAG_FILESERVER, "Failed to allocate memory for server data");
+        ESP_LOGE(TAG, "Failed to allocate memory for server data");
 //        return ESP_ERR_NO_MEM;
     }
     strlcpy(server_data->base_path, base_path,

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -999,15 +999,14 @@ std::string unzip_new(std::string _in_zip_file, std::string _target_zip, std::st
                     ESP_LOGD(TAG, "ERROR in writting extracted file (function fwrite) extracted file \"%s\", size %u", archive_filename, (uint)uncomp_size);
                 }
 
-                DeleteFile(zw);
                 if (!isokay)
                     ESP_LOGE(TAG, "ERROR in fwrite \"%s\", size %u", archive_filename, (uint)uncomp_size);
                 isokay = isokay && RenameFile(filename_zw, zw);
                 if (!isokay)
                     ESP_LOGE(TAG, "ERROR in Rename \"%s\" to \"%s\"", filename_zw.c_str(), zw.c_str());
-//                isokay = isokay && DeleteFile(filename_zw);
-//                if (!isokay)
-//                    ESP_LOGE(TAG, "ERROR in Delete \"%s\"", filename_zw.c_str());
+                isokay = isokay && DeleteFile(filename_zw);
+                if (!isokay)
+                    ESP_LOGE(TAG, "ERROR in Delete \"%s\"", filename_zw.c_str());
 
                 if (isokay)
                     ESP_LOGI(TAG, "Successfully extracted file \"%s\", size %u", archive_filename, (uint)uncomp_size);

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -517,7 +517,7 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 /* Handler to download a file kept on the server */
 static esp_err_t download_get_handler(httpd_req_t *req)
 {
-    //LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "download_get_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "download_get_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     struct stat file_stat;

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -45,7 +45,7 @@ extern "C" {
 #include "Helper.h"
 #include "miniz.h"
 
-static const char *TAG = "OTA File";
+static const char *TAG = "OTA FILE";
 
 /* Max length a file path can have on storage */
 // #define FILE_PATH_MAX (ESP_VFS_PATH_MAX + CONFIG_SPIFFS_OBJ_NAME_LEN)
@@ -109,7 +109,7 @@ esp_err_t get_data_file_handler(httpd_req_t *req)
     size_t pos = 0;
     
     const char verz_name[] = "/sdcard/log/data";
-    ESP_LOGD(TAG, "Suche TFLITE in /sdcard/log/data");
+    ESP_LOGD(TAG, "Suche data files in /sdcard/log/data");
 
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
     httpd_resp_set_type(req, "text/plain");
@@ -132,7 +132,7 @@ esp_err_t get_data_file_handler(httpd_req_t *req)
 
         ESP_LOGD(TAG, " Extension: %s", _fileext.c_str());
 
-        if (_fileext == "txt")
+        if (_fileext == "csv")
         {
             _filename = _filename + "\t";
             httpd_resp_sendstr_chunk(req, _filename.c_str());
@@ -345,7 +345,7 @@ static esp_err_t datafileact_get_last_part_handler(httpd_req_t *req) {
 
 static esp_err_t send_datafile(httpd_req_t *req, bool send_full_file)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "log_get_last_part_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "data_get_last_part_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     //struct stat file_stat;
@@ -373,7 +373,7 @@ static esp_err_t send_datafile(httpd_req_t *req, bool send_full_file)
     set_content_type_from_file(req, filename);
 
     if (!send_full_file) { // Send only last part of file
-        ESP_LOGD(TAG, "Sending last %d bytes of the actual logfile!", LOGFILE_LAST_PART_BYTES);
+        ESP_LOGD(TAG, "Sending last %d bytes of the actual datafile!", LOGFILE_LAST_PART_BYTES);
 
         /* Adapted from https://www.geeksforgeeks.org/implement-your-own-tail-read-last-n-lines-of-a-huge-file/ */
         if (fseek(fd, 0, SEEK_END)) {
@@ -431,7 +431,7 @@ static esp_err_t send_datafile(httpd_req_t *req, bool send_full_file)
 
 static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "log_get_last_part_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "log_get_last_part_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     //struct stat file_stat;
@@ -517,7 +517,7 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 /* Handler to download a file kept on the server */
 static esp_err_t download_get_handler(httpd_req_t *req)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "download_get_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "download_get_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     struct stat file_stat;
@@ -618,7 +618,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 /* Handler to upload a file onto the server */
 static esp_err_t upload_post_handler(httpd_req_t *req)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "upload_post_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "upload_post_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     struct stat file_stat;
@@ -733,10 +733,8 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
     int start_fn = strlen(((struct file_server_data *)req->user_ctx)->base_path);
     ESP_LOGD(TAG, "Directory: %s, start_fn: %d, found: %d", directory.c_str(), start_fn, found);
 	directory = directory.substr(start_fn, found - start_fn + 1);
-    ESP_LOGD(TAG, "Directory danach 1: %s", directory.c_str());
-
     directory = "/fileserver" + directory;
-    ESP_LOGD(TAG, "Directory danach 2: %s", directory.c_str());
+//    ESP_LOGD(TAG, "Directory danach 2: %s", directory.c_str());
 
     /* Redirect onto root to see the updated file list */
     httpd_resp_set_status(req, "303 See Other");
@@ -761,7 +759,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 /* Handler to delete a file from the server */
 static esp_err_t delete_post_handler(httpd_req_t *req)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "delete_post_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "delete_post_handler");
     char filepath[FILE_PATH_MAX];
     struct stat file_stat;
 
@@ -855,8 +853,6 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
         int start_fn = strlen(((struct file_server_data *)req->user_ctx)->base_path);
         ESP_LOGD(TAG, "Directory: %s, start_fn: %d, found: %d", directory.c_str(), start_fn, found);
         directory = directory.substr(start_fn, found - start_fn + 1);
-        ESP_LOGD(TAG, "Directory danach 3: %s", directory.c_str());
-
         directory = "/fileserver" + directory;
         ESP_LOGD(TAG, "Directory danach 4: %s", directory.c_str());
     }
@@ -914,9 +910,9 @@ std::string unzip_new(std::string _in_zip_file, std::string _target_zip, std::st
 
     ESP_LOGD(TAG, "miniz.c version: %s", MZ_VERSION);
     ESP_LOGD(TAG, "Zipfile: %s", _in_zip_file.c_str());
-    ESP_LOGD(TAG, "Target Dir ZIP: %s", _target_zip.c_str());
-    ESP_LOGD(TAG, "Target Dir BIN: %s", _target_bin.c_str());
-    ESP_LOGD(TAG, "Target Dir main: %s", _main.c_str());
+//    ESP_LOGD(TAG, "Target Dir ZIP: %s", _target_zip.c_str());
+//    ESP_LOGD(TAG, "Target Dir BIN: %s", _target_bin.c_str());
+//    ESP_LOGD(TAG, "Target Dir main: %s", _main.c_str());
 
     // Now try to open the archive.
     memset(&zip_archive, 0, sizeof(zip_archive));
@@ -981,24 +977,43 @@ std::string unzip_new(std::string _in_zip_file, std::string _target_zip, std::st
             
                 string filename_zw = zw + SUFFIX_ZW;
 
-                ESP_LOGD(TAG, "Filename to extract: %s, Zwischenfilename: %s", zw.c_str(), filename_zw.c_str());
+                ESP_LOGI(TAG, "Filename to extract: %s, Zwischenfilename: %s", zw.c_str(), filename_zw.c_str());
 
                 // extrahieren in zwischendatei
                 DeleteFile(filename_zw);
                 FILE* fpTargetFile = OpenFileAndWait(filename_zw.c_str(), "wb");
-                fwrite(p, 1, (uint)uncomp_size, fpTargetFile);
+                uint writtenbytes = fwrite(p, 1, (uint)uncomp_size, fpTargetFile);
                 fclose(fpTargetFile);
+                
+                bool isokay = true;
 
+                if (writtenbytes == (uint)uncomp_size)
+                {
+                    isokay = true;
+                }
+                else
+                {
+                    isokay = false;
+                    ESP_LOGD(TAG, "ERROR in writting extracted file (function fwrite) extracted file \"%s\", size %u", archive_filename, (uint)uncomp_size);
+                }
+
+                DeleteFile(zw);
                 if (!isokay)
                     ESP_LOGE(TAG, "ERROR in fwrite \"%s\", size %u", archive_filename, (uint)uncomp_size);
                 isokay = isokay && RenameFile(filename_zw, zw);
                 if (!isokay)
                     ESP_LOGE(TAG, "ERROR in Rename \"%s\" to \"%s\"", filename_zw.c_str(), zw.c_str());
-                isokay = isokay && DeleteFile(filename_zw);
-                if (!isokay)
-                    ESP_LOGE(TAG, "ERROR in Delete \"%s\"", filename_zw.c_str());
+//                isokay = isokay && DeleteFile(filename_zw);
+//                if (!isokay)
+//                    ESP_LOGE(TAG, "ERROR in Delete \"%s\"", filename_zw.c_str());
 
-                // We're done.
+                if (isokay)
+                    ESP_LOGI(TAG, "Successfully extracted file \"%s\", size %u", archive_filename, (uint)uncomp_size);
+                else
+                {
+                    ESP_LOGE(TAG, "ERROR in extracting file \"%s\", size %u", archive_filename, (uint)uncomp_size);
+                    ret = "ERROR";
+                }
                 mz_free(p);
             }
         }

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -431,7 +431,7 @@ static esp_err_t send_datafile(httpd_req_t *req, bool send_full_file)
 
 static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 {
-    //LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "log_get_last_part_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "log_get_last_part_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     //struct stat file_stat;

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -345,7 +345,7 @@ static esp_err_t datafileact_get_last_part_handler(httpd_req_t *req) {
 
 static esp_err_t send_datafile(httpd_req_t *req, bool send_full_file)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "data_get_last_part_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "data_get_last_part_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     //struct stat file_stat;
@@ -431,7 +431,7 @@ static esp_err_t send_datafile(httpd_req_t *req, bool send_full_file)
 
 static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "log_get_last_part_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "log_get_last_part_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     //struct stat file_stat;
@@ -517,7 +517,7 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 /* Handler to download a file kept on the server */
 static esp_err_t download_get_handler(httpd_req_t *req)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "download_get_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "download_get_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     struct stat file_stat;
@@ -618,7 +618,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 /* Handler to upload a file onto the server */
 static esp_err_t upload_post_handler(httpd_req_t *req)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "upload_post_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "upload_post_handler");
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
     struct stat file_stat;
@@ -759,7 +759,7 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 /* Handler to delete a file from the server */
 static esp_err_t delete_post_handler(httpd_req_t *req)
 {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "delete_post_handler");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "delete_post_handler");
     char filepath[FILE_PATH_MAX];
     struct stat file_stat;
 

--- a/code/components/jomjol_fileserver_ota/server_help.cpp
+++ b/code/components/jomjol_fileserver_ota/server_help.cpp
@@ -22,7 +22,7 @@ extern "C" {
 #include "esp_http_server.h"
 
 
-static const char *TAG = "serverhelp";
+static const char *TAG = "SERVER HELP";
 
 #define SCRATCH_BUFSIZE  8192 
 char scratch[SCRATCH_BUFSIZE];

--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -296,7 +296,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
     LogFile.WriteHeapInfo("handler_ota_update - Start");    
 #endif
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "handler_ota_update");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_ota_update");
     char _query[200];
     char _filename[100];
     char _valuechar[30];    
@@ -518,8 +518,8 @@ void task_reboot(void *pvParameter)
 }
 
 void doReboot(){
-    LogFile.WriteToFile(ESP_LOG_INFO, "Reboot triggered by Software (5s).");
-    LogFile.WriteToFile(ESP_LOG_WARN, "Reboot in 5sec");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Reboot triggered by Software (5s).");
+    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Reboot in 5sec");
     xTaskCreate(&task_reboot, "reboot", configMINIMAL_STACK_SIZE * 64, NULL, 10, NULL);
     // KillTFliteTasks(); // kills itself 
     gpio_handler_destroy();
@@ -535,7 +535,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
     LogFile.WriteHeapInfo("handler_reboot - Start");
 #endif    
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "handler_reboot");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_reboot");
     ESP_LOGI(TAG, "!!! System will restart within 5 sec!!!");
     const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s.<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch(window.location.hostname,{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 1000);</script>";
     httpd_resp_send(req, resp_str, strlen(resp_str)); 

--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -48,7 +48,7 @@ static char ota_write_data[BUFFSIZE + 1] = { 0 };
 
 
 #define OTA_URL_SIZE 256
-static const char *TAGPARTOTA = "server_ota";
+static const char *TAG = "OTA";
 
 esp_err_t handler_reboot(httpd_req_t *req);
 
@@ -56,9 +56,9 @@ esp_err_t handler_reboot(httpd_req_t *req);
 static void infinite_loop(void)
 {
     int i = 0;
-    ESP_LOGI(TAGPARTOTA, "When a new firmware is available on the server, press the reset button to download it");
+    ESP_LOGI(TAG, "When a new firmware is available on the server, press the reset button to download it");
     while(1) {
-        ESP_LOGI(TAGPARTOTA, "Waiting for a new firmware... %d", ++i);
+        ESP_LOGI(TAG, "Waiting for a new firmware... %d", ++i);
         vTaskDelay(2000 / portTICK_PERIOD_MS);
     }
 }
@@ -72,22 +72,22 @@ static bool ota_update_task(std::string fn)
     esp_ota_handle_t update_handle = 0 ;
     const esp_partition_t *update_partition = NULL;
 
-    ESP_LOGI(TAGPARTOTA, "Starting OTA update");
+    ESP_LOGI(TAG, "Starting OTA update");
 
     const esp_partition_t *configured = esp_ota_get_boot_partition();
     const esp_partition_t *running = esp_ota_get_running_partition();
 
     if (configured != running) {
-        ESP_LOGW(TAGPARTOTA, "Configured OTA boot partition at offset 0x%08x, but running from offset 0x%08x",
+        ESP_LOGW(TAG, "Configured OTA boot partition at offset 0x%08x, but running from offset 0x%08x",
                  configured->address, running->address);
-        ESP_LOGW(TAGPARTOTA, "(This can happen if either the OTA boot data or preferred boot image become somehow corrupted.)");
+        ESP_LOGW(TAG, "(This can happen if either the OTA boot data or preferred boot image become somehow corrupted.)");
     }
-    ESP_LOGI(TAGPARTOTA, "Running partition type %d subtype %d (offset 0x%08x)",
+    ESP_LOGI(TAG, "Running partition type %d subtype %d (offset 0x%08x)",
              running->type, running->subtype, running->address);
 
 
     update_partition = esp_ota_get_next_update_partition(NULL);
-    ESP_LOGI(TAGPARTOTA, "Writing to partition subtype %d at offset 0x%x",
+    ESP_LOGI(TAG, "Writing to partition subtype %d at offset 0x%x",
              update_partition->subtype, update_partition->address);
 //    assert(update_partition != NULL);
 
@@ -108,7 +108,7 @@ static bool ota_update_task(std::string fn)
 
     while (data_read > 0) {
         if (data_read < 0) {
-            ESP_LOGE(TAGPARTOTA, "Error: SSL data read error");
+            ESP_LOGE(TAG, "Error: SSL data read error");
             return false;
         } else if (data_read > 0) {
             if (image_header_was_checked == false) {
@@ -116,32 +116,32 @@ static bool ota_update_task(std::string fn)
                 if (data_read > sizeof(esp_image_header_t) + sizeof(esp_image_segment_header_t) + sizeof(esp_app_desc_t)) {
                     // check current version with downloading
                     memcpy(&new_app_info, &ota_write_data[sizeof(esp_image_header_t) + sizeof(esp_image_segment_header_t)], sizeof(esp_app_desc_t));
-                    ESP_LOGI(TAGPARTOTA, "New firmware version: %s", new_app_info.version);
+                    ESP_LOGI(TAG, "New firmware version: %s", new_app_info.version);
 
                     esp_app_desc_t running_app_info;
                     if (esp_ota_get_partition_description(running, &running_app_info) == ESP_OK) {
-                        ESP_LOGI(TAGPARTOTA, "Running firmware version: %s", running_app_info.version);
+                        ESP_LOGI(TAG, "Running firmware version: %s", running_app_info.version);
                     }
 
                     const esp_partition_t* last_invalid_app = esp_ota_get_last_invalid_partition();
                     esp_app_desc_t invalid_app_info;
                     if (esp_ota_get_partition_description(last_invalid_app, &invalid_app_info) == ESP_OK) {
-                        ESP_LOGI(TAGPARTOTA, "Last invalid firmware version: %s", invalid_app_info.version);
+                        ESP_LOGI(TAG, "Last invalid firmware version: %s", invalid_app_info.version);
                     }
 
                     // check current version with last invalid partition
                     if (last_invalid_app != NULL) {
                         if (memcmp(invalid_app_info.version, new_app_info.version, sizeof(new_app_info.version)) == 0) {
-                            ESP_LOGW(TAGPARTOTA, "New version is the same as invalid version.");
-                            ESP_LOGW(TAGPARTOTA, "Previously, there was an attempt to launch the firmware with %s version, but it failed.", invalid_app_info.version);
-                            ESP_LOGW(TAGPARTOTA, "The firmware has been rolled back to the previous version.");
+                            ESP_LOGW(TAG, "New version is the same as invalid version.");
+                            ESP_LOGW(TAG, "Previously, there was an attempt to launch the firmware with %s version, but it failed.", invalid_app_info.version);
+                            ESP_LOGW(TAG, "The firmware has been rolled back to the previous version.");
                             infinite_loop();
                         }
                     }
 
 /*
                     if (memcmp(new_app_info.version, running_app_info.version, sizeof(new_app_info.version)) == 0) {
-                        ESP_LOGW(TAGPARTOTA, "Current running version is the same as a new. We will not continue the update.");
+                        ESP_LOGW(TAG, "Current running version is the same as a new. We will not continue the update.");
                         infinite_loop();
                     }
 */
@@ -149,12 +149,12 @@ static bool ota_update_task(std::string fn)
 
                     err = esp_ota_begin(update_partition, OTA_SIZE_UNKNOWN, &update_handle);
                     if (err != ESP_OK) {
-                        ESP_LOGE(TAGPARTOTA, "esp_ota_begin failed (%s)", esp_err_to_name(err));
+                        ESP_LOGE(TAG, "esp_ota_begin failed (%s)", esp_err_to_name(err));
                         return false;
                     }
-                    ESP_LOGI(TAGPARTOTA, "esp_ota_begin succeeded");
+                    ESP_LOGI(TAG, "esp_ota_begin succeeded");
                 } else {
-                    ESP_LOGE(TAGPARTOTA, "received package is not fit len");
+                    ESP_LOGE(TAG, "received package is not fit len");
                     return false;
                 }
             }            
@@ -163,14 +163,14 @@ static bool ota_update_task(std::string fn)
                 return false;
             }
             binary_file_length += data_read;
-            ESP_LOGD(TAGPARTOTA, "Written image length %d", binary_file_length);
+            ESP_LOGD(TAG, "Written image length %d", binary_file_length);
         } else if (data_read == 0) {
            //
            // * As esp_http_client_read never returns negative error code, we rely on
            // * `errno` to check for underlying transport connectivity closure if any
            //
             if (errno == ECONNRESET || errno == ENOTCONN) {
-                ESP_LOGE(TAGPARTOTA, "Connection closed, errno = %d", errno);
+                ESP_LOGE(TAG, "Connection closed, errno = %d", errno);
                 break;
             }
         }
@@ -178,23 +178,23 @@ static bool ota_update_task(std::string fn)
     }
     fclose(f);  
 
-    ESP_LOGI(TAGPARTOTA, "Total Write binary data length: %d", binary_file_length);
+    ESP_LOGI(TAG, "Total Write binary data length: %d", binary_file_length);
 
     err = esp_ota_end(update_handle);
     if (err != ESP_OK) {
         if (err == ESP_ERR_OTA_VALIDATE_FAILED) {
-            ESP_LOGE(TAGPARTOTA, "Image validation failed, image is corrupted");
+            ESP_LOGE(TAG, "Image validation failed, image is corrupted");
         }
-        ESP_LOGE(TAGPARTOTA, "esp_ota_end failed (%s)!", esp_err_to_name(err));
+        ESP_LOGE(TAG, "esp_ota_end failed (%s)!", esp_err_to_name(err));
         return false;
     }
 
     err = esp_ota_set_boot_partition(update_partition);
     if (err != ESP_OK) {
-        ESP_LOGE(TAGPARTOTA, "esp_ota_set_boot_partition failed (%s)!", esp_err_to_name(err));
+        ESP_LOGE(TAG, "esp_ota_set_boot_partition failed (%s)!", esp_err_to_name(err));
 
     }
-//    ESP_LOGI(TAGPARTOTA, "Prepare to restart system!");
+//    ESP_LOGI(TAG, "Prepare to restart system!");
 //    esp_restart();
 
     return true ;
@@ -208,7 +208,7 @@ static void print_sha256 (const uint8_t *image_hash, const char *label)
     for (int i = 0; i < HASH_LEN; ++i) {
         sprintf(&hash_print[i * 2], "%02x", image_hash[i]);
     }
-    ESP_LOGI(TAGPARTOTA, "%s: %s", label, hash_print);
+    ESP_LOGI(TAG, "%s: %s", label, hash_print);
 }
 
 
@@ -219,7 +219,7 @@ static bool diagnostic(void)
 
 void CheckOTAUpdate(void)
 {
-    ESP_LOGI(TAGPARTOTA, "Start CheckOTAUpdateCheck...");
+    ESP_LOGI(TAG, "Start CheckOTAUpdateCheck...");
 
     uint8_t sha_256[HASH_LEN] = { 0 };
     esp_partition_t partition;
@@ -248,29 +248,29 @@ void CheckOTAUpdate(void)
     switch (res_stat_partition)
     {
         case ESP_OK:
-            ESP_LOGD(TAGPARTOTA, "CheckOTAUpdate Partition: ESP_OK");
+            ESP_LOGD(TAG, "CheckOTAUpdate Partition: ESP_OK");
             if (esp_ota_get_state_partition(running, &ota_state) == ESP_OK) {
                 if (ota_state == ESP_OTA_IMG_PENDING_VERIFY) {
                     // run diagnostic function ...
                     bool diagnostic_is_ok = diagnostic();
                     if (diagnostic_is_ok) {
-                        ESP_LOGI(TAGPARTOTA, "Diagnostics completed successfully! Continuing execution...");
+                        ESP_LOGI(TAG, "Diagnostics completed successfully! Continuing execution...");
                         esp_ota_mark_app_valid_cancel_rollback();
                     } else {
-                        ESP_LOGE(TAGPARTOTA, "Diagnostics failed! Start rollback to the previous version...");
+                        ESP_LOGE(TAG, "Diagnostics failed! Start rollback to the previous version...");
                         esp_ota_mark_app_invalid_rollback_and_reboot();
                     }
                 }
             }            
             break;
         case ESP_ERR_INVALID_ARG:
-            ESP_LOGD(TAGPARTOTA, "CheckOTAUpdate Partition: ESP_ERR_INVALID_ARG");
+            ESP_LOGD(TAG, "CheckOTAUpdate Partition: ESP_ERR_INVALID_ARG");
             break;
         case ESP_ERR_NOT_SUPPORTED:
-            ESP_LOGD(TAGPARTOTA, "CheckOTAUpdate Partition: ESP_ERR_NOT_SUPPORTED");
+            ESP_LOGD(TAG, "CheckOTAUpdate Partition: ESP_ERR_NOT_SUPPORTED");
             break;
         case ESP_ERR_NOT_FOUND:
-            ESP_LOGD(TAGPARTOTA, "CheckOTAUpdate Partition: ESP_ERR_NOT_FOUND");
+            ESP_LOGD(TAG, "CheckOTAUpdate Partition: ESP_ERR_NOT_FOUND");
             break;
     }
     if (esp_ota_get_state_partition(running, &ota_state) == ESP_OK) {
@@ -278,10 +278,10 @@ void CheckOTAUpdate(void)
             // run diagnostic function ...
             bool diagnostic_is_ok = diagnostic();
             if (diagnostic_is_ok) {
-                ESP_LOGI(TAGPARTOTA, "Diagnostics completed successfully! Continuing execution...");
+                ESP_LOGI(TAG, "Diagnostics completed successfully! Continuing execution...");
                 esp_ota_mark_app_valid_cancel_rollback();
             } else {
-                ESP_LOGE(TAGPARTOTA, "Diagnostics failed! Start rollback to the previous version...");
+                ESP_LOGE(TAG, "Diagnostics failed! Start rollback to the previous version...");
                 esp_ota_mark_app_invalid_rollback_and_reboot();
             }
         }
@@ -296,7 +296,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
     LogFile.WriteHeapInfo("handler_ota_update - Start");    
 #endif
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "handler_ota_update");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_ota_update");
     char _query[200];
     char _filename[100];
     char _valuechar[30];    
@@ -306,44 +306,27 @@ esp_err_t handler_ota_update(httpd_req_t *req)
 
     if (httpd_req_get_url_query_str(req, _query, 200) == ESP_OK)
     {
-        ESP_LOGD(TAGPARTOTA, "Query: %s", _query);
+        ESP_LOGD(TAG, "Query: %s", _query);
         
         if (httpd_query_key_value(_query, "task", _valuechar, 30) == ESP_OK)
         {
-            ESP_LOGD(TAGPARTOTA, "task is found: %s", _valuechar);
+            ESP_LOGD(TAG, "task is found: %s", _valuechar);
             _task = std::string(_valuechar);
         }
 
         if (httpd_query_key_value(_query, "file", _filename, 100) == ESP_OK)
         {
             fn.append(_filename);
-            ESP_LOGD(TAGPARTOTA, "File: %s", fn.c_str());
+            ESP_LOGD(TAG, "File: %s", fn.c_str());
         }
         if (httpd_query_key_value(_query, "delete", _filename, 100) == ESP_OK)
         {
             fn.append(_filename);
             _file_del = true;
-            ESP_LOGD(TAGPARTOTA, "Delete Default File: %s", fn.c_str());
+            ESP_LOGD(TAG, "Delete Default File: %s", fn.c_str());
         }
 
     };
-
-    if (_task.compare("emptyfirmwaredir") == 0)
-    {
-        ESP_LOGD(TAGPARTOTA, "Start empty directory /firmware");
-        delete_all_in_directory("/sdcard/firmware");
-        std::string zw = "firmware directory deleted - v2\n";
-        ESP_LOGD(TAGPARTOTA, "%s", zw.c_str());
-        printf("Ausgabe: %s\n", zw.c_str());
-    
-        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-        httpd_resp_send(req, zw.c_str(), strlen(zw.c_str())); 
-        /* Respond with an empty chunk to signal HTTP response completion */
-        httpd_resp_send_chunk(req, NULL, 0);  
-
-        ESP_LOGD(TAGPARTOTA, "Done empty directory /firmware");
-        return ESP_OK;
-    }
 
     if (_task.compare("update") == 0)
     {
@@ -406,7 +389,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
                 std::string zw = "reboot\n";
                 httpd_resp_sendstr_chunk(req, zw.c_str());
                 httpd_resp_sendstr_chunk(req, NULL);  
-                ESP_LOGD(TAGPARTOTA, "Send reboot");
+                ESP_LOGD(TAG, "Send reboot");
                 return ESP_OK;                
             }
 
@@ -430,7 +413,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
 
     if (_task.compare("unziphtml") == 0)
     {
-        ESP_LOGD(TAGPARTOTA, "Task unziphtml");
+        ESP_LOGD(TAG, "Task unziphtml");
         std::string in, out, zw;
 
         in = "/sdcard/firmware/html.zip";
@@ -447,35 +430,27 @@ esp_err_t handler_ota_update(httpd_req_t *req)
 
     if (_file_del)
     {
-        ESP_LOGD(TAGPARTOTA, "Delete !! _file_del: %s", fn.c_str());
+        ESP_LOGD(TAG, "Delete !! _file_del: %s", fn.c_str());
         struct stat file_stat;
         int _result = stat(fn.c_str(), &file_stat);
-        ESP_LOGD(TAGPARTOTA, "Ergebnis %d\n", _result);
+        ESP_LOGD(TAG, "Ergebnis %d\n", _result);
         if (_result == 0) {
-            ESP_LOGD(TAGPARTOTA, "Deleting file : %s", fn.c_str());
+            ESP_LOGD(TAG, "Deleting file : %s", fn.c_str());
             /* Delete file */
             unlink(fn.c_str());
         }
         else
         {
-            ESP_LOGD(TAGPARTOTA, "File does not exist: %s", fn.c_str());
+            ESP_LOGD(TAG, "File does not exist: %s", fn.c_str());
         }
         /* Respond with an empty chunk to signal HTTP response completion */
         std::string zw = "file deleted\n";
-        ESP_LOGD(TAGPARTOTA, "%s", zw.c_str());
+        ESP_LOGD(TAG, "%s", zw.c_str());
         httpd_resp_send(req, zw.c_str(), strlen(zw.c_str()));
         httpd_resp_send_chunk(req, NULL, 0);
         return ESP_OK;
     }
 
-    string zw = "ota without parameter - should not be the case!";
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_send(req, zw.c_str(), strlen(zw.c_str())); 
-    httpd_resp_send_chunk(req, NULL, 0);  
-
-    ESP_LOGE(TAGPARTOTA, "ota without parameter - should not be the case!");
-
-/*  
     const char* resp_str;    
 
     KillTFliteTasks();
@@ -494,7 +469,6 @@ esp_err_t handler_ota_update(httpd_req_t *req)
 #ifdef DEBUG_DETAIL_ON 
     LogFile.WriteHeapInfo("handler_ota_update - Done");    
 #endif
-*/
 
     return ESP_OK;
 };
@@ -518,8 +492,8 @@ void task_reboot(void *pvParameter)
 }
 
 void doReboot(){
-    LogFile.WriteToFile(ESP_LOG_INFO, "Reboot triggered by Software (5s).");
-    LogFile.WriteToFile(ESP_LOG_WARN, "Reboot in 5sec");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Reboot triggered by Software (5s).");
+    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Reboot in 5sec");
     xTaskCreate(&task_reboot, "reboot", configMINIMAL_STACK_SIZE * 64, NULL, 10, NULL);
     // KillTFliteTasks(); // kills itself 
     gpio_handler_destroy();
@@ -535,8 +509,8 @@ esp_err_t handler_reboot(httpd_req_t *req)
     LogFile.WriteHeapInfo("handler_reboot - Start");
 #endif    
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "handler_reboot");
-    ESP_LOGI(TAGPARTOTA, "!!! System will restart within 5 sec!!!");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_reboot");
+    ESP_LOGI(TAG, "!!! System will restart within 5 sec!!!");
     const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s.<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch(window.location.hostname,{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 1000);</script>";
     httpd_resp_send(req, resp_str, strlen(resp_str)); 
     
@@ -551,7 +525,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
 
 void register_server_ota_sdcard_uri(httpd_handle_t server)
 {
-    ESP_LOGI(TAGPARTOTA, "server_ota - Registering URI handlers");
+    ESP_LOGI(TAG, "server_ota - Registering URI handlers");
     
     httpd_uri_t camuri = { };
     camuri.method    = HTTP_GET;

--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -296,7 +296,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
     LogFile.WriteHeapInfo("handler_ota_update - Start");    
 #endif
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_ota_update");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "handler_ota_update");
     char _query[200];
     char _filename[100];
     char _valuechar[30];    
@@ -327,6 +327,23 @@ esp_err_t handler_ota_update(httpd_req_t *req)
         }
 
     };
+
+    if (_task.compare("emptyfirmwaredir") == 0)
+    {
+        ESP_LOGD(TAG, "Start empty directory /firmware");
+        delete_all_in_directory("/sdcard/firmware");
+        std::string zw = "firmware directory deleted - v2\n";
+        ESP_LOGD(TAG, "%s", zw.c_str());
+        printf("Ausgabe: %s\n", zw.c_str());
+    
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+        httpd_resp_send(req, zw.c_str(), strlen(zw.c_str())); 
+        /* Respond with an empty chunk to signal HTTP response completion */
+        httpd_resp_send_chunk(req, NULL, 0);  
+
+        ESP_LOGD(TAG, "Done empty directory /firmware");
+        return ESP_OK;
+    }
 
     if (_task.compare("update") == 0)
     {
@@ -451,6 +468,14 @@ esp_err_t handler_ota_update(httpd_req_t *req)
         return ESP_OK;
     }
 
+    string zw = "ota without parameter - should not be the case!";
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_send(req, zw.c_str(), strlen(zw.c_str())); 
+    httpd_resp_send_chunk(req, NULL, 0);  
+
+    ESP_LOGE(TAG, "ota without parameter - should not be the case!");
+
+/*  
     const char* resp_str;    
 
     KillTFliteTasks();
@@ -469,6 +494,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
 #ifdef DEBUG_DETAIL_ON 
     LogFile.WriteHeapInfo("handler_ota_update - Done");    
 #endif
+*/
 
     return ESP_OK;
 };
@@ -492,8 +518,8 @@ void task_reboot(void *pvParameter)
 }
 
 void doReboot(){
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Reboot triggered by Software (5s).");
-    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Reboot in 5sec");
+    LogFile.WriteToFile(ESP_LOG_INFO, "Reboot triggered by Software (5s).");
+    LogFile.WriteToFile(ESP_LOG_WARN, "Reboot in 5sec");
     xTaskCreate(&task_reboot, "reboot", configMINIMAL_STACK_SIZE * 64, NULL, 10, NULL);
     // KillTFliteTasks(); // kills itself 
     gpio_handler_destroy();
@@ -509,7 +535,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
     LogFile.WriteHeapInfo("handler_reboot - Start");
 #endif    
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_reboot");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "handler_reboot");
     ESP_LOGI(TAG, "!!! System will restart within 5 sec!!!");
     const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s.<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch(window.location.hostname,{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 1000);</script>";
     httpd_resp_send(req, resp_str, strlen(resp_str)); 
@@ -525,7 +551,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
 
 void register_server_ota_sdcard_uri(httpd_handle_t server)
 {
-    ESP_LOGI(TAG, "server_ota - Registering URI handlers");
+    ESP_LOGI(TAG, "Registering URI handlers");
     
     httpd_uri_t camuri = { };
     camuri.method    = HTTP_GET;

--- a/code/components/jomjol_flowcontroll/ClassFlow.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlow.cpp
@@ -5,7 +5,7 @@
 #include <string.h>
 #include "esp_log.h"
 
-static const char *TAG = "class_flow";
+static const char *TAG = "FLOW CLASS";
 
 
 void ClassFlow::SetInitialParameter(void)

--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -9,7 +9,7 @@
 #include "ClassLogFile.h"
 
 
-static const char *TAG = "class_flow_alignment";
+static const char *TAG = "FLOW ALIGN";
 
 bool AlignmentExtendedDebugging = true;
 
@@ -120,7 +120,7 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, string& aktparamgraph)
         {
 #ifdef DEBUG_DETAIL_ON
             std::string zw2 = "Alignmentmodus gewählt: " + zerlegt[1];
-            LogFile.WriteToFile(ESP_LOG_DEBUG, zw2);
+            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, zw2);
 #endif
             if (toUpper(zerlegt[1]) == "HIGHACCURACY")
                 alg_algo = 1;
@@ -137,7 +137,7 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, string& aktparamgraph)
         References[i].alignment_algo = alg_algo;
 #ifdef DEBUG_DETAIL_ON
         std::string zw2 = "Alignmentmodus geschrieben: " + std::to_string(alg_algo);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, zw2);
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, zw2);
 #endif
     }
 

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -35,7 +35,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
 
     if (GENERAL[_analog]->ROI.size() == 0)
         return result;
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout _analog=" + std::to_string(_analog) + ", _extendedResolution=" + std::to_string(_extendedResolution) + ", prev=" + std::to_string(prev));
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout _analog=" + std::to_string(_analog) + ", _extendedResolution=" + std::to_string(_extendedResolution) + ", prev=" + std::to_string(prev));
  
     if (CNNType == Analogue || CNNType == Analogue100)
     {
@@ -43,7 +43,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
         int ergebnis_nachkomma = ((int) floor(zahl * 10) + 10) % 10;
         
         prev = ZeigerEvalAnalogNeu(GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float, prev);
-//        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(analog) zahl=" + std::to_string(zahl) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
+//        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(analog) zahl=" + std::to_string(zahl) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
         result = std::to_string(prev);
 
         if (_extendedResolution && (CNNType != Digital))
@@ -82,7 +82,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
 
                 result = std::to_string(ergebnis_vorkomma) + std::to_string(ergebnis_nachkomma);
                 prev = ergebnis_vorkomma;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(dig100-ext) ergebnis_vorkomma=" + std::to_string(ergebnis_vorkomma) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100-ext) ergebnis_vorkomma=" + std::to_string(ergebnis_vorkomma) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
             }
             else
             {
@@ -92,7 +92,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
                 else
                     prev = ZeigerEvalHybridNeu(GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float, prev, prev);
                 result = std::to_string(prev);
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(dig100)  prev=" + std::to_string(prev));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100)  prev=" + std::to_string(prev));
         
             }
         }
@@ -108,16 +108,16 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
             if (GENERAL[_analog]->ROI[i]->result_float >= 0)
             {
                 prev = ZeigerEvalHybridNeu(GENERAL[_analog]->ROI[i]->result_float, GENERAL[_analog]->ROI[i+1]->result_float, prev);
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout#ZeigerEvalHybridNeu()= " + std::to_string(prev));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout#ZeigerEvalHybridNeu()= " + std::to_string(prev));
                 result = std::to_string(prev) + result;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout#result= " + result);
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout#result= " + result);
                 
             }
             else
             {
                 prev = -1;
                 result = "N" + result;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(result_float<0 /'N')  result_float=" + std::to_string(GENERAL[_analog]->ROI[i]->result_float));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(result_float<0 /'N')  result_float=" + std::to_string(GENERAL[_analog]->ROI[i]->result_float));
         
             }
         }
@@ -141,7 +141,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         else
             result = (int) ((int) trunc(zahl) + 10) % 10;
 
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }
@@ -149,7 +149,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
     if (AnalogerVorgaenger)
     {
         result = ZeigerEvalAnalogToDigitNeu(zahl, zahl_vorgaenger, eval_vorgaenger, digitalAnalogTransitionStart);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - Analoger Vorgänger, Bewertung über ZeigerEvalAnalogNeu = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - Analoger Vorgänger, Bewertung über ZeigerEvalAnalogNeu = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }
@@ -162,7 +162,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         else
             result = ((int) trunc(zahl) + 10) % 10;
 
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, kein Ziffernwechsel, da Vorkomma weit genug weg = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, kein Ziffernwechsel, da Vorkomma weit genug weg = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }  
@@ -177,7 +177,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         else
             // Akt. digit und Vorgänger haben Nulldurchgang
             result =  ergebnis_vorkomma;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, Nulldurchgang hat stattgefunden = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, Nulldurchgang hat stattgefunden = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }
@@ -196,7 +196,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         // keinen Nulldurchgang hat. Daher wird um 1 reduziert.
         result =  (ergebnis_vorkomma - 1 + 10) % 10;
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, >= 9.5 --> noch kein Nulldurchgang = " + std::to_string(result) +
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, >= 9.5 --> noch kein Nulldurchgang = " + std::to_string(result) +
                                                 " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe) + " ergebnis_nachkomma = " + std::to_string(ergebnis_nachkomma));
     return result;
 }
@@ -216,13 +216,13 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu(float zahl, float ziffer_vor
         // vor/nachkomma neu berechnen, da wir anhand der Unschaefe die Zahl anpassen.
         ergebnis_nachkomma = ((int) floor(result * 10)) % 10;
         ergebnis_vorkomma = ((int) floor(result) + 10) % 10;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu - digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogToDigitNeu - digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger: " + std::to_string(ziffer_vorgaenger) +
                                                     " erg_vorkomma: " + std::to_string(ergebnis_vorkomma) + 
                                                     " erg_nachkomma: " + std::to_string(ergebnis_nachkomma));
     } else {
         result = (int) ((int) trunc(zahl) + 10) % 10;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu - KEINE digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogToDigitNeu - KEINE digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger));
     }
 
@@ -236,7 +236,7 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu(float zahl, float ziffer_vor
 
     {
         result =  ((ergebnis_vorkomma+10) - 1) % 10;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu - Nulldurchgang noch nicht stattgefunden = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogToDigitNeu - Nulldurchgang noch nicht stattgefunden = " + std::to_string(result) +
                                     " zahl: " + std::to_string(zahl) + 
                                     " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + 
                                     " erg_nachkomma = " +  std::to_string(ergebnis_nachkomma));
@@ -255,7 +255,7 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogNeu(float zahl, int ziffer_vorgaenger)
     if (ziffer_vorgaenger == -1)
     {
         result = (int) floor(zahl);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
         return result;
     }
@@ -268,14 +268,14 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogNeu(float zahl, int ziffer_vorgaenger)
         if (ziffer_vorgaenger <= AnalogFehler)
         {
             result = ((int) floor(zahl_max) + 10) % 10;
-            LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach oben - Ergebnis = " + std::to_string(result) +
+            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach oben - Ergebnis = " + std::to_string(result) +
                                                         " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
             return result;
         }
         if (ziffer_vorgaenger >= 10 - AnalogFehler)
         {
             result = ((int) floor(zahl_min) + 10) % 10;
-            LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach unten - Ergebnis = " + std::to_string(result) +
+            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach unten - Ergebnis = " + std::to_string(result) +
                                                         " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
             return result;
         }
@@ -283,7 +283,7 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogNeu(float zahl, int ziffer_vorgaenger)
     
 
     result = ((int) floor(zahl) + 10) % 10;
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - Zahl eindeutig, keine Korrektur notwendig - Ergebnis = " + std::to_string(result) +
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - Zahl eindeutig, keine Korrektur notwendig - Ergebnis = " + std::to_string(result) +
                                                 " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
 
     return result;
@@ -471,7 +471,7 @@ bool ClassFlowCNNGeneral::doFlow(string time)
         return false;
     };
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::doFlow nach Alignment");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "doFlow nach Alignment");
 
     doNeuralNetwork(time);
 
@@ -548,7 +548,7 @@ bool ClassFlowCNNGeneral::getNetworkParameter()
     zwcnn = FormatFileName(zwcnn);
     ESP_LOGD(TAG, "%s", zwcnn.c_str());
     if (!tflite->LoadModel(zwcnn)) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
         delete tflite;
         return false;
     } 
@@ -595,7 +595,7 @@ bool ClassFlowCNNGeneral::getNetworkParameter()
                 }
                 break;
             default:
-                LogFile.WriteToFile(ESP_LOG_ERROR, "tflite passt nicht zur Firmware (outout_dimension=" + std::to_string(_anzoutputdimensions) + ")");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "tflite passt nicht zur Firmware (outout_dimension=" + std::to_string(_anzoutputdimensions) + ")");
         }
     }
 
@@ -615,7 +615,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
     zwcnn = FormatFileName(zwcnn);
     ESP_LOGD(TAG, "%s", zwcnn.c_str());
     if (!tflite->LoadModel(zwcnn)) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
 
         delete tflite;
         return false;
@@ -636,7 +636,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
 
                         f1 = tflite->GetOutputValue(0);
                         f2 = tflite->GetOutputValue(1);
@@ -679,7 +679,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
 
                         _num = tflite->GetOutClassification(0, 10);
                         _nachkomma = tflite->GetOutClassification(11, 21);
@@ -719,7 +719,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
 
                         _num = tflite->GetOutClassification(0, 9);
                         _nachkomma = tflite->GetOutClassification(10, 19);
@@ -759,7 +759,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
 
                         _num = tflite->GetOutClassification(0, 9);
                         _numplus = (_num + 1) % 10;

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -9,7 +9,7 @@
 #include "ClassLogFile.h"
 #include "esp_log.h"
 
-static const char* TAG = "flow_analog";
+static const char* TAG = "CNN";
 
 
 
@@ -35,7 +35,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
 
     if (GENERAL[_analog]->ROI.size() == 0)
         return result;
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout _analog=" + std::to_string(_analog) + ", _extendedResolution=" + std::to_string(_extendedResolution) + ", prev=" + std::to_string(prev));
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout _analog=" + std::to_string(_analog) + ", _extendedResolution=" + std::to_string(_extendedResolution) + ", prev=" + std::to_string(prev));
  
     if (CNNType == Analogue || CNNType == Analogue100)
     {
@@ -43,7 +43,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
         int ergebnis_nachkomma = ((int) floor(zahl * 10) + 10) % 10;
         
         prev = ZeigerEvalAnalogNeu(GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float, prev);
-//        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(analog) zahl=" + std::to_string(zahl) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
+//        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(analog) zahl=" + std::to_string(zahl) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
         result = std::to_string(prev);
 
         if (_extendedResolution && (CNNType != Digital))
@@ -82,7 +82,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
 
                 result = std::to_string(ergebnis_vorkomma) + std::to_string(ergebnis_nachkomma);
                 prev = ergebnis_vorkomma;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(dig100-ext) ergebnis_vorkomma=" + std::to_string(ergebnis_vorkomma) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100-ext) ergebnis_vorkomma=" + std::to_string(ergebnis_vorkomma) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
             }
             else
             {
@@ -92,7 +92,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
                 else
                     prev = ZeigerEvalHybridNeu(GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float, prev, prev);
                 result = std::to_string(prev);
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(dig100)  prev=" + std::to_string(prev));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100)  prev=" + std::to_string(prev));
         
             }
         }
@@ -108,16 +108,16 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
             if (GENERAL[_analog]->ROI[i]->result_float >= 0)
             {
                 prev = ZeigerEvalHybridNeu(GENERAL[_analog]->ROI[i]->result_float, GENERAL[_analog]->ROI[i+1]->result_float, prev);
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout#ZeigerEvalHybridNeu()= " + std::to_string(prev));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout#ZeigerEvalHybridNeu()= " + std::to_string(prev));
                 result = std::to_string(prev) + result;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout#result= " + result);
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout#result= " + result);
                 
             }
             else
             {
                 prev = -1;
                 result = "N" + result;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(result_float<0 /'N')  result_float=" + std::to_string(GENERAL[_analog]->ROI[i]->result_float));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(result_float<0 /'N')  result_float=" + std::to_string(GENERAL[_analog]->ROI[i]->result_float));
         
             }
         }
@@ -141,7 +141,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         else
             result = (int) ((int) trunc(zahl) + 10) % 10;
 
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }
@@ -149,7 +149,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
     if (AnalogerVorgaenger)
     {
         result = ZeigerEvalAnalogToDigitNeu(zahl, zahl_vorgaenger, eval_vorgaenger, digitalAnalogTransitionStart);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - Analoger Vorgänger, Bewertung über ZeigerEvalAnalogNeu = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - Analoger Vorgänger, Bewertung über ZeigerEvalAnalogNeu = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }
@@ -162,7 +162,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         else
             result = ((int) trunc(zahl) + 10) % 10;
 
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, kein Ziffernwechsel, da Vorkomma weit genug weg = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, kein Ziffernwechsel, da Vorkomma weit genug weg = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }  
@@ -177,7 +177,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         else
             // Akt. digit und Vorgänger haben Nulldurchgang
             result =  ergebnis_vorkomma;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, Nulldurchgang hat stattgefunden = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, Nulldurchgang hat stattgefunden = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }
@@ -196,7 +196,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         // keinen Nulldurchgang hat. Daher wird um 1 reduziert.
         result =  (ergebnis_vorkomma - 1 + 10) % 10;
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, >= 9.5 --> noch kein Nulldurchgang = " + std::to_string(result) +
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, >= 9.5 --> noch kein Nulldurchgang = " + std::to_string(result) +
                                                 " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe) + " ergebnis_nachkomma = " + std::to_string(ergebnis_nachkomma));
     return result;
 }
@@ -216,13 +216,13 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu(float zahl, float ziffer_vor
         // vor/nachkomma neu berechnen, da wir anhand der Unschaefe die Zahl anpassen.
         ergebnis_nachkomma = ((int) floor(result * 10)) % 10;
         ergebnis_vorkomma = ((int) floor(result) + 10) % 10;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu - digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogToDigitNeu - digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger: " + std::to_string(ziffer_vorgaenger) +
                                                     " erg_vorkomma: " + std::to_string(ergebnis_vorkomma) + 
                                                     " erg_nachkomma: " + std::to_string(ergebnis_nachkomma));
     } else {
         result = (int) ((int) trunc(zahl) + 10) % 10;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu - KEINE digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogToDigitNeu - KEINE digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger));
     }
 
@@ -236,7 +236,7 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu(float zahl, float ziffer_vor
 
     {
         result =  ((ergebnis_vorkomma+10) - 1) % 10;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu - Nulldurchgang noch nicht stattgefunden = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogToDigitNeu - Nulldurchgang noch nicht stattgefunden = " + std::to_string(result) +
                                     " zahl: " + std::to_string(zahl) + 
                                     " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + 
                                     " erg_nachkomma = " +  std::to_string(ergebnis_nachkomma));
@@ -255,7 +255,7 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogNeu(float zahl, int ziffer_vorgaenger)
     if (ziffer_vorgaenger == -1)
     {
         result = (int) floor(zahl);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
         return result;
     }
@@ -268,14 +268,14 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogNeu(float zahl, int ziffer_vorgaenger)
         if (ziffer_vorgaenger <= AnalogFehler)
         {
             result = ((int) floor(zahl_max) + 10) % 10;
-            LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach oben - Ergebnis = " + std::to_string(result) +
+            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach oben - Ergebnis = " + std::to_string(result) +
                                                         " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
             return result;
         }
         if (ziffer_vorgaenger >= 10 - AnalogFehler)
         {
             result = ((int) floor(zahl_min) + 10) % 10;
-            LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach unten - Ergebnis = " + std::to_string(result) +
+            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach unten - Ergebnis = " + std::to_string(result) +
                                                         " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
             return result;
         }
@@ -283,7 +283,7 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogNeu(float zahl, int ziffer_vorgaenger)
     
 
     result = ((int) floor(zahl) + 10) % 10;
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - Zahl eindeutig, keine Korrektur notwendig - Ergebnis = " + std::to_string(result) +
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - Zahl eindeutig, keine Korrektur notwendig - Ergebnis = " + std::to_string(result) +
                                                 " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
 
     return result;
@@ -471,7 +471,7 @@ bool ClassFlowCNNGeneral::doFlow(string time)
         return false;
     };
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::doFlow nach Alignment");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "doFlow nach Alignment");
 
     doNeuralNetwork(time);
 
@@ -548,7 +548,7 @@ bool ClassFlowCNNGeneral::getNetworkParameter()
     zwcnn = FormatFileName(zwcnn);
     ESP_LOGD(TAG, "%s", zwcnn.c_str());
     if (!tflite->LoadModel(zwcnn)) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
         delete tflite;
         return false;
     } 
@@ -595,7 +595,7 @@ bool ClassFlowCNNGeneral::getNetworkParameter()
                 }
                 break;
             default:
-                LogFile.WriteToFile(ESP_LOG_ERROR, "tflite passt nicht zur Firmware (outout_dimension=" + std::to_string(_anzoutputdimensions) + ")");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "tflite passt nicht zur Firmware (outout_dimension=" + std::to_string(_anzoutputdimensions) + ")");
         }
     }
 
@@ -615,7 +615,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
     zwcnn = FormatFileName(zwcnn);
     ESP_LOGD(TAG, "%s", zwcnn.c_str());
     if (!tflite->LoadModel(zwcnn)) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
 
         delete tflite;
         return false;
@@ -636,7 +636,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
 
                         f1 = tflite->GetOutputValue(0);
                         f2 = tflite->GetOutputValue(1);
@@ -679,14 +679,14 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
 
                         _num = tflite->GetOutClassification(0, 10);
                         _nachkomma = tflite->GetOutClassification(11, 21);
 
 
                         string _zwres = "Nach Invoke - Nummer: " + to_string(_num) + " Nachkomma: " + to_string(_nachkomma);
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, _zwres);
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, _zwres);
 
                         if ((_num == 10) || (_nachkomma == 10))                      // NaN detektiert
                             GENERAL[_ana]->ROI[i]->result_float = -1;
@@ -695,7 +695,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         ESP_LOGD(TAG, "Result General(DigitalHyprid)%i: %f\n", i, GENERAL[_ana]->ROI[i]->result_float);
                         _zwres = "Result General(DigitalHyprid)" + to_string(i) + ": " + to_string(GENERAL[_ana]->ROI[i]->result_float);
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, _zwres);
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, _zwres);
 
                         if (isLogImage)
                         {
@@ -719,20 +719,20 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
 
                         _num = tflite->GetOutClassification(0, 9);
                         _nachkomma = tflite->GetOutClassification(10, 19);
 
 
                         string _zwres = "Nach Invoke - Nummer: " + to_string(_num) + " Nachkomma: " + to_string(_nachkomma);
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, _zwres);
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, _zwres);
 
                         GENERAL[_ana]->ROI[i]->result_float = fmod((double) _num + (((double)_nachkomma)-5)/10 + (double) 10, 10);
 
                         ESP_LOGD(TAG, "Result General(DigitalHyprid)%i: %f\n", i, GENERAL[_ana]->ROI[i]->result_float);
                         _zwres = "Result General(DigitalHyprid)" + to_string(i) + ": " + to_string(GENERAL[_ana]->ROI[i]->result_float);
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, _zwres);
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, _zwres);
 
                         if (isLogImage)
                         {
@@ -759,7 +759,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
 
                         _num = tflite->GetOutClassification(0, 9);
                         _numplus = (_num + 1) % 10;
@@ -791,7 +791,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                         zw = zw + " _val (p, m): " + to_string(_val) + " " + to_string(_valplus) + " " + to_string(_valminus);
                         zw = zw + " result: " + to_string(result) + " _fit: " + to_string(_fit);
                         ESP_LOGD(TAG, "details cnn: %s", zw.c_str());
-                        LogFile.WriteToFile(ESP_LOG_INFO, zw);
+                        LogFile.WriteToFile(ESP_LOG_INFO, TAG, zw);
 
 
                         _result_save_file = result;
@@ -802,7 +802,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                             result = -1;
                             _result_save_file+= 100;     // Für den Fall, dass fit nicht ausreichend, soll trotzdem das Ergebnis mit "-10x.y" abgespeichert werden.
                             string zw = "Value Rejected due to Threshold (Fit: " + to_string(_fit) + "Threshold: " + to_string(CNNGoodThreshold) + ")";
-                            LogFile.WriteToFile(ESP_LOG_WARN, zw);
+                            LogFile.WriteToFile(ESP_LOG_WARN, TAG, zw);
                         }
                         else
                         {
@@ -979,20 +979,20 @@ string ClassFlowCNNGeneral::getReadoutRawString(int _analog)
     {
         if (CNNType == Analogue || CNNType == Analogue100)
         {
-            rt = rt + "," + RundeOutput(GENERAL[_analog]->ROI[i]->result_float, 1);
+            rt = rt + "\t" + RundeOutput(GENERAL[_analog]->ROI[i]->result_float, 1);
         }
 
         if (CNNType == Digital)
         {
             if (GENERAL[_analog]->ROI[i]->result_klasse == 10)
-                rt = rt + ",N";
+                rt = rt + "\tN";
             else
-                rt = rt + "," + RundeOutput(GENERAL[_analog]->ROI[i]->result_klasse, 0);
+                rt = rt + "\t" + RundeOutput(GENERAL[_analog]->ROI[i]->result_klasse, 0);
         }
 
         if ((CNNType == DoubleHyprid10) || (CNNType == Digital100))
         {
-            rt = rt + "," + RundeOutput(GENERAL[_analog]->ROI[i]->result_float, 1);
+            rt = rt + "\t" + RundeOutput(GENERAL[_analog]->ROI[i]->result_float, 1);
         }
     }
     return rt;

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -35,7 +35,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
 
     if (GENERAL[_analog]->ROI.size() == 0)
         return result;
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout _analog=" + std::to_string(_analog) + ", _extendedResolution=" + std::to_string(_extendedResolution) + ", prev=" + std::to_string(prev));
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout _analog=" + std::to_string(_analog) + ", _extendedResolution=" + std::to_string(_extendedResolution) + ", prev=" + std::to_string(prev));
  
     if (CNNType == Analogue || CNNType == Analogue100)
     {
@@ -43,7 +43,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
         int ergebnis_nachkomma = ((int) floor(zahl * 10) + 10) % 10;
         
         prev = ZeigerEvalAnalogNeu(GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float, prev);
-//        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(analog) zahl=" + std::to_string(zahl) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
+//        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(analog) zahl=" + std::to_string(zahl) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
         result = std::to_string(prev);
 
         if (_extendedResolution && (CNNType != Digital))
@@ -82,7 +82,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
 
                 result = std::to_string(ergebnis_vorkomma) + std::to_string(ergebnis_nachkomma);
                 prev = ergebnis_vorkomma;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100-ext) ergebnis_vorkomma=" + std::to_string(ergebnis_vorkomma) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(dig100-ext) ergebnis_vorkomma=" + std::to_string(ergebnis_vorkomma) + ", ergebnis_nachkomma=" + std::to_string(ergebnis_nachkomma) + ", prev=" + std::to_string(prev));
             }
             else
             {
@@ -92,7 +92,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
                 else
                     prev = ZeigerEvalHybridNeu(GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float, prev, prev);
                 result = std::to_string(prev);
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100)  prev=" + std::to_string(prev));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(dig100)  prev=" + std::to_string(prev));
         
             }
         }
@@ -108,16 +108,16 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
             if (GENERAL[_analog]->ROI[i]->result_float >= 0)
             {
                 prev = ZeigerEvalHybridNeu(GENERAL[_analog]->ROI[i]->result_float, GENERAL[_analog]->ROI[i+1]->result_float, prev);
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout#ZeigerEvalHybridNeu()= " + std::to_string(prev));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout#ZeigerEvalHybridNeu()= " + std::to_string(prev));
                 result = std::to_string(prev) + result;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout#result= " + result);
+                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout#result= " + result);
                 
             }
             else
             {
                 prev = -1;
                 result = "N" + result;
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(result_float<0 /'N')  result_float=" + std::to_string(GENERAL[_analog]->ROI[i]->result_float));
+                LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::getReadout(result_float<0 /'N')  result_float=" + std::to_string(GENERAL[_analog]->ROI[i]->result_float));
         
             }
         }
@@ -141,7 +141,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         else
             result = (int) ((int) trunc(zahl) + 10) % 10;
 
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }
@@ -149,7 +149,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
     if (AnalogerVorgaenger)
     {
         result = ZeigerEvalAnalogToDigitNeu(zahl, zahl_vorgaenger, eval_vorgaenger, digitalAnalogTransitionStart);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - Analoger Vorgänger, Bewertung über ZeigerEvalAnalogNeu = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - Analoger Vorgänger, Bewertung über ZeigerEvalAnalogNeu = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }
@@ -162,7 +162,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         else
             result = ((int) trunc(zahl) + 10) % 10;
 
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, kein Ziffernwechsel, da Vorkomma weit genug weg = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, kein Ziffernwechsel, da Vorkomma weit genug weg = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }  
@@ -177,7 +177,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         else
             // Akt. digit und Vorgänger haben Nulldurchgang
             result =  ergebnis_vorkomma;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, Nulldurchgang hat stattgefunden = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, Nulldurchgang hat stattgefunden = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe));
         return result;
     }
@@ -196,7 +196,7 @@ int ClassFlowCNNGeneral::ZeigerEvalHybridNeu(float zahl, float zahl_vorgaenger, 
         // keinen Nulldurchgang hat. Daher wird um 1 reduziert.
         result =  (ergebnis_vorkomma - 1 + 10) % 10;
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, >= 9.5 --> noch kein Nulldurchgang = " + std::to_string(result) +
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalHybridNeu - KEIN Analoger Vorgänger, >= 9.5 --> noch kein Nulldurchgang = " + std::to_string(result) +
                                                 " zahl: " + std::to_string(zahl) + " zahl_vorgaenger = " + std::to_string(zahl_vorgaenger)+ " eval_vorgaenger = " + std::to_string(eval_vorgaenger) + " DigitalUnschaerfe = " +  std::to_string(DigitalUnschaerfe) + " ergebnis_nachkomma = " + std::to_string(ergebnis_nachkomma));
     return result;
 }
@@ -216,13 +216,13 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu(float zahl, float ziffer_vor
         // vor/nachkomma neu berechnen, da wir anhand der Unschaefe die Zahl anpassen.
         ergebnis_nachkomma = ((int) floor(result * 10)) % 10;
         ergebnis_vorkomma = ((int) floor(result) + 10) % 10;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogToDigitNeu - digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu - digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger: " + std::to_string(ziffer_vorgaenger) +
                                                     " erg_vorkomma: " + std::to_string(ergebnis_vorkomma) + 
                                                     " erg_nachkomma: " + std::to_string(ergebnis_nachkomma));
     } else {
         result = (int) ((int) trunc(zahl) + 10) % 10;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogToDigitNeu - KEINE digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu - KEINE digitaleUnschaerfe - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger));
     }
 
@@ -236,7 +236,7 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu(float zahl, float ziffer_vor
 
     {
         result =  ((ergebnis_vorkomma+10) - 1) % 10;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogToDigitNeu - Nulldurchgang noch nicht stattgefunden = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogToDigitNeu - Nulldurchgang noch nicht stattgefunden = " + std::to_string(result) +
                                     " zahl: " + std::to_string(zahl) + 
                                     " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + 
                                     " erg_nachkomma = " +  std::to_string(ergebnis_nachkomma));
@@ -255,7 +255,7 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogNeu(float zahl, int ziffer_vorgaenger)
     if (ziffer_vorgaenger == -1)
     {
         result = (int) floor(zahl);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
+        LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - kein Vorgänger - Ergebnis = " + std::to_string(result) +
                                                     " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
         return result;
     }
@@ -268,14 +268,14 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogNeu(float zahl, int ziffer_vorgaenger)
         if (ziffer_vorgaenger <= AnalogFehler)
         {
             result = ((int) floor(zahl_max) + 10) % 10;
-            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach oben - Ergebnis = " + std::to_string(result) +
+            LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach oben - Ergebnis = " + std::to_string(result) +
                                                         " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
             return result;
         }
         if (ziffer_vorgaenger >= 10 - AnalogFehler)
         {
             result = ((int) floor(zahl_min) + 10) % 10;
-            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach unten - Ergebnis = " + std::to_string(result) +
+            LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - Zahl uneindeutig, Korrektur nach unten - Ergebnis = " + std::to_string(result) +
                                                         " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
             return result;
         }
@@ -283,7 +283,7 @@ int ClassFlowCNNGeneral::ZeigerEvalAnalogNeu(float zahl, int ziffer_vorgaenger)
     
 
     result = ((int) floor(zahl) + 10) % 10;
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "ZeigerEvalAnalogNeu - Zahl eindeutig, keine Korrektur notwendig - Ergebnis = " + std::to_string(result) +
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::ZeigerEvalAnalogNeu - Zahl eindeutig, keine Korrektur notwendig - Ergebnis = " + std::to_string(result) +
                                                 " zahl: " + std::to_string(zahl) + " ziffer_vorgaenger = " + std::to_string(ziffer_vorgaenger) + " AnalogFehler = " +  std::to_string(AnalogFehler));
 
     return result;
@@ -471,7 +471,7 @@ bool ClassFlowCNNGeneral::doFlow(string time)
         return false;
     };
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "doFlow nach Alignment");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, "ClassFlowCNNGeneral::doFlow nach Alignment");
 
     doNeuralNetwork(time);
 
@@ -548,7 +548,7 @@ bool ClassFlowCNNGeneral::getNetworkParameter()
     zwcnn = FormatFileName(zwcnn);
     ESP_LOGD(TAG, "%s", zwcnn.c_str());
     if (!tflite->LoadModel(zwcnn)) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
+        LogFile.WriteToFile(ESP_LOG_ERROR, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
         delete tflite;
         return false;
     } 
@@ -595,7 +595,7 @@ bool ClassFlowCNNGeneral::getNetworkParameter()
                 }
                 break;
             default:
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "tflite passt nicht zur Firmware (outout_dimension=" + std::to_string(_anzoutputdimensions) + ")");
+                LogFile.WriteToFile(ESP_LOG_ERROR, "tflite passt nicht zur Firmware (outout_dimension=" + std::to_string(_anzoutputdimensions) + ")");
         }
     }
 
@@ -615,7 +615,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
     zwcnn = FormatFileName(zwcnn);
     ESP_LOGD(TAG, "%s", zwcnn.c_str());
     if (!tflite->LoadModel(zwcnn)) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
+        LogFile.WriteToFile(ESP_LOG_ERROR, "Can't read model file /sdcard%s", cnnmodelfile.c_str());
 
         delete tflite;
         return false;
@@ -636,7 +636,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
 
                         f1 = tflite->GetOutputValue(0);
                         f2 = tflite->GetOutputValue(1);
@@ -679,14 +679,14 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
 
                         _num = tflite->GetOutClassification(0, 10);
                         _nachkomma = tflite->GetOutClassification(11, 21);
 
 
                         string _zwres = "Nach Invoke - Nummer: " + to_string(_num) + " Nachkomma: " + to_string(_nachkomma);
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, _zwres);
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, _zwres);
 
                         if ((_num == 10) || (_nachkomma == 10))                      // NaN detektiert
                             GENERAL[_ana]->ROI[i]->result_float = -1;
@@ -695,7 +695,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         ESP_LOGD(TAG, "Result General(DigitalHyprid)%i: %f\n", i, GENERAL[_ana]->ROI[i]->result_float);
                         _zwres = "Result General(DigitalHyprid)" + to_string(i) + ": " + to_string(GENERAL[_ana]->ROI[i]->result_float);
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, _zwres);
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, _zwres);
 
                         if (isLogImage)
                         {
@@ -719,20 +719,20 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
 
                         _num = tflite->GetOutClassification(0, 9);
                         _nachkomma = tflite->GetOutClassification(10, 19);
 
 
                         string _zwres = "Nach Invoke - Nummer: " + to_string(_num) + " Nachkomma: " + to_string(_nachkomma);
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, _zwres);
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, _zwres);
 
                         GENERAL[_ana]->ROI[i]->result_float = fmod((double) _num + (((double)_nachkomma)-5)/10 + (double) 10, 10);
 
                         ESP_LOGD(TAG, "Result General(DigitalHyprid)%i: %f\n", i, GENERAL[_ana]->ROI[i]->result_float);
                         _zwres = "Result General(DigitalHyprid)" + to_string(i) + ": " + to_string(GENERAL[_ana]->ROI[i]->result_float);
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, _zwres);
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, _zwres);
 
                         if (isLogImage)
                         {
@@ -759,7 +759,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
 
                         tflite->LoadInputImageBasis(GENERAL[_ana]->ROI[i]->image);        
                         tflite->Invoke();
-                        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach Invoke");
+                        LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach Invoke");
 
                         _num = tflite->GetOutClassification(0, 9);
                         _numplus = (_num + 1) % 10;
@@ -791,7 +791,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                         zw = zw + " _val (p, m): " + to_string(_val) + " " + to_string(_valplus) + " " + to_string(_valminus);
                         zw = zw + " result: " + to_string(result) + " _fit: " + to_string(_fit);
                         ESP_LOGD(TAG, "details cnn: %s", zw.c_str());
-                        LogFile.WriteToFile(ESP_LOG_INFO, TAG, zw);
+                        LogFile.WriteToFile(ESP_LOG_INFO, zw);
 
 
                         _result_save_file = result;
@@ -802,7 +802,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                             result = -1;
                             _result_save_file+= 100;     // Für den Fall, dass fit nicht ausreichend, soll trotzdem das Ergebnis mit "-10x.y" abgespeichert werden.
                             string zw = "Value Rejected due to Threshold (Fit: " + to_string(_fit) + "Threshold: " + to_string(CNNGoodThreshold) + ")";
-                            LogFile.WriteToFile(ESP_LOG_WARN, TAG, zw);
+                            LogFile.WriteToFile(ESP_LOG_WARN, zw);
                         }
                         else
                         {
@@ -979,20 +979,20 @@ string ClassFlowCNNGeneral::getReadoutRawString(int _analog)
     {
         if (CNNType == Analogue || CNNType == Analogue100)
         {
-            rt = rt + "\t" + RundeOutput(GENERAL[_analog]->ROI[i]->result_float, 1);
+            rt = rt + "," + RundeOutput(GENERAL[_analog]->ROI[i]->result_float, 1);
         }
 
         if (CNNType == Digital)
         {
             if (GENERAL[_analog]->ROI[i]->result_klasse == 10)
-                rt = rt + "\tN";
+                rt = rt + ",N";
             else
-                rt = rt + "\t" + RundeOutput(GENERAL[_analog]->ROI[i]->result_klasse, 0);
+                rt = rt + "," + RundeOutput(GENERAL[_analog]->ROI[i]->result_klasse, 0);
         }
 
         if ((CNNType == DoubleHyprid10) || (CNNType == Digital100))
         {
-            rt = rt + "\t" + RundeOutput(GENERAL[_analog]->ROI[i]->result_float, 1);
+            rt = rt + "," + RundeOutput(GENERAL[_analog]->ROI[i]->result_float, 1);
         }
     }
     return rt;

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -791,7 +791,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                         zw = zw + " _val (p, m): " + to_string(_val) + " " + to_string(_valplus) + " " + to_string(_valminus);
                         zw = zw + " result: " + to_string(result) + " _fit: " + to_string(_fit);
                         ESP_LOGD(TAG, "details cnn: %s", zw.c_str());
-                        LogFile.WriteToFile(ESP_LOG_INFO, zw);
+                        LogFile.WriteToFile(ESP_LOG_INFO, TAG, zw);
 
 
                         _result_save_file = result;
@@ -802,7 +802,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                             result = -1;
                             _result_save_file+= 100;     // Für den Fall, dass fit nicht ausreichend, soll trotzdem das Ergebnis mit "-10x.y" abgespeichert werden.
                             string zw = "Value Rejected due to Threshold (Fit: " + to_string(_fit) + "Threshold: " + to_string(CNNGoodThreshold) + ")";
-                            LogFile.WriteToFile(ESP_LOG_WARN, zw);
+                            LogFile.WriteToFile(ESP_LOG_WARN, TAG, zw);
                         }
                         else
                         {

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -27,7 +27,7 @@ extern "C" {
 
 //#define DEBUG_DETAIL_ON  
 
-static const char* TAG = "flow_controll";
+static const char* TAG = "FLOW CTRL";
 
 
 
@@ -300,11 +300,11 @@ bool ClassFlowControll::doFlow(string time)
 
         if (!FlowControll[i]->doFlow(time)){
             repeat++;
-            LogFile.WriteToFile(ESP_LOG_WARN, "Fehler im vorheriger Schritt - wird zum " + to_string(repeat) + ". Mal wiederholt");
+            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Fehler im vorheriger Schritt - wird zum " + to_string(repeat) + ". Mal wiederholt");
             if (i) i -= 1;    // vorheriger Schritt muss wiederholt werden (vermutlich Bilder aufnehmen)
             result = false;
             if (repeat > 5) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, "Wiederholung 5x nicht erfolgreich --> reboot");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Wiederholung 5x nicht erfolgreich --> reboot");
                 doReboot();
                 // Schritt wurde 5x wiederholt --> reboot
             }
@@ -500,7 +500,7 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, string& aktparamgraph)
             {
                 // reboot notwendig damit die neue wlan.ini auch benutzt wird !!!
                 fclose(pfile);
-                LogFile.WriteToFile(ESP_LOG_ERROR, "Rebooting to activate new HOSTNAME...");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Rebooting to activate new HOSTNAME...");
                 esp_restart();
                 hard_restart();                   
                 doReboot();

--- a/code/components/jomjol_flowcontroll/ClassFlowImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowImage.cpp
@@ -16,6 +16,7 @@ extern "C" {
 #include "CImageBasis.h"
 #include "esp_log.h"
 
+static const char* TAG = "FLOW IMG";
 
 ClassFlowImage::ClassFlowImage(const char* logTag)
 {
@@ -47,7 +48,7 @@ string ClassFlowImage::CreateLogFolder(string time) {
 	string logPath = LogImageLocation + "/" + time.LOGFILE_TIME_FORMAT_DATE_EXTR + "/" + time.LOGFILE_TIME_FORMAT_HOUR_EXTR;
     isLogImage = mkdir_r(logPath.c_str(), S_IRWXU) == 0;
     if (!isLogImage) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Can't create log folder for analog images. Path " + logPath);
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Can't create log folder for analog images. Path " + logPath);
     }
 
 	return logPath;
@@ -128,7 +129,7 @@ void ClassFlowImage::RemoveOldLogs()
             }
 		}
     }
-    LogFile.WriteToFile(ESP_LOG_INFO, "Image folder deleted: " + std::to_string(deleted) + ". Image folder not deleted: " + std::to_string(notDeleted));	
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Image folder deleted: " + std::to_string(deleted) + ". Image folder not deleted: " + std::to_string(notDeleted));	
     closedir(dir);
 }
 

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -195,7 +195,7 @@ bool ClassFlowMQTT::Start(float AutoIntervall) {
     std::stringstream stream;
     stream << std::fixed << std::setprecision(1) << "Digitizer interval is " << roundInterval <<
             " minutes => setting MQTT LWT timeout to " << ((float)keepAlive/60) << " minutes.";
-    LogFile.WriteToFile(ESP_LOG_INFO, stream.str());
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, stream.str());
 
     mqttServer_setParameter(flowpostprocessing->GetNumbers(), keepAlive, roundInterval);
 
@@ -245,7 +245,7 @@ bool ClassFlowMQTT::doFlow(string zwtime)
             else
                 namenumber = maintopic + "/" + namenumber + "/";
 
-            LogFile.WriteToFile(ESP_LOG_INFO, "Publishing MQTT topics...");
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Publishing MQTT topics...");
 
             if (result.length() > 0)   
                 MQTTPublish(namenumber + "value", result, SetRetainFlag);

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -17,6 +17,7 @@
 
 #define __HIDE_PASSWORD
 
+static const char *TAG = "FLOW MQTT";
 #define LWT_TOPIC        "connection"
 #define LWT_CONNECTED    "connected"
 #define LWT_DISCONNECTED "connection lost"

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -12,7 +12,7 @@
 
 #include "esp_log.h"
 
-static const char* TAG = "class_flow_postproc";
+static const char* TAG = "FLOW POSTPROC";
 
 //#define SERIAL_DEBUG // testing debug on serial enabled
 
@@ -856,7 +856,7 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
 
         string _zw = "PostProcessing - Raw: " + NUMBERS[j]->ReturnRawValue + " Value: " + NUMBERS[j]->ReturnValue + " Error: " + NUMBERS[j]->ErrorMessageText;
         ESP_LOGD(TAG, "%s", zw.c_str());
-        LogFile.WriteToFile(ESP_LOG_INFO, _zw);
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, _zw);
         WriteDataLog(j);
     }
 

--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -26,7 +26,7 @@ extern "C" {
 
 #include "esp_vfs_fat.h"
 
-static const char* TAG = "helper";
+static const char* TAG = "HELPER";
 
 //#define ISWINDOWS_TRUE
 #define PATH_MAX_STRING_SIZE 256

--- a/code/components/jomjol_image_proc/CFindTemplate.cpp
+++ b/code/components/jomjol_image_proc/CFindTemplate.cpp
@@ -4,7 +4,7 @@
 
 #include <esp_log.h>
 
-static const char* TAG = "c_find_template";
+static const char* TAG = "C FIND TEMPL";
 
 // #define DEBUG_DETAIL_ON  
 
@@ -67,7 +67,7 @@ bool CFindTemplate::FindTemplate(RefInfo *_ref)
     if (isSimilar)
     {
 #ifdef DEBUG_DETAIL_ON  
-        LogFile.WriteToFile(ESP_LOG_INFO, "Use FastAlignment sucessfull");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Use FastAlignment sucessfull");
 #endif
         _ref->found_x = _ref->fastalg_x;
         _ref->found_y = _ref->fastalg_y;

--- a/code/components/jomjol_image_proc/CImageBasis.cpp
+++ b/code/components/jomjol_image_proc/CImageBasis.cpp
@@ -18,7 +18,7 @@
 
 using namespace std;
 
-static const char *TAG = "CImageBasis";
+static const char *TAG = "C IMG BASIS";
 
 //#define DEBUG_DETAIL_ON   
 
@@ -362,7 +362,7 @@ void CImageBasis::LoadFromMemory(stbi_uc *_buffer, int len)
     ESP_LOGD(TAG, "Image loaded from memory: %d, %d, %d", width, height, channels);
     if ((width * height * channels) == 0)
     {
-        LogFile.WriteToFile(ESP_LOG_ERROR, "Image with size 0 loaded --> reboot to be done! "
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Image with size 0 loaded --> reboot to be done! "
                 "Check that your camera module is working and connected properly.");
 
         doReboot();

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -8,7 +8,7 @@
 
 #define MAX_HTTP_OUTPUT_BUFFER 2048
 
-static const char *TAG_INTERFACEINFLUXDB = "interface_influxdb";
+static const char *TAG = "INFLUXDB";
 
 std::string _influxDBURI;
 std::string _influxDBDatabase;
@@ -21,25 +21,25 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
     switch(evt->event_id)
     {
         case HTTP_EVENT_ERROR:
-            ESP_LOGE(TAG_INTERFACEINFLUXDB, "HTTP Client Error encountered");
+            ESP_LOGE(TAG, "HTTP Client Error encountered");
             break;
         case HTTP_EVENT_ON_CONNECTED:
-            ESP_LOGI(TAG_INTERFACEINFLUXDB, "HTTP Client Connected");
+            ESP_LOGI(TAG, "HTTP Client Connected");
             break;
         case HTTP_EVENT_HEADERS_SENT:
-            ESP_LOGV(TAG_INTERFACEINFLUXDB, "HTTP Client sent all request headers");
+            ESP_LOGV(TAG, "HTTP Client sent all request headers");
             break;
         case HTTP_EVENT_ON_HEADER:
-            ESP_LOGV(TAG_INTERFACEINFLUXDB, "Header: key=%s, value=%s", evt->header_key, evt->header_value);
+            ESP_LOGV(TAG, "Header: key=%s, value=%s", evt->header_key, evt->header_value);
             break;
         case HTTP_EVENT_ON_DATA:
-            ESP_LOGV(TAG_INTERFACEINFLUXDB, "HTTP Client data recevied: len=%d", evt->data_len);
+            ESP_LOGV(TAG, "HTTP Client data recevied: len=%d", evt->data_len);
             break;
         case HTTP_EVENT_ON_FINISH:
-            ESP_LOGI(TAG_INTERFACEINFLUXDB, "HTTP Client finished");
+            ESP_LOGI(TAG, "HTTP Client finished");
             break;
          case HTTP_EVENT_DISCONNECTED:
-            ESP_LOGI(TAG_INTERFACEINFLUXDB, "HTTP Client Disconnected");
+            ESP_LOGI(TAG, "HTTP Client Disconnected");
             break;
     }
     return ESP_OK;
@@ -69,31 +69,31 @@ void InfluxDBPublish(std::string _key, std::string _content, std::string _timest
     
     std::string payload = _influxDBMeasurement + " " + _key + "=" + _content + " " + nowTimestamp;
     payload.shrink_to_fit();
-    ESP_LOGI(TAG_INTERFACEINFLUXDB, "sending line to influxdb: %s\n", payload.c_str());
+    ESP_LOGI(TAG, "sending line to influxdb: %s\n", payload.c_str());
 
     // use the default retention policy of the database
     std::string apiURI = _influxDBURI + "/api/v2/write?bucket=" + _influxDBDatabase + "/";
     apiURI.shrink_to_fit();
     http_config.url = apiURI.c_str();
-    ESP_LOGI(TAG_INTERFACEINFLUXDB, "API URI: %s", apiURI.c_str());
+    ESP_LOGI(TAG, "API URI: %s", apiURI.c_str());
 
     esp_http_client_handle_t http_client = esp_http_client_init(&http_config);
-    ESP_LOGI(TAG_INTERFACEINFLUXDB, "client is initialized%s\n", "");
+    ESP_LOGI(TAG, "client is initialized%s\n", "");
 
     esp_http_client_set_header(http_client, "Content-Type", "text/plain");
-    ESP_LOGI(TAG_INTERFACEINFLUXDB, "header is set%s\n", "");
+    ESP_LOGI(TAG, "header is set%s\n", "");
 
     ESP_ERROR_CHECK(esp_http_client_set_post_field(http_client, payload.c_str(), payload.length()));
-    ESP_LOGI(TAG_INTERFACEINFLUXDB, "post payload is set%s\n", "");
+    ESP_LOGI(TAG, "post payload is set%s\n", "");
 
     esp_err_t err = ESP_ERROR_CHECK_WITHOUT_ABORT(esp_http_client_perform(http_client));
 
     if( err == ESP_OK ) {
-      ESP_LOGI(TAG_INTERFACEINFLUXDB, "HTTP request was performed%s\n", "");
+      ESP_LOGI(TAG, "HTTP request was performed%s\n", "");
       int status_code = esp_http_client_get_status_code(http_client);
-      ESP_LOGI(TAG_INTERFACEINFLUXDB, "HTTP status code %d\n", status_code);
+      ESP_LOGI(TAG, "HTTP status code %d\n", status_code);
     } else {
-      ESP_LOGW(TAG_INTERFACEINFLUXDB, "HTTP request failed%s\n", "");
+      ESP_LOGW(TAG, "HTTP request failed%s\n", "");
     }
     esp_http_client_cleanup(http_client);
 }

--- a/code/components/jomjol_logfile/ClassLogFile.cpp
+++ b/code/components/jomjol_logfile/ClassLogFile.cpp
@@ -26,7 +26,7 @@ void ClassLogFile::WriteHeapInfo(std::string _id)
     if (loglevel > ESP_LOG_WARN) 
         _zw =  _zw + "\t" + getESPHeapInfo();
 
-    WriteToFile(ESP_LOG_DEBUG, "HEAP", _zw);
+    WriteToFile(ESP_LOG_DEBUG, TAG, "HEAP", _zw);
 }
 
 

--- a/code/components/jomjol_logfile/ClassLogFile.cpp
+++ b/code/components/jomjol_logfile/ClassLogFile.cpp
@@ -26,7 +26,7 @@ void ClassLogFile::WriteHeapInfo(std::string _id)
     if (loglevel > ESP_LOG_WARN) 
         _zw =  _zw + "\t" + getESPHeapInfo();
 
-    WriteToFile(ESP_LOG_DEBUG, TAG, "HEAP", _zw);
+    WriteToFile(ESP_LOG_DEBUG, "HEAP", _zw);
 }
 
 

--- a/code/components/jomjol_logfile/ClassLogFile.h
+++ b/code/components/jomjol_logfile/ClassLogFile.h
@@ -22,12 +22,15 @@ public:
     void setLogLevel(esp_log_level_t _logLevel);
     void SetRetention(unsigned short _retentionInDays);
 
-    void WriteToFile(esp_log_level_t level, std::string info, bool _time = true);
-    void WriteToDedicatedFile(std::string _fn, esp_log_level_t level, std::string info, bool _time = true);
+    void WriteToFile(esp_log_level_t level, std::string tag, std::string message, bool _time);
+    void WriteToFile(esp_log_level_t level, std::string tag, std::string message);
+
+    void WriteToDedicatedFile(std::string _fn, esp_log_level_t level, std::string message, bool _time = true);
 
     void CreateLogDirectories();
     void RemoveOld();
 
+//    void WriteToData(std::string _ReturnRawValue, std::string _ReturnValue, std::string _ReturnPreValue, std::string _ErrorMessageText, std::string _digital, std::string _analog);
     void WriteToData(std::string _timestamp, std::string _name, std::string  _ReturnRawValue, std::string  _ReturnValue, std::string  _ReturnPreValue, std::string  _ReturnRateValue, std::string  _ReturnChangeAbsolute, std::string  _ErrorMessageText, std::string  _digital, std::string  _analog);
 
 

--- a/code/components/jomjol_mqtt/interface_mqtt.cpp
+++ b/code/components/jomjol_mqtt/interface_mqtt.cpp
@@ -7,7 +7,7 @@
 
 #define __HIDE_PASSWORD
 
-static const char *TAG_INTERFACEMQTT = "interface_mqtt";
+static const char *TAG = "MQTT INTERFACE";
 
 std::map<std::string, std::function<void()>>* connectFunktionMap = NULL;  
 std::map<std::string, std::function<bool(std::string, char*, int)>>* subscribeFunktionMap = NULL;  
@@ -28,10 +28,10 @@ bool MQTTPublish(std::string _key, std::string _content, int retained_flag) {
     std::string zw;
 
     if (!mqtt_connected) {
-        LogFile.WriteToFile(ESP_LOG_WARN, "MQTT - Not connected, trying to re-connect...");
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Not connected, trying to re-connect...");
         if (!MQTT_Init()) {
             if (!MQTT_Init()) { // Retry
-                LogFile.WriteToFile(ESP_LOG_ERROR, "MQTT - Failed to init!");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to init!");
                 return false;
             }
         }
@@ -39,11 +39,11 @@ bool MQTTPublish(std::string _key, std::string _content, int retained_flag) {
 
     msg_id = esp_mqtt_client_publish(client, _key.c_str(), _content.c_str(), 0, 1, retained_flag);
     if (msg_id < 0) {
-        LogFile.WriteToFile(ESP_LOG_WARN, "MQTT - Failed to publish topic '" + _key + "', re-trying...");
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Failed to publish topic '" + _key + "', re-trying...");
 
         msg_id = esp_mqtt_client_publish(client, _key.c_str(), _content.c_str(), 0, 1, retained_flag);
         if (msg_id < 0) {
-            LogFile.WriteToFile(ESP_LOG_ERROR, "MQTT - Failed to publish topic '" + _key + "'!");
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to publish topic '" + _key + "'!");
             mqtt_connected = false; // Force re-init on next call
             return false;
         }
@@ -54,8 +54,8 @@ bool MQTTPublish(std::string _key, std::string _content, int retained_flag) {
         _content.append("..");
     }
 
-    zw = "MQTT - Published topic: " + _key + ", content: " + _content + " (msg_id=" + std::to_string(msg_id) + ")";
-    LogFile.WriteToFile(ESP_LOG_DEBUG, zw);
+    zw = "Published topic: " + _key + ", content: " + _content + " (msg_id=" + std::to_string(msg_id) + ")";
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, zw);
 
     return true;
 }
@@ -67,57 +67,57 @@ static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
     std::string topic = "";
     switch (event->event_id) {
         case MQTT_EVENT_BEFORE_CONNECT:
-            ESP_LOGD(TAG_INTERFACEMQTT, "MQTT_EVENT_BEFORE_CONNECT");
+            ESP_LOGD(TAG, "MQTT_EVENT_BEFORE_CONNECT");
             break;
         case MQTT_EVENT_CONNECTED:
-            ESP_LOGD(TAG_INTERFACEMQTT, "MQTT_EVENT_CONNECTED");
+            ESP_LOGD(TAG, "MQTT_EVENT_CONNECTED");
             mqtt_connected = true;
             MQTTconnected();
             break;
         case MQTT_EVENT_DISCONNECTED:
-            ESP_LOGD(TAG_INTERFACEMQTT, "MQTT_EVENT_DISCONNECTED");
-            LogFile.WriteToFile(ESP_LOG_WARN, "MQTT - Disconnected, going to re-connect...");
+            ESP_LOGD(TAG, "MQTT_EVENT_DISCONNECTED");
+            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Disconnected! Going to re-connect...");
             mqtt_connected = false; // Force re-init on next call
             esp_mqtt_client_reconnect(client);
             break;
         case MQTT_EVENT_SUBSCRIBED:
-            ESP_LOGD(TAG_INTERFACEMQTT, "MQTT_EVENT_SUBSCRIBED, msg_id=%d", event->msg_id);
+            ESP_LOGD(TAG, "MQTT_EVENT_SUBSCRIBED, msg_id=%d", event->msg_id);
             msg_id = esp_mqtt_client_publish(client, "/topic/qos0", "data", 0, 0, 0);
-            ESP_LOGD(TAG_INTERFACEMQTT, "sent publish successful, msg_id=%d", msg_id);
+            ESP_LOGD(TAG, "sent publish successful, msg_id=%d", msg_id);
             break;
         case MQTT_EVENT_UNSUBSCRIBED:
-            ESP_LOGD(TAG_INTERFACEMQTT, "MQTT_EVENT_UNSUBSCRIBED, msg_id=%d", event->msg_id);
+            ESP_LOGD(TAG, "MQTT_EVENT_UNSUBSCRIBED, msg_id=%d", event->msg_id);
             break;
         case MQTT_EVENT_PUBLISHED:
-            ESP_LOGD(TAG_INTERFACEMQTT, "MQTT_EVENT_PUBLISHED, msg_id=%d", event->msg_id);
+            ESP_LOGD(TAG, "MQTT_EVENT_PUBLISHED, msg_id=%d", event->msg_id);
             break;
         case MQTT_EVENT_DATA:
-            ESP_LOGD(TAG_INTERFACEMQTT, "MQTT_EVENT_DATA");
-            ESP_LOGD(TAG_INTERFACEMQTT, "TOPIC=%.*s", event->topic_len, event->topic);
-            ESP_LOGD(TAG_INTERFACEMQTT, "DATA=%.*s", event->data_len, event->data);
+            ESP_LOGD(TAG, "MQTT_EVENT_DATA");
+            ESP_LOGD(TAG, "TOPIC=%.*s\r\n", event->topic_len, event->topic);
+            ESP_LOGD(TAG, "DATA=%.*s\r\n", event->data_len, event->data);
             topic.assign(event->topic, event->topic_len);
             if (subscribeFunktionMap != NULL) {
                 if (subscribeFunktionMap->find(topic) != subscribeFunktionMap->end()) {
-                    ESP_LOGD(TAG_INTERFACEMQTT, "call handler function");
+                    ESP_LOGD(TAG, "call handler function\r\n");
                     (*subscribeFunktionMap)[topic](topic, event->data, event->data_len);
                 }
             } else {
-                ESP_LOGW(TAG_INTERFACEMQTT, "no handler available");
+                ESP_LOGW(TAG, "no handler available\r\n");
             }
             break;
         case MQTT_EVENT_ERROR:
-            ESP_LOGD(TAG_INTERFACEMQTT, "MQTT_EVENT_ERROR");
+            ESP_LOGD(TAG, "MQTT_EVENT_ERROR");
             mqtt_connected = false; // Force re-init on next call
             break;
         default:
-            ESP_LOGD(TAG_INTERFACEMQTT, "Other event id:%d", event->event_id);
+            ESP_LOGD(TAG, "Other event id:%d", event->event_id);
             break;
     }
     return ESP_OK;
 }
 
 static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data) {
-    ESP_LOGD(TAG_INTERFACEMQTT, "Event dispatched from event loop base=%s, event_id=%d", base, event_id);
+    ESP_LOGD(TAG, "Event dispatched from event loop base=%s, event_id=%d", base, event_id);
     mqtt_event_handler_cb((esp_mqtt_event_handle_t) event_data);
 }
 
@@ -126,11 +126,11 @@ void MQTT_Configure(std::string _mqttURI, std::string _clientid, std::string _us
         std::string _maintopic, std::string _lwt, std::string _lwt_connected, std::string _lwt_disconnected,
         int _keepalive, int _SetRetainFlag, void *_callbackOnConnected){
 #ifdef __HIDE_PASSWORD
-    LogFile.WriteToFile(ESP_LOG_INFO, "MQTT Configuration: uri: " + _mqttURI + ", clientname: " + _clientid + 
-            ", user: " + _user + ", password: XXXXXXXX, maintopic: " + _maintopic + ", last-will-topic: " + _maintopic + "/" + _lwt + ", keepAlive: " + std::to_string(_keepalive) + " s"); 
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "URI: " + _mqttURI + ", clientname: " + _clientid + 
+            ", user: " + _user + ", password: XXXXXXXX, maintopic: " + _maintopic + ", last-will-topic: " + _maintopic + "/" + _lwt + ", keepAlive: " + std::to_string(_keepalive)); 
 #else
-    LogFile.WriteToFile(ESP_LOG_INFO, "MQTT Configuration: uri: " + _mqttURI + ", clientname: " + _clientid + 
-            ", user: " + _user + ", password: " + _password + ", maintopic: " + _maintopic + ", last-will-topic: " + _maintopic + "/" + _lwt + ", keepAlive: " + std::to_string(_keepalive)+ " s"); 
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "URI: " + _mqttURI + ", clientname: " + _clientid + 
+            ", user: " + _user + ", password: " + _password + ", maintopic: " + _maintopic + ", last-will-topic: " + _maintopic + "/" + _lwt + ", keepAlive: " + std::to_string(_keepalive)); 
 #endif
 
     uri = _mqttURI;
@@ -151,7 +151,7 @@ void MQTT_Configure(std::string _mqttURI, std::string _clientid, std::string _us
 
 bool MQTT_Init() {
     esp_err_t ret;
-    LogFile.WriteToFile(ESP_LOG_INFO, "MQTT - Init");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, std::string("Init"));
 
     MQTTdestroy_client();
 
@@ -178,29 +178,29 @@ bool MQTT_Init() {
         ret = esp_mqtt_client_register_event(client, esp_mmqtt_ID, mqtt_event_handler, client);
         if (ret != ESP_OK)
         {
-            LogFile.WriteToFile(ESP_LOG_ERROR, "MQTT - Could not register event (ret=" + std::to_string(ret) + ")!");
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Could not register event (ret=" + std::to_string(ret) + ")!");
             return false;
         }
 
         ret = esp_mqtt_client_start(client);
         if (ret != ESP_OK)
         {
-            LogFile.WriteToFile(ESP_LOG_WARN, "MQTT - Could not start client (ret=" + std::to_string(ret) + "), retrying...");
+            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Could not start client (ret=" + std::to_string(ret) + "), retrying...");
             ret = esp_mqtt_client_start(client);
             if (ret != ESP_OK)
             {
-                LogFile.WriteToFile(ESP_LOG_ERROR, "MQTT - Could not start client (ret=" + std::to_string(ret) + ")!");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Could not start client (ret=" + std::to_string(ret) + ")!");
                 return false;
             }
         }
     }
     else
     {
-        LogFile.WriteToFile(ESP_LOG_ERROR, "MQTT - Could not init client!");
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Could not init client!");
         return false;
     }
 
-    LogFile.WriteToFile(ESP_LOG_INFO, "MQTT - Init successful");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init successful");
     return true;
 }
 
@@ -217,13 +217,13 @@ bool MQTTisConnected() {
 }
 
 void MQTTregisterConnectFunction(std::string name, std::function<void()> func){
-    ESP_LOGD(TAG_INTERFACEMQTT, "MQTTregisteronnectFunction %s", name.c_str());
+    ESP_LOGD(TAG, "MQTTregisteronnectFunction %s\r\n", name.c_str());
     if (connectFunktionMap == NULL) {
         connectFunktionMap = new std::map<std::string, std::function<void()>>();
     }
 
     if ((*connectFunktionMap)[name] != NULL) {
-        ESP_LOGW(TAG_INTERFACEMQTT, "connect function %s already registred", name.c_str());
+        ESP_LOGW(TAG, "connect function %s already registred", name.c_str());
         return;
     }
 
@@ -235,20 +235,20 @@ void MQTTregisterConnectFunction(std::string name, std::function<void()> func){
 }
 
 void MQTTunregisterConnectFunction(std::string name){
-    ESP_LOGD(TAG_INTERFACEMQTT, "MQTTregisteronnectFunction %s", name.c_str());
+    ESP_LOGD(TAG, "unregisterConnnectFunction %s\r\n", name.c_str());
     if ((connectFunktionMap != NULL) && (connectFunktionMap->find(name) != connectFunktionMap->end())) {
         connectFunktionMap->erase(name);
     }
 }
 
 void MQTTregisterSubscribeFunction(std::string topic, std::function<bool(std::string, char*, int)> func){
-    ESP_LOGD(TAG_INTERFACEMQTT, "MQTTregisterSubscribeFunction %s", topic.c_str());
+    ESP_LOGD(TAG, "registerSubscribeFunction %s\r\n", topic.c_str());
     if (subscribeFunktionMap == NULL) {
         subscribeFunktionMap = new std::map<std::string, std::function<bool(std::string, char*, int)>>();
     }
 
     if ((*subscribeFunktionMap)[topic] != NULL) {
-        ESP_LOGW(TAG_INTERFACEMQTT, "topic %s already registred for subscription", topic.c_str());
+        ESP_LOGW(TAG, "topic %s already registered for subscription", topic.c_str());
         return;
     }
 
@@ -256,27 +256,27 @@ void MQTTregisterSubscribeFunction(std::string topic, std::function<bool(std::st
 
     if (mqtt_connected) {
         int msg_id = esp_mqtt_client_subscribe(client, topic.c_str(), 0);
-        ESP_LOGD(TAG_INTERFACEMQTT, "topic %s subscribe successful, msg_id=%d", topic.c_str(), msg_id);
+        ESP_LOGD(TAG, "topic %s subscribe successful, msg_id=%d", topic.c_str(), msg_id);
     }
 }
 
 void MQTTconnected(){
     if (mqtt_connected) {
-        LogFile.WriteToFile(ESP_LOG_INFO, "MQTT - Connected");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Connected");
 
         MQTTPublish(lwt_topic, lwt_connected, true);
 
         if (connectFunktionMap != NULL) {
             for(std::map<std::string, std::function<void()>>::iterator it = connectFunktionMap->begin(); it != connectFunktionMap->end(); ++it) {
                 it->second();
-                ESP_LOGD(TAG_INTERFACEMQTT, "call connect function %s", it->first.c_str());
+                ESP_LOGD(TAG, "call connect function %s", it->first.c_str());
             }
         }
 
        if (subscribeFunktionMap != NULL) {
             for(std::map<std::string, std::function<bool(std::string, char*, int)>>::iterator it = subscribeFunktionMap->begin(); it != subscribeFunktionMap->end(); ++it) {
                 int msg_id = esp_mqtt_client_subscribe(client, it->first.c_str(), 0);
-                LogFile.WriteToFile(ESP_LOG_INFO, "MQTT - topic " + it->first + " subscribe successful, msg_id=" + std::to_string(msg_id));
+                LogFile.WriteToFile(ESP_LOG_INFO, TAG, "topic " + it->first + " subscribe successful, msg_id=" + std::to_string(msg_id));
             }
         }
 
@@ -291,7 +291,7 @@ void MQTTdestroySubscribeFunction(){
         if (mqtt_connected) {
             for(std::map<std::string, std::function<bool(std::string, char*, int)>>::iterator it = subscribeFunktionMap->begin(); it != subscribeFunktionMap->end(); ++it) {
                 int msg_id = esp_mqtt_client_unsubscribe(client, it->first.c_str());
-                ESP_LOGI(TAG_INTERFACEMQTT, "topic %s unsubscribe successful, msg_id=%d", it->first.c_str(), msg_id);
+                ESP_LOGI(TAG, "topic %s unsubscribe successful, msg_id=%d", it->first.c_str(), msg_id);
             }
         }
 

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -137,7 +137,7 @@ void sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
 }
 
 void MQTThomeassistantDiscovery() {    
-    LogFile.WriteToFile(ESP_LOG_INFO, "MQTT - Sending Homeassistant Discovery Topics (Meter Type: " + meterType + ", Value Unit: " + valueUnit + " , Rate Unit: " + rateUnit + ")...");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "MQTT - Sending Homeassistant Discovery Topics (Meter Type: " + meterType + ", Value Unit: " + valueUnit + " , Rate Unit: " + rateUnit + ")...");
 
     //                              Group | Field            | User Friendly Name | Icon                      | Unit | Device Class     | State Class  | Entity Category
     sendHomeAssistantDiscoveryTopic("",     "uptime",          "Uptime",            "clock-time-eight-outline", "s",   "",                "",            "diagnostic");
@@ -172,7 +172,7 @@ void MQTThomeassistantDiscovery() {
 void publishSystemData() {
     char tmp_char[50];
 
-    LogFile.WriteToFile(ESP_LOG_INFO, "Publishing system MQTT topics...");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Publishing system MQTT topics...");
 
     sprintf(tmp_char, "%ld", (long)getUpTime());
     MQTTPublish(maintopic + "/" + "uptime", std::string(tmp_char), retainFlag);
@@ -189,7 +189,7 @@ void publishSystemData() {
 
 
 void publishStaticData() {
-    LogFile.WriteToFile(ESP_LOG_INFO, "Publishing static MQTT topics...");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Publishing static MQTT topics...");
     MQTTPublish(maintopic + "/" + "MAC", getMac(), retainFlag);
     MQTTPublish(maintopic + "/" + "IP", *getIPAddress(), retainFlag);
     MQTTPublish(maintopic + "/" + "hostname", hostname, retainFlag);

--- a/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
+++ b/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
@@ -8,7 +8,7 @@
 // #define DEBUG_DETAIL_ON
 
 
-static const char *TAG = "ctflite_class";
+static const char *TAG = "C TFLITE";
 
 float CTfLiteClass::GetOutputValue(int nr)
 {
@@ -167,7 +167,7 @@ bool CTfLiteClass::LoadInputImageBasis(CImageBasis *rs)
             }
 
 #ifdef DEBUG_DETAIL_ON          
-    LogFile.WriteToFile(ESP_LOG_DEBUG, "Nach dem Laden in input");
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Nach dem Laden in input");
 #endif
 
     return true;
@@ -185,7 +185,7 @@ void CTfLiteClass::MakeAllocate()
     TfLiteStatus allocate_status = this->interpreter->AllocateTensors();
     if (allocate_status != kTfLiteOk) {
         TF_LITE_REPORT_ERROR(error_reporter, "AllocateTensors() failed");
-        LogFile.WriteToFile(ESP_LOG_ERROR, "AllocateTensors() failed");
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "AllocateTensors() failed");
 
     this->GetInputDimension();   
     return;

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -39,7 +39,7 @@ bool auto_isrunning = false;
 
 int countRounds = 0;
 
-static const char *TAGTFLITE = "server_tflite";
+static const char *TAG = "TFLITE";
 
 
 int getCountFlowRounds() {
@@ -67,7 +67,7 @@ bool isSetupModusActive() {
 void KillTFliteTasks()
 {
 #ifdef DEBUG_DETAIL_ON          
-    ESP_LOGD(TAGTFLITE, "Handle: xHandleblink_task_doFlow: %ld", (long) xHandleblink_task_doFlow);
+    ESP_LOGD(TAG, "Handle: xHandleblink_task_doFlow: %ld", (long) xHandleblink_task_doFlow);
 #endif  
     if (xHandleblink_task_doFlow != NULL)
     {
@@ -75,12 +75,12 @@ void KillTFliteTasks()
         xHandleblink_task_doFlow = NULL;
         vTaskDelete(xHandleblink_task_doFlowTmp);
 #ifdef DEBUG_DETAIL_ON      
-        ESP_LOGD(TAGTFLITE, "Killed: xHandleblink_task_doFlow");
+        ESP_LOGD(TAG, "Killed: xHandleblink_task_doFlow");
 #endif
     }
 
 #ifdef DEBUG_DETAIL_ON      
-    ESP_LOGD(TAGTFLITE, "Handle: xHandletask_autodoFlow: %ld", (long) xHandletask_autodoFlow);
+    ESP_LOGD(TAG, "Handle: xHandletask_autodoFlow: %ld", (long) xHandletask_autodoFlow);
 #endif
     if (xHandletask_autodoFlow != NULL)
     {
@@ -88,7 +88,7 @@ void KillTFliteTasks()
         xHandletask_autodoFlow = NULL;
         vTaskDelete(xHandletask_autodoFlowTmp);
 #ifdef DEBUG_DETAIL_ON      
-        ESP_LOGD(TAGTFLITE, "Killed: xHandletask_autodoFlow");
+        ESP_LOGD(TAG, "Killed: xHandletask_autodoFlow");
 #endif
     }
 
@@ -97,11 +97,11 @@ void KillTFliteTasks()
 void doInit(void)
 {
 #ifdef DEBUG_DETAIL_ON             
-    ESP_LOGD(TAGTFLITE, "Start tfliteflow.InitFlow(config);");
+    ESP_LOGD(TAG, "Start tfliteflow.InitFlow(config);");
 #endif
     tfliteflow.InitFlow(CONFIG_FILE);
 #ifdef DEBUG_DETAIL_ON      
-    ESP_LOGD(TAGTFLITE, "Finished tfliteflow.InitFlow(config);");
+    ESP_LOGD(TAG, "Finished tfliteflow.InitFlow(config);");
 #endif
 }
 
@@ -110,13 +110,13 @@ bool doflow(void)
 {
     
     std::string zw_time = gettimestring(LOGFILE_TIME_FORMAT);
-    ESP_LOGD(TAGTFLITE, "doflow - start %s", zw_time.c_str());
+    ESP_LOGD(TAG, "doflow - start %s", zw_time.c_str());
     flowisrunning = true;
     tfliteflow.doFlow(zw_time);
     flowisrunning = false;
 
 #ifdef DEBUG_DETAIL_ON      
-    ESP_LOGD(TAGTFLITE, "doflow - end %s", zw_time.c_str());
+    ESP_LOGD(TAG, "doflow - end %s", zw_time.c_str());
 #endif    
     return true;
 }
@@ -124,7 +124,7 @@ bool doflow(void)
 void blink_task_doFlow(void *pvParameter)
 {
 #ifdef DEBUG_DETAIL_ON          
-    ESP_LOGD(TAGTFLITE, "blink_task_doFlow");
+    ESP_LOGD(TAG, "blink_task_doFlow");
 #endif
     if (!flowisrunning)
     {
@@ -141,7 +141,7 @@ esp_err_t handler_init(httpd_req_t *req)
 {
 #ifdef DEBUG_DETAIL_ON      
     LogFile.WriteHeapInfo("handler_init - Start");       
-    ESP_LOGD(TAGTFLITE, "handler_doinit uri: %s", req->uri);
+    ESP_LOGD(TAG, "handler_doinit uri: %s", req->uri);
 #endif
 
     const char* resp_str = "Init started<br>";
@@ -167,7 +167,7 @@ esp_err_t handler_doflow(httpd_req_t *req)
     LogFile.WriteHeapInfo("handler_doflow - Start");       
 #endif
 
-    ESP_LOGD(TAGTFLITE, "handler_doFlow uri: %s", req->uri);
+    ESP_LOGD(TAG, "handler_doFlow uri: %s", req->uri);
 
     if (flowisrunning)
     {
@@ -199,7 +199,7 @@ esp_err_t handler_json(httpd_req_t *req)
 #endif
 
 
-    ESP_LOGD(TAGTFLITE, "handler_JSON uri: %s", req->uri);
+    ESP_LOGD(TAG, "handler_JSON uri: %s", req->uri);
 
     char _query[100];
 //    char _size[10];
@@ -236,18 +236,18 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
     std::string _type = "value";
     string zw;
 
-    ESP_LOGD(TAGTFLITE, "handler_wasserzaehler uri: %s", req->uri);
+    ESP_LOGD(TAG, "handler_wasserzaehler uri: %s", req->uri);
 
     char _query[100];
     char _size[10];
 
     if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
     {
-//        ESP_LOGD(TAGTFLITE, "Query: %s", _query);
+//        ESP_LOGD(TAG, "Query: %s", _query);
         if (httpd_query_key_value(_query, "all", _size, 10) == ESP_OK)
         {
 #ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAGTFLITE, "all is found%s", _size);
+            ESP_LOGD(TAG, "all is found%s", _size);
 #endif
             _all = true;
         }
@@ -255,7 +255,7 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
         if (httpd_query_key_value(_query, "type", _size, 10) == ESP_OK)
         {
 #ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAGTFLITE, "all is found: %s", _size);
+            ESP_LOGD(TAG, "all is found: %s", _size);
 #endif
             _type = std::string(_size);
         }
@@ -263,14 +263,14 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
         if (httpd_query_key_value(_query, "rawvalue", _size, 10) == ESP_OK)
         {
 #ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAGTFLITE, "rawvalue is found: %s", _size);
+            ESP_LOGD(TAG, "rawvalue is found: %s", _size);
 #endif
             _rawValue = true;
         }
         if (httpd_query_key_value(_query, "noerror", _size, 10) == ESP_OK)
         {
 #ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAGTFLITE, "noerror is found: %s", _size);
+            ESP_LOGD(TAG, "noerror is found: %s", _size);
 #endif
             _noerror = true;
         }        
@@ -281,7 +281,7 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
     if (_all)
     {
         httpd_resp_set_type(req, "text/plain");
-        ESP_LOGD(TAGTFLITE, "TYPE: %s", _type.c_str());
+        ESP_LOGD(TAG, "TYPE: %s", _type.c_str());
         int _intype = READOUT_TYPE_VALUE;
         if (_type == "prevalue")
             _intype = READOUT_TYPE_PREVALUE;
@@ -292,7 +292,7 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
 
 
         zw = tfliteflow.getReadoutAll(_intype);
-        ESP_LOGD(TAGTFLITE, "ZW: %s", zw.c_str());
+        ESP_LOGD(TAG, "ZW: %s", zw.c_str());
         if (zw.length() > 0)
             httpd_resp_sendstr_chunk(req, zw.c_str()); 
         httpd_resp_sendstr_chunk(req, NULL);   
@@ -304,7 +304,7 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
         httpd_resp_sendstr_chunk(req, zw.c_str()); 
 
     string query = std::string(_query);
-//    ESP_LOGD(TAGTFLITE, "Query: %s, query.c_str());
+//    ESP_LOGD(TAG, "Query: %s, query.c_str());
     if (query.find("full") != std::string::npos)
     {
         string txt, zw;
@@ -380,7 +380,7 @@ esp_err_t handler_editflow(httpd_req_t *req)
     LogFile.WriteHeapInfo("handler_editflow - Start");       
 #endif
 
-    ESP_LOGD(TAGTFLITE, "handler_editflow uri: %s", req->uri);
+    ESP_LOGD(TAG, "handler_editflow uri: %s", req->uri);
 
     char _query[200];
     char _valuechar[30];
@@ -391,7 +391,7 @@ esp_err_t handler_editflow(httpd_req_t *req)
         if (httpd_query_key_value(_query, "task", _valuechar, 30) == ESP_OK)
         {
 #ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAGTFLITE, "task is found: %s", _valuechar);
+            ESP_LOGD(TAG, "task is found: %s", _valuechar);
 #endif
             _task = string(_valuechar);
         }
@@ -399,19 +399,19 @@ esp_err_t handler_editflow(httpd_req_t *req)
 
     if (_task.compare("namenumbers") == 0)
     {
-        ESP_LOGI(TAGTFLITE, "Get NUMBER list");
+        ESP_LOGI(TAG, "Get NUMBER list");
         return get_numbers_file_handler(req);
     }
 
     if (_task.compare("data") == 0)
     {
-        ESP_LOGI(TAGTFLITE, "Get data list");
+        ESP_LOGI(TAG, "Get data list");
         return get_data_file_handler(req);
     }
 
     if (_task.compare("tflite") == 0)
     {
-        ESP_LOGD(TAGTFLITE, "Get tflite list");
+        ESP_LOGD(TAG, "Get tflite list");
         return get_tflite_file_handler(req);
     }
 
@@ -426,8 +426,8 @@ esp_err_t handler_editflow(httpd_req_t *req)
         out = string(_valuechar);  
 
 #ifdef DEBUG_DETAIL_ON       
-        ESP_LOGD(TAGTFLITE, "in: %s", in.c_str());
-        ESP_LOGD(TAGTFLITE, "out: %s", out.c_str());
+        ESP_LOGD(TAG, "in: %s", in.c_str());
+        ESP_LOGD(TAG, "out: %s", out.c_str());
 #endif
 
         in = "/sdcard" + in;
@@ -468,12 +468,12 @@ esp_err_t handler_editflow(httpd_req_t *req)
         dy = stoi(zw);          
 
 #ifdef DEBUG_DETAIL_ON       
-        ESP_LOGD(TAGTFLITE, "in: %s", in.c_str());
-        ESP_LOGD(TAGTFLITE, "out: %s", out.c_str());
-        ESP_LOGD(TAGTFLITE, "x: %s", zw.c_str());
-        ESP_LOGD(TAGTFLITE, "y: %s", zw.c_str());
-        ESP_LOGD(TAGTFLITE, "dx: %s", zw.c_str());
-        ESP_LOGD(TAGTFLITE, "dy: %s", zw.c_str());
+        ESP_LOGD(TAG, "in: %s", in.c_str());
+        ESP_LOGD(TAG, "out: %s", out.c_str());
+        ESP_LOGD(TAG, "x: %s", zw.c_str());
+        ESP_LOGD(TAG, "y: %s", zw.c_str());
+        ESP_LOGD(TAG, "dx: %s", zw.c_str());
+        ESP_LOGD(TAG, "dy: %s", zw.c_str());
 #endif
 
         if (httpd_query_key_value(_query, "enhance", _valuechar, 10) == ESP_OK)
@@ -541,11 +541,11 @@ esp_err_t handler_editflow(httpd_req_t *req)
         }
 
 
-//        ESP_LOGD(TAGTFLITE, "Parameter host: %s", _host.c_str());
-//        string zwzw = "Do " + _task + " start\n"; ESP_LOGD(TAGTFLITE, zwzw.c_str());
+//        ESP_LOGD(TAG, "Parameter host: %s", _host.c_str());
+//        string zwzw = "Do " + _task + " start\n"; ESP_LOGD(TAG, zwzw.c_str());
         Camera.SetBrightnessContrastSaturation(bri, con, sat);
         Camera.SetLEDIntensity(intens);
-        ESP_LOGD(TAGTFLITE, "test_take - vor MakeImage");
+        ESP_LOGD(TAG, "test_take - vor MakeImage");
         std::string zw = tfliteflow.doSingleStep("[MakeImage]", _host);
         httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
         httpd_resp_sendstr_chunk(req, zw.c_str()); 
@@ -558,9 +558,9 @@ esp_err_t handler_editflow(httpd_req_t *req)
         if (httpd_query_key_value(_query, "host", _valuechar, 30) == ESP_OK) {
             _host = std::string(_valuechar);
         }
-//        ESP_LOGD(TAGTFLITE, "Parameter host: %s", _host.c_str());
+//        ESP_LOGD(TAG, "Parameter host: %s", _host.c_str());
 
-//        string zwzw = "Do " + _task + " start\n"; ESP_LOGD(TAGTFLITE, zwzw.c_str());
+//        string zwzw = "Do " + _task + " start\n"; ESP_LOGD(TAG, zwzw.c_str());
         std::string zw = tfliteflow.doSingleStep("[Alignment]", _host);
         httpd_resp_sendstr_chunk(req, zw.c_str()); 
     }
@@ -585,7 +585,7 @@ esp_err_t handler_statusflow(httpd_req_t *req)
     const char* resp_str;
 
 #ifdef DEBUG_DETAIL_ON       
-    ESP_LOGD(TAGTFLITE, "handler_prevalue: %s", req->uri);
+    ESP_LOGD(TAG, "handler_prevalue: %s", req->uri);
 #endif
 
     string* zw = tfliteflow.getActStatus();
@@ -663,7 +663,7 @@ esp_err_t handler_prevalue(httpd_req_t *req)
     string zw;
 
 #ifdef DEBUG_DETAIL_ON       
-    ESP_LOGD(TAGTFLITE, "handler_prevalue: %s", req->uri);
+    ESP_LOGD(TAG, "handler_prevalue: %s", req->uri);
 #endif
 
     char _query[100];
@@ -673,13 +673,13 @@ esp_err_t handler_prevalue(httpd_req_t *req)
     if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
     {
 #ifdef DEBUG_DETAIL_ON       
-        ESP_LOGD(TAGTFLITE, "Query: %s", _query);
+        ESP_LOGD(TAG, "Query: %s", _query);
 #endif
 
         if (httpd_query_key_value(_query, "value", _size, 10) == ESP_OK)
         {
 #ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAGTFLITE, "Value: %s", _size);
+            ESP_LOGD(TAG, "Value: %s", _size);
 #endif
         }
 
@@ -715,7 +715,7 @@ void task_autodoFlow(void *pvParameter)
 {
     int64_t fr_start, fr_delta_ms;
 
-    ESP_LOGD(TAGTFLITE, "task_autodoFlow: start");
+    ESP_LOGD(TAG, "task_autodoFlow: start");
     doInit();
     gpio_handler_init();
 
@@ -729,46 +729,46 @@ void task_autodoFlow(void *pvParameter)
     while (auto_isrunning)
     {
         std::string _zw = "task_autodoFlow - next round - Round #" + std::to_string(++countRounds);
-        LogFile.WriteToFile(ESP_LOG_INFO, _zw); 
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, _zw); 
         fr_start = esp_timer_get_time();
 
         if (flowisrunning)
         {
 #ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAGTFLITE, "Autoflow: doFlow is already running!");
+            ESP_LOGD(TAG, "Autoflow: doFlow is already running!");
 #endif
         }
         else
         {
 #ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAGTFLITE, "Autoflow: doFlow is started");
+            ESP_LOGD(TAG, "Autoflow: doFlow is started");
 #endif
             flowisrunning = true;
             doflow();
 #ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAGTFLITE, "Remove older log files");
+            ESP_LOGD(TAG, "Remove older log files");
 #endif
             LogFile.RemoveOld();
         }
         
-        LogFile.WriteToFile(ESP_LOG_INFO, "task_autodoFlow - round done");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "task_autodoFlow - round #" + std::to_string(countRounds) + " done");
         //CPU Temp
         float cputmp = temperatureRead();
         std::stringstream stream;
         stream << std::fixed << std::setprecision(1) << cputmp;
         string zwtemp = "CPU Temperature: " + stream.str();
-        LogFile.WriteToFile(ESP_LOG_INFO, zwtemp); 
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, zwtemp); 
         fr_delta_ms = (esp_timer_get_time() - fr_start) / 1000;
         if (auto_intervall > fr_delta_ms)
         {
             const TickType_t xDelay = (auto_intervall - fr_delta_ms)  / portTICK_PERIOD_MS;
-            ESP_LOGD(TAGTFLITE, "Autoflow: sleep for: %ldms", (long) xDelay);
+            ESP_LOGD(TAG, "Autoflow: sleep for: %ldms", (long) xDelay);
             vTaskDelay( xDelay );        
         }
     }
     vTaskDelete(NULL); //Delete this task if it exits from the loop above
     xHandletask_autodoFlow = NULL;
-    ESP_LOGD(TAGTFLITE, "task_autodoFlow: end");
+    ESP_LOGD(TAG, "task_autodoFlow: end");
 }
 
 void TFliteDoAutoStart()
@@ -777,17 +777,17 @@ void TFliteDoAutoStart()
 
     int _i = configMINIMAL_STACK_SIZE;
 
-    ESP_LOGD(TAGTFLITE, "task_autodoFlow configMINIMAL_STACK_SIZE: %d", _i);
-    ESP_LOGD(TAGTFLITE, "getESPHeapInfo: %s", getESPHeapInfo().c_str());
+    ESP_LOGD(TAG, "task_autodoFlow configMINIMAL_STACK_SIZE: %d", _i);
+    ESP_LOGD(TAG, "getESPHeapInfo: %s", getESPHeapInfo().c_str());
 
     xReturned = xTaskCreate(&task_autodoFlow, "task_autodoFlow", configMINIMAL_STACK_SIZE * 35, NULL, tskIDLE_PRIORITY+1, &xHandletask_autodoFlow);
     if( xReturned != pdPASS )
     {
 
        //Memory: 64 --> 48 --> 35 --> 25
-       ESP_LOGD(TAGTFLITE, "ERROR task_autodoFlow konnte nicht erzeugt werden!");
+       ESP_LOGD(TAG, "ERROR task_autodoFlow konnte nicht erzeugt werden!");
     }
-    ESP_LOGD(TAGTFLITE, "getESPHeapInfo: %s", getESPHeapInfo().c_str());
+    ESP_LOGD(TAG, "getESPHeapInfo: %s", getESPHeapInfo().c_str());
 
 
 }
@@ -801,7 +801,7 @@ std::string GetMQTTMainTopic()
 
 void register_server_tflite_uri(httpd_handle_t server)
 {
-    ESP_LOGI(TAGTFLITE, "server_part_camera - Registering URI handlers");
+    ESP_LOGI(TAG, "server_part_camera - Registering URI handlers");
     
     httpd_uri_t camuri = { };
     camuri.method    = HTTP_GET;

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -728,6 +728,7 @@ void task_autodoFlow(void *pvParameter)
     }
     while (auto_isrunning)
     {
+        LogFile.WriteToFile(ESP_LOG_DEBUG, "----------------------------------------------------------------"); // Clear separation between runs
         std::string _zw = "task_autodoFlow - next round - Round #" + std::to_string(++countRounds);
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, _zw); 
         fr_start = esp_timer_get_time();

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -728,7 +728,7 @@ void task_autodoFlow(void *pvParameter)
     }
     while (auto_isrunning)
     {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, "----------------------------------------------------------------"); // Clear separation between runs
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "----------------------------------------------------------------"); // Clear separation between runs
         std::string _zw = "task_autodoFlow - next round - Round #" + std::to_string(++countRounds);
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, _zw); 
         fr_start = esp_timer_get_time();

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -15,7 +15,7 @@
 
 #include "ClassLogFile.h"
 
-static const char *TAG = "sntp";
+static const char *TAG = "SNTP";
 
 bool setTimeAlwaysOnReboot = true;
 time_t bootTime;
@@ -86,7 +86,7 @@ void setTimeZone(std::string _tzstring)
     setenv("TZ", _tzstring.c_str(), 1);
     tzset();    
     _tzstring = "Time zone set to " + _tzstring;
-    LogFile.WriteToFile(ESP_LOG_INFO, _tzstring);
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, _tzstring);
 }
 
 static void obtain_time(void)

--- a/code/components/jomjol_wlan/connect_wlan.cpp
+++ b/code/components/jomjol_wlan/connect_wlan.cpp
@@ -35,7 +35,7 @@ static EventGroupHandle_t s_wifi_event_group;
 #define WIFI_CONNECTED_BIT BIT0
 #define WIFI_FAIL_BIT      BIT1
 
-static const char *TAG = "wifi station";
+static const char *TAG = "WIFI";
 
 static int s_retry_num = 0;
 

--- a/code/components/jomjol_wlan/read_wlanini.cpp
+++ b/code/components/jomjol_wlan/read_wlanini.cpp
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "esp_log.h"
 
-static const char *TAG = "read_wlanini";
+static const char *TAG = "WLAN.INI";
 
 std::vector<string> ZerlegeZeileWLAN(std::string input, std::string _delimiter = "")
 {

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -49,7 +49,7 @@ extern const char* BUILD_TIME;
 
 #define BLINK_GPIO GPIO_NUM_33
 
-static const char *TAGMAIN = "main";
+static const char *TAG = "MAIN";
 
 //#define FLASH_GPIO GPIO_NUM_4
 
@@ -62,7 +62,7 @@ bool Init_NVS_SDCard()
     }
 ////////////////////////////////////////////////
 
-    ESP_LOGI(TAGMAIN, "Using SDMMC peripheral");
+    ESP_LOGI(TAG, "Using SDMMC peripheral");
     sdmmc_host_t host = SDMMC_HOST_DEFAULT();
 
     // This initializes the slot without card detect (CD) and write protect (WP) signals.
@@ -104,10 +104,10 @@ bool Init_NVS_SDCard()
 
     if (ret != ESP_OK) {
         if (ret == ESP_FAIL) {
-            ESP_LOGE(TAGMAIN, "Failed to mount filesystem. "
+            ESP_LOGE(TAG, "Failed to mount filesystem. "
                 "If you want the card to be formatted, set format_if_mount_failed = true.");
         } else {
-            ESP_LOGE(TAGMAIN, "Failed to initialize the card (%s). "
+            ESP_LOGE(TAG, "Failed to initialize the card (%s). "
                 "Make sure SD card lines have pull-up resistors in place.", esp_err_to_name(ret));
         }
         return false;
@@ -128,7 +128,7 @@ void task_NoSDBlink(void *pvParameter)
     
     TickType_t xDelay;
     xDelay = 100 / portTICK_PERIOD_MS;
-    ESP_LOGD(TAGMAIN, "SD-Card could not be inialized - STOP THE PROGRAMM HERE");
+    ESP_LOGD(TAG, "SD-Card could not be inialized - STOP THE PROGRAMM HERE");
 
     while (1)
     {
@@ -148,18 +148,18 @@ extern "C" void app_main(void)
     string versionFormated = "Branch: '" + std::string(GIT_BRANCH) + "', Tag: '" + std::string(GIT_TAG) + \
             "', Revision: " + std::string(GIT_REV) +", Date/Time: " + std::string(BUILD_TIME);
 
-    ESP_LOGI(TAGMAIN, "\n\n\n\n\n"); // Add mark on log to see when it restarted
-    ESP_LOGD(TAGMAIN, "=============================================================================================");
-    ESP_LOGD(TAGMAIN, "%s", versionFormated.c_str());
-    ESP_LOGD(TAGMAIN, "=============================================================================================");
-    ESP_LOGD(TAGMAIN, "Reset reason: %s", getResetReason().c_str());
+    ESP_LOGI(TAG, "\n\n\n\n\n"); // Add mark on log to see when it restarted
+    ESP_LOGD(TAG, "=============================================================================================");
+    ESP_LOGD(TAG, "%s", versionFormated.c_str());
+    ESP_LOGD(TAG, "=============================================================================================");
+    ESP_LOGD(TAG, "Reset reason: %s", getResetReason().c_str());
 
 
     PowerResetCamera();
     esp_err_t cam = Camera.InitCam();
     Camera.LightOnOff(false);
     xDelay = 2000 / portTICK_PERIOD_MS;
-    ESP_LOGD(TAGMAIN, "After camera initialization: sleep for: %ldms", (long) xDelay);
+    ESP_LOGD(TAG, "After camera initialization: sleep for: %ldms", (long) xDelay);
     vTaskDelay( xDelay );   
 
 
@@ -174,9 +174,9 @@ extern "C" void app_main(void)
     LogFile.CreateLogDirectories();
 /*
     int mk_ret = mkdir("/sdcard/new_fd_mkdir", 0775);
-    ESP_LOGI(TAGMAIN, "mkdir ret %d", mk_ret);
+    ESP_LOGI(TAG, "mkdir ret %d", mk_ret);
     mk_ret = mkdir("/sdcard/new_fd_mkdir/test", 0775);
-    ESP_LOGI(TAGMAIN, "mkdir ret %d", mk_ret);
+    ESP_LOGI(TAG, "mkdir ret %d", mk_ret);
     MakeDir("/sdcard/test2");
     MakeDir("/sdcard/test2/intern");
 */
@@ -187,58 +187,58 @@ extern "C" void app_main(void)
 
     if (ssid != NULL && passwd != NULL)
 #ifdef __HIDE_PASSWORD
-        ESP_LOGD(TAGMAIN, "WLan: %s, XXXXXX", ssid);
+        ESP_LOGD(TAG, "WLan: %s, XXXXXX", ssid);
 #else
-        ESP_LOGD(TAGMAIN, "WLan: %s, %s", ssid, passwd);
+        ESP_LOGD(TAG, "WLan: %s, %s", ssid, passwd);
 #endif        
 
     else
-        ESP_LOGD(TAGMAIN, "No SSID and PASSWORD set!!!");
+        ESP_LOGD(TAG, "No SSID and PASSWORD set!!!");
 
     if (hostname != NULL)
-        ESP_LOGD(TAGMAIN, "Hostname: %s", hostname);
+        ESP_LOGD(TAG, "Hostename: %s", hostname);
     else
-        ESP_LOGD(TAGMAIN, "Hostname not set");
+        ESP_LOGD(TAG, "Hostname not set");
 
     if (ip != NULL && gateway != NULL && netmask != NULL)
-       ESP_LOGD(TAGMAIN, "Fixed IP: %s, Gateway %s, Netmask %s", ip, gateway, netmask);
+       ESP_LOGD(TAG, "Fixed IP: %s, Gateway %s, Netmask %s", ip, gateway, netmask);
     if (dns != NULL)
-       ESP_LOGD(TAGMAIN, "DNS IP: %s", dns);
+       ESP_LOGD(TAG, "DNS IP: %s", dns);
 
 
     wifi_init_sta(ssid, passwd, hostname, ip, gateway, netmask, dns);   
 
 
     xDelay = 2000 / portTICK_PERIOD_MS;
-    ESP_LOGD(TAGMAIN, "main: sleep for: %ldms", (long) xDelay);
+    ESP_LOGD(TAG, "main: sleep for: %ldms", (long) xDelay);
     vTaskDelay( xDelay );   
     setup_time();
     setBootTime();
 
-    LogFile.WriteToFile(ESP_LOG_INFO, "=============================================================================================");
-    LogFile.WriteToFile(ESP_LOG_INFO, "=================================== Main Started ============================================");
-    LogFile.WriteToFile(ESP_LOG_INFO, "=============================================================================================");
-    LogFile.WriteToFile(ESP_LOG_INFO, versionFormated);
-    LogFile.WriteToFile(ESP_LOG_INFO, "Reset reason: " + getResetReason());
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "=============================================================================================");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "=================================== Main Started ============================================");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "=============================================================================================");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, versionFormated);
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Reset reason: " + getResetReason());
 
     std::string zw = gettimestring("%Y%m%d-%H%M%S");
-    ESP_LOGD(TAGMAIN, "time %s", zw.c_str());
+    ESP_LOGD(TAG, "time %s", zw.c_str());
 
     size_t _hsize = getESPHeapSize();
     if (_hsize < 4000000)
     {
         std::string _zws = "Not enough PSRAM available. Expected 4.194.304 MByte - available: " + std::to_string(_hsize);
         _zws = _zws + "\nEither not initialzed, too small (2MByte only) or not present at all. Firmware cannot start!!";
-        LogFile.WriteToFile(ESP_LOG_ERROR, _zws);
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, _zws);
     } else {
         if (cam != ESP_OK) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, "Failed to initialize camera module. "
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to initialize camera module. "
                         "Check that your camera module is working and connected properly.");
         } else {
 // Test Camera            
             camera_fb_t * fb = esp_camera_fb_get();
             if (!fb) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, "Camera cannot be initialzed. "
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera cannot be initialzed. "
                         "System will reboot.");
                 doReboot();
             }
@@ -250,10 +250,10 @@ extern "C" void app_main(void)
 
 
     xDelay = 2000 / portTICK_PERIOD_MS;
-    ESP_LOGD(TAGMAIN, "main: sleep for: %ldms", (long) xDelay*10);
+    ESP_LOGD(TAG, "main: sleep for: %ldms", (long) xDelay*10);
     vTaskDelay( xDelay ); 
 
-    ESP_LOGD(TAGMAIN, "starting server");
+    ESP_LOGD(TAG, "starting server");
 
     server = start_webserver();   
     register_server_camera_uri(server); 
@@ -264,10 +264,10 @@ extern "C" void app_main(void)
 
     gpio_handler_create(server);
 
-    ESP_LOGD(TAGMAIN, "vor reg server main");
+    ESP_LOGD(TAG, "vor reg server main");
     register_server_main_uri(server, "/sdcard");
 
-    ESP_LOGD(TAGMAIN, "vor dotautostart");
+    ESP_LOGD(TAG, "vor dotautostart");
     TFliteDoAutoStart();
 
 }

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -25,7 +25,7 @@
 httpd_handle_t server = NULL;   
 std::string starttime = "";
 
-static const char *TAG_SERVERMAIN = "server-main";
+static const char *TAG = "MAIN SERVER";
 
 /* An HTTP GET handler */
 esp_err_t info_get_handler(httpd_req_t *req)
@@ -34,18 +34,18 @@ esp_err_t info_get_handler(httpd_req_t *req)
     LogFile.WriteHeapInfo("info_get_handler - Start");    
 #endif
 
-    LogFile.WriteToFile(ESP_LOG_INFO, "info_get_handler");    
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "info_get_handler");    
     char _query[200];
     char _valuechar[30];    
     std::string _task;
 
     if (httpd_req_get_url_query_str(req, _query, 200) == ESP_OK)
     {
-        ESP_LOGD(TAG_SERVERMAIN, "Query: %s", _query);
+        ESP_LOGD(TAG, "Query: %s", _query);
         
         if (httpd_query_key_value(_query, "type", _valuechar, 30) == ESP_OK)
         {
-            ESP_LOGD(TAG_SERVERMAIN, "type is found: %s", _valuechar);
+            ESP_LOGD(TAG, "type is found: %s", _valuechar);
             _task = std::string(_valuechar);
         }
     };
@@ -221,7 +221,7 @@ esp_err_t hello_main_handler(httpd_req_t *req)
 #endif
 
     char filepath[50];
-    ESP_LOGD(TAG_SERVERMAIN, "uri: %s\n", req->uri);
+    ESP_LOGD(TAG, "uri: %s\n", req->uri);
     int _pos;
     esp_err_t res;
 
@@ -230,7 +230,7 @@ esp_err_t hello_main_handler(httpd_req_t *req)
 
     const char *filename = get_path_from_uri(filepath, base_path,
                                              req->uri - 1, sizeof(filepath));    
-    ESP_LOGD(TAG_SERVERMAIN, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
+    ESP_LOGD(TAG, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
 
     if ((strcmp(req->uri, "/") == 0))
     {
@@ -248,16 +248,16 @@ esp_err_t hello_main_handler(httpd_req_t *req)
     }
 
     if (filetosend == "/sdcard/html/index.html" && isSetupModusActive()) {
-        ESP_LOGD(TAG_SERVERMAIN, "System is in setup mode --> index.html --> setup.html");
+        ESP_LOGD(TAG, "System is in setup mode --> index.html --> setup.html");
         filetosend = "/sdcard/html/setup.html";
     }
 
-    ESP_LOGD(TAG_SERVERMAIN, "Filename: %s", filename);
+    ESP_LOGD(TAG, "Filename: %s", filename);
     
-    ESP_LOGD(TAG_SERVERMAIN, "File requested: %s", filetosend.c_str());
+    ESP_LOGD(TAG, "File requested: %s", filetosend.c_str());
 
     if (!filename) {
-        ESP_LOGE(TAG_SERVERMAIN, "Filename is too long");
+        ESP_LOGE(TAG, "Filename is too long");
         /* Respond with 500 Internal Server Error */
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Filename too long");
         return ESP_FAIL;
@@ -284,17 +284,17 @@ esp_err_t hello_main_handler(httpd_req_t *req)
 esp_err_t img_tmp_handler(httpd_req_t *req)
 {
     char filepath[50];
-    ESP_LOGD(TAG_SERVERMAIN, "uri: %s", req->uri);
+    ESP_LOGD(TAG, "uri: %s", req->uri);
 
     char *base_path = (char*) req->user_ctx;
     std::string filetosend(base_path);
 
     const char *filename = get_path_from_uri(filepath, base_path,
                                              req->uri  + sizeof("/img_tmp/") - 1, sizeof(filepath));    
-    ESP_LOGD(TAG_SERVERMAIN, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
+    ESP_LOGD(TAG, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
 
     filetosend = filetosend + "/img_tmp/" + std::string(filename);
-    ESP_LOGD(TAG_SERVERMAIN, "File to upload: %s", filetosend.c_str());
+    ESP_LOGD(TAG, "File to upload: %s", filetosend.c_str());
 
     esp_err_t res = send_file(req, filetosend); 
     if (res != ESP_OK)
@@ -313,17 +313,17 @@ esp_err_t img_tmp_virtual_handler(httpd_req_t *req)
 
     char filepath[50];
 
-    ESP_LOGD(TAG_SERVERMAIN, "uri: %s", req->uri);
+    ESP_LOGD(TAG, "uri: %s", req->uri);
 
     char *base_path = (char*) req->user_ctx;
     std::string filetosend(base_path);
 
     const char *filename = get_path_from_uri(filepath, base_path,
                                              req->uri  + sizeof("/img_tmp/") - 1, sizeof(filepath));    
-    ESP_LOGD(TAG_SERVERMAIN, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
+    ESP_LOGD(TAG, "1 uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
 
     filetosend = std::string(filename);
-    ESP_LOGD(TAG_SERVERMAIN, "File to upload: %s", filetosend.c_str());
+    ESP_LOGD(TAG, "File to upload: %s", filetosend.c_str());
 
     if (filetosend == "raw.jpg")
     {
@@ -468,14 +468,14 @@ httpd_handle_t start_webserver(void)
     starttime = gettimestring("%Y%m%d-%H%M%S");
 
     // Start the httpd server
-    ESP_LOGI(TAG_SERVERMAIN, "Starting server on port: '%d'", config.server_port);
+    ESP_LOGI(TAG, "Starting server on port: '%d'", config.server_port);
     if (httpd_start(&server, &config) == ESP_OK) {
         // Set URI handlers
-        ESP_LOGI(TAG_SERVERMAIN, "Registering URI handlers");
+        ESP_LOGI(TAG, "Registering URI handlers");
         return server;
     }
 
-    ESP_LOGI(TAG_SERVERMAIN, "Error starting server!");
+    ESP_LOGI(TAG, "Error starting server!");
     return NULL;
 }
 
@@ -490,7 +490,7 @@ void disconnect_handler(void* arg, esp_event_base_t event_base,
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;
     if (*server) {
-        ESP_LOGI(TAG_SERVERMAIN, "Stopping webserver");
+        ESP_LOGI(TAG, "Stopping webserver");
         stop_webserver(*server);
         *server = NULL;
     }
@@ -501,7 +501,7 @@ void connect_handler(void* arg, esp_event_base_t event_base,
 {
     httpd_handle_t* server = (httpd_handle_t*) arg;
     if (*server == NULL) {
-        ESP_LOGI(TAG_SERVERMAIN, "Starting webserver");
+        ESP_LOGI(TAG, "Starting webserver");
         *server = start_webserver();
     }
 }

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
@@ -1,7 +1,7 @@
 #include "test_flow_postrocess_helper.h"
 #include "esp_log.h"
 
-static const char *TAG = "test_flow_postproc_helper";
+static const char *TAG = "FLOW CTRL POSTPROC TEST";
 
 UnderTestPost* setUpClassFlowPostprocessing(t_CNNType digType, t_CNNType anaType)
 {

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -11,7 +11,7 @@
 #include "sdmmc_cmd.h"
 #include "driver/sdmmc_host.h"
 #include "driver/sdmmc_defs.h"
-static const char *TAGMAIN = "main";
+static const char *TAG = "MAIN TEST";
 #define __SD_USE_ONE_LINE_MODE__
 #include "server_GPIO.h"
 
@@ -24,7 +24,7 @@ bool Init_NVS_SDCard()
     }
 ////////////////////////////////////////////////
 
-    ESP_LOGI(TAGMAIN, "Using SDMMC peripheral");
+    ESP_LOGI(TAG, "Using SDMMC peripheral");
     sdmmc_host_t host = SDMMC_HOST_DEFAULT();
 
     // This initializes the slot without card detect (CD) and write protect (WP) signals.
@@ -66,10 +66,10 @@ bool Init_NVS_SDCard()
 
     if (ret != ESP_OK) {
         if (ret == ESP_FAIL) {
-            ESP_LOGE(TAGMAIN, "Failed to mount filesystem. "
+            ESP_LOGE(TAG, "Failed to mount filesystem. "
                 "If you want the card to be formatted, set format_if_mount_failed = true.");
         } else {
-            ESP_LOGE(TAGMAIN, "Failed to initialize the card (%s). "
+            ESP_LOGE(TAG, "Failed to initialize the card (%s). "
                 "Make sure SD card lines have pull-up resistors in place.", esp_err_to_name(ret));
         }
         return false;

--- a/sd-card/html/gethost.js
+++ b/sd-card/html/gethost.js
@@ -13,7 +13,7 @@ function getbasepath(){
     {
 //        host = "http://192.168.2.219";          // jomjol interner test
 //        host = "http://192.168.178.46";          // jomjol interner test
-        host = "http://192.168.178.62";          // jomjol interner Real
+        host = "http://192.168.178.44";          // jomjol interner Real
 //        host = "http://192.168.43.191";
 //        host = ".";                           // jomjol interner localhost   
 

--- a/sd-card/html/gethost.js
+++ b/sd-card/html/gethost.js
@@ -13,7 +13,7 @@ function getbasepath(){
     {
 //        host = "http://192.168.2.219";          // jomjol interner test
 //        host = "http://192.168.178.46";          // jomjol interner test
-        host = "http://192.168.178.44";          // jomjol interner Real
+        host = "http://192.168.178.62";          // jomjol interner Real
 //        host = "http://192.168.43.191";
 //        host = ".";                           // jomjol interner localhost   
 


### PR DESCRIPTION
This PR makes all logfile logs to look more consistent.

- renamed all variables `TAGxxxx` to `TAG`
- The logfile now also uses those tags
- Shortened some log messages to remove redundancy with the TAG
- Added separator to see better where a new round starts
- Show round number at end of round message


Example log:
```
2022-11-01T22:11:24 <DBG> [HEAP] FlowControll.doFlow - ClassFlowCNNGeneral Heap: 3027298 Min Free: 995674 larg. Block: 2949120 SPI Heap: 3014239 NOT_SPI Heap: 13059 Internal Heap: 13059 Internal Min Heap free: 2063
2022-11-01T22:11:24 <DBG> [CNN] doFlow nach Alignment
2022-11-01T22:11:25 <DBG> [CNN] Nach Invoke
2022-11-01T22:11:29 <DBG> [HEAP] FlowControll.doFlow - ClassFlowPostProcessing Heap: 3027294 Min Free: 995674 larg. Block: 2949120 SPI Heap: 3014239 NOT_SPI Heap: 13055 Internal Heap: 13055 Internal Min Heap free: 2063
2022-11-01T22:11:29 <DBG> [CNN] getReadout _analog=0, _extendedResolution=0, prev=-1
2022-11-01T22:11:29 <DBG> [HEAP] FlowControll.doFlow - ClassFlowMQTT Heap: 3027362 Min Free: 995674 larg. Block: 2949120 SPI Heap: 3014239 NOT_SPI Heap: 13123 Internal Heap: 13123 Internal Min Heap free: 2063
2022-11-01T22:11:30 <DBG> [MQTT INTERFACE] Published topic: Testzaehler8/uptime, content: 226 (msg_id=50286)
2022-11-01T22:11:30 <INF> [LOGFILE] logfiles deleted: 0 files not deleted (incl. leer.txt): 13
2022-11-01T22:11:30 <INF> [TFLITE] task_autodoFlow - next round - Round #4
2022-11-01T22:11:30 <DBG> [HEAP] FlowControll.doFlow - ClassFlowMakeImage Heap: 3027326 Min Free: 995674 larg. Block: 2949120 SPI Heap: 3014239 NOT_SPI Heap: 13087 Internal Heap: 13087 Internal Min Heap free: 2063
2022-11-01T22:11:58 <DBG> [CNN] doFlow nach Alignment
```