### PR TITLE
Use none chunked transfer for "/json" endpoint

### DIFF
--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -201,20 +201,18 @@ esp_err_t handler_json(httpd_req_t *req)
 
     ESP_LOGD(TAG, "handler_JSON uri: %s", req->uri);
 
-    char _query[100];
-//    char _size[10];
-
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
     httpd_resp_set_type(req, "application/json");
 
     std::string zw = tfliteflow.getJSON();
     if (zw.length() > 0)
-        httpd_resp_sendstr_chunk(req, zw.c_str()); 
-
-    string query = std::string(_query);
-
-    /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_sendstr_chunk(req, NULL);   
+    {
+        httpd_resp_send(req, zw.c_str(), zw.length());
+    }
+    else
+    {
+        httpd_resp_send(req, NULL, 0);
+    }
 
 #ifdef DEBUG_DETAIL_ON       
     LogFile.WriteHeapInfo("handler_JSON - Done");   


### PR DESCRIPTION
Hi,

I know it is not your fault, but this was the easy route. ;-)

We are trying to integrate the water meter into a Loxone Home Automation but this device is struggling with the http chunked transfer.
Therefore I have changed the calls to the "normal" response function. From my point of view there is also no need to do a chunked transfer, because all data is rendered way ahead.
This way you can also use more simple devices to grab the current values from the meter.
And also removed two unused variables.

We are trying to give Loxone a bug report so it can be fixed in the right place.

Thanks for you project! :+1: 

