### PR TITLE
Disable the Idle Task Watchdog resp. the Task Watchdog in general because we do not use it ATM

### DIFF
--- a/code/sdkconfig.defaults
+++ b/code/sdkconfig.defaults
@@ -5,6 +5,9 @@
 # sdkconfig.esp32cam to apply your changes!
 ##################################################
 
+CONFIG_TASK_WDT=n
+CONFIG_TASK_WDT_CHECK_IDLE_TASK=n
+
 CONFIG_COMPILER_OPTIMIZATION_DEFAULT=n
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y
 


### PR DESCRIPTION
This gets rid of the periodic log messages
```
E (37267) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time:
E (37267) task_wdt:  - IDLE (CPU 0)
E (37267) task_wdt: Tasks currently running:
[..]
```

A nice explanation of the Task Watchdog can be found here: https://www.linkedin.com/pulse/watchdog-processing-esp-idf-neil-kolban