### PR TITLE
Fix file retention, remove/correct logs

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -27,6 +27,7 @@ ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalign, t_CNNTy
     CNNType = AutoDetect;
     CNNType = _cnntype;
     flowpostalignment = _flowalign;
+    logfileRetentionInDays = 5;
 }
 
 string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution, int prev, float _vorgaengerAnalog, float analogDigitalTransitionStart)

--- a/code/components/jomjol_flowcontroll/ClassFlowMakeImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMakeImage.cpp
@@ -57,6 +57,8 @@ void ClassFlowMakeImage::SetInitialParameter(void)
 
 ClassFlowMakeImage::ClassFlowMakeImage(std::vector<ClassFlow*>* lfc) : ClassFlowImage(lfc, TAG)
 {
+    LogImageLocation = "/log/source";
+    logfileRetentionInDays = 5;
     SetInitialParameter();
 }
 
@@ -104,6 +106,10 @@ bool ClassFlowMakeImage::ReadParameter(FILE* pfile, string& aktparamgraph)
             waitbeforepicture = stoi(zerlegt[1]);
         }
 
+        if ((toUpper(zerlegt[0]) == "LOGFILERETENTIONINDAYS") && (zerlegt.size() > 1))
+        {
+            this->logfileRetentionInDays = std::stoi(zerlegt[1]);
+        }
 
         if ((toUpper(zerlegt[0]) == "BRIGHTNESS") && (zerlegt.size() > 1))
         {

--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -90,7 +90,7 @@ string getSDCardPartitionSize(){
     f_getfree("0:", (DWORD *)&fre_clust, &fs);
     tot_sect = ((fs->n_fatent - 2) * fs->csize) /1024 /(1024/SDCardCsd.sector_size);	//corrected by SD Card sector size (usually 512 bytes) and convert to MB
 
-    printf("%d MB total drive space (Sector size [bytes]: %d)\n", (int)tot_sect, (int)fs->csize*512);
+	//ESP_LOGD(TAG, "%d MB total drive space (Sector size [bytes]: %d)", (int)tot_sect, (int)fs->ssize);
 
 	return std::to_string(tot_sect);
 }
@@ -103,7 +103,7 @@ string getSDCardFreePartitionSpace(){
     f_getfree("0:", (DWORD *)&fre_clust, &fs);
     fre_sect = (fre_clust * fs->csize) / 1024 /(1024/SDCardCsd.sector_size);	//corrected by SD Card sector size (usually 512 bytes) and convert to MB
 
-    printf("%d MB free drive space (Sector size [bytes]: %d)\n", (int)fre_sect, (int)fs->ssize);
+    //ESP_LOGD(TAG, "%d MB free drive space (Sector size [bytes]: %d)", (int)fre_sect, (int)fs->ssize);
 
 	return std::to_string(fre_sect);
 }
@@ -116,7 +116,7 @@ string getSDCardPartitionAllocationSize(){
     f_getfree("0:", (DWORD *)&fre_clust, &fs);
     allocation_size = fs->ssize;
 
-    printf("SD Card Partition Allocation Size (bytes): %d)\n", allocation_size);
+    //ESP_LOGD(TAG, "SD Card Partition Allocation Size: %d bytes", allocation_size);
 
 	return std::to_string(allocation_size);
 }
@@ -129,28 +129,28 @@ void SaveSDCardInfo(sdmmc_card_t* card) {
 
 string getSDCardManufacturer(){
 	string SDCardManufacturer = SDCardParseManufacturerIDs(SDCardCid.mfg_id);
-	printf("SD Card Manufactuer: %s\n", SDCardManufacturer.c_str());
+	//ESP_LOGD(TAG, "SD Card Manufacturer: %s", SDCardManufacturer.c_str());
 	
 	return (SDCardManufacturer + " (ID: " + std::to_string(SDCardCid.mfg_id) + ")");
 }
 
 string getSDCardName(){
 	char *SDCardName = SDCardCid.name;
-	printf("SD Card Name: %s\n", SDCardName); 
+	//ESP_LOGD(TAG, "SD Card Name: %s", SDCardName); 
 
 	return std::string(SDCardName);
 }
 
 string getSDCardCapacity(){
 	int SDCardCapacity = SDCardCsd.capacity / (1024/SDCardCsd.sector_size) / 1024;  // total sectors * sector size  --> Byte to MB (1024*1024)
-	printf("SD Card Capacity: %s\n", std::to_string(SDCardCapacity).c_str()); 
+	//ESP_LOGD(TAG, "SD Card Capacity: %s", std::to_string(SDCardCapacity).c_str()); 
 
 	return std::to_string(SDCardCapacity);
 }
 
 string getSDCardSectorSize(){
 	int SDCardSectorSize = SDCardCsd.sector_size;
-	printf("SD Card Sector Size: %s\n", std::to_string(SDCardSectorSize).c_str()); 
+	//ESP_LOGD(TAG, "SD Card Sector Size: %s bytes", std::to_string(SDCardSectorSize).c_str()); 
 
 	return std::to_string(SDCardSectorSize);
 }
@@ -500,11 +500,11 @@ time_t addDays(time_t startTime, int days) {
 }
 
 int removeFolder(const char* folderPath, const char* logTag) {
-	ESP_LOGI(logTag, "Delete folder %s", folderPath);
+	//ESP_LOGD(logTag, "Delete content in path %s", folderPath);
 
 	DIR *dir = opendir(folderPath);
     if (!dir) {
-        ESP_LOGI(logTag, "Failed to stat dir : %s", folderPath);
+        ESP_LOGE(logTag, "Failed to stat dir : %s", folderPath);
         return -1;
     }
 
@@ -513,6 +513,7 @@ int removeFolder(const char* folderPath, const char* logTag) {
     while ((entry = readdir(dir)) != NULL) {
         std::string path = string(folderPath) + "/" + entry->d_name;
 		if (entry->d_type == DT_REG) {
+			//ESP_LOGD(logTag, "Delete file %s", path.c_str());
 			if (unlink(path.c_str()) == 0) {
 				deleted ++;
 			} else {
@@ -525,9 +526,9 @@ int removeFolder(const char* folderPath, const char* logTag) {
     
     closedir(dir);
 	if (rmdir(folderPath) != 0) {
-		ESP_LOGE(logTag, "can't delete file : %s", folderPath);
+		ESP_LOGE(logTag, "can't delete folder : %s", folderPath);
 	}
-	ESP_LOGI(logTag, "%d older log files in folder %s deleted.", deleted, folderPath);
+	ESP_LOGD(logTag, "%d files in folder %s deleted.", deleted, folderPath);
 
 	return deleted;
 }

--- a/code/components/jomjol_wlan/connect_wlan.cpp
+++ b/code/components/jomjol_wlan/connect_wlan.cpp
@@ -231,7 +231,7 @@ void wifi_init_sta(const char *_ssid, const char *_password, const char *_hostna
             ESP_LOGE(TAG,"failed to set hostname:%d",ret);  
         }
         else {
-            ESP_LOGE(TAG,"Set Hostname to:%s", _hostname); 
+            ESP_LOGI(TAG,"Set Hostname to:%s", _hostname); 
         }
 
     }


### PR DESCRIPTION
1. Fix file retention routines
- Preset default retention times (when retention setting in config is skipped)
- Read retention time for raw/source files out of config (was missing)
- Correct mismatch in retention days between config setting and actual kept back number of files/folders
- Set correct root folder for data logs ( fixes #1304 )

2. Remove / correct some logs