### PR TITLE
slow down reboot loops

### DIFF
--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -714,10 +714,10 @@ void task_autodoFlow(void *pvParameter)
     int64_t fr_start, fr_delta_ms;
 
     if (esp_reset_reason() == ESP_RST_PANIC) {
-        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Restarted due to an Exception/panic! Postponing first round start by 5 minutes to allow for a proper OTA!"); 
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Restarted due to an Exception/panic! Postponing first round start by 5 minutes to allow for an OTA or to fetch the log!"); 
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Setting logfile level to DEBUG until the next reboot!");
         LogFile.setLogLevel(ESP_LOG_DEBUG);
-        vTaskDelay(60*5000 / portTICK_RATE_MS);
+        vTaskDelay(60*5000 / portTICK_RATE_MS); // Wait 5 minutes to give time to do an OTA or fetch the log
     }
 
     ESP_LOGD(TAG, "task_autodoFlow: start");

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -713,6 +713,13 @@ void task_autodoFlow(void *pvParameter)
 {
     int64_t fr_start, fr_delta_ms;
 
+    if (esp_reset_reason() == ESP_RST_PANIC) {
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Restarted due to an Exception/panic! Postponing first round start by 5 minutes to allow for a proper OTA!"); 
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Setting logfile level to DEBUG until the next reboot!");
+        LogFile.setLogLevel(ESP_LOG_DEBUG);
+        vTaskDelay(60*5000 / portTICK_RATE_MS);
+    }
+
     ESP_LOGD(TAG, "task_autodoFlow: start");
     doInit();
     gpio_handler_init();

--- a/code/components/jomjol_time_sntp/time_sntp.h
+++ b/code/components/jomjol_time_sntp/time_sntp.h
@@ -12,7 +12,7 @@
 // #include "nvs_flash.h"
 #include "esp_sntp.h"
 
-void setup_time(void);
+bool setup_time(void);
 
 std::string gettimestring(const char * frm);
 std::string ConvertTimeToString(time_t _time, const char * frm);

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -296,7 +296,7 @@ extern "C" void app_main(void)
     register_server_main_uri(server, "/sdcard");
 
     if (initSucessful) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Initialization completed!");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Initialization completed successfully!");
         ESP_LOGD(TAG, "vor do autostart");
         TFliteDoAutoStart();
     }

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -146,11 +146,12 @@ void task_NoSDBlink(void *pvParameter)
 extern "C" void app_main(void)
 {
     TickType_t xDelay;
+    bool initSucessful = true;
 
     ESP_LOGI(TAG, "\n\n\n\n\n"); // Add mark on log to see when it restarted
     
     PowerResetCamera();
-    esp_err_t cam = Camera.InitCam();
+    esp_err_t camStatus = Camera.InitCam();
     Camera.LightOnOff(false);
     xDelay = 2000 / portTICK_PERIOD_MS;
     ESP_LOGD(TAG, "After camera initialization: sleep for: %ldms", (long) xDelay);
@@ -218,6 +219,7 @@ extern "C" void app_main(void)
     xDelay = 2000 / portTICK_PERIOD_MS;
     ESP_LOGD(TAG, "main: sleep for: %ldms", (long) xDelay);
     vTaskDelay( xDelay );   
+
     setup_time();
     setBootTime();
 
@@ -238,22 +240,34 @@ extern "C" void app_main(void)
     if (_hsize < 4000000)
     {
         std::string _zws = "Not enough PSRAM available. Expected 4.194.304 MByte - available: " + std::to_string(_hsize);
-        _zws = _zws + "\nEither not initialzed, too small (2MByte only) or not present at all. Firmware cannot start!!";
+        _zws = _zws + "\nEither not initialized, too small (2MByte only) or not present at all. Firmware cannot start!!";
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, _zws);
-    } else {
-        if (cam != ESP_OK) {
+    } else { // Bad Camera Status, retry init   
+        if (camStatus != ESP_OK) {
+            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Failed to initialize camera module, retrying...");
+
+            PowerResetCamera();
+            esp_err_t camStatus = Camera.InitCam();
+            Camera.LightOnOff(false);
+            xDelay = 2000 / portTICK_PERIOD_MS;
+            ESP_LOGD(TAG, "After camera initialization: sleep for: %ldms", (long) xDelay);
+            vTaskDelay( xDelay ); 
+
+            if (camStatus != ESP_OK) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to initialize camera module. "
                         "Check that your camera module is working and connected properly.");
-        } else {
-// Test Camera            
+                initSucessful = false;
+            }
+        } else { // Test Camera            
             camera_fb_t * fb = esp_camera_fb_get();
             if (!fb) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera cannot be initialzed. "
-                        "System will reboot.");
-                doReboot();
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera cannot be initialzed.");
+                initSucessful = false;
             }
-            esp_camera_fb_return(fb);   
-            Camera.LightOnOff(false);
+            else {
+                esp_camera_fb_return(fb);   
+                Camera.LightOnOff(false);
+            }
         }
     }
 
@@ -263,7 +277,7 @@ extern "C" void app_main(void)
     ESP_LOGD(TAG, "main: sleep for: %ldms", (long) xDelay*10);
     vTaskDelay( xDelay ); 
 
-    ESP_LOGD(TAG, "starting server");
+    ESP_LOGD(TAG, "starting servers");
 
     server = start_webserver();   
     register_server_camera_uri(server); 
@@ -277,8 +291,14 @@ extern "C" void app_main(void)
     ESP_LOGD(TAG, "vor reg server main");
     register_server_main_uri(server, "/sdcard");
 
-    ESP_LOGD(TAG, "vor dotautostart");
-    TFliteDoAutoStart();
-
+    if (initSucessful) {
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Initialization completed!");
+        ESP_LOGD(TAG, "vor do autostart");
+        TFliteDoAutoStart();
+    }
+    else { // Initialization failed
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Initialization failed. Will restart in 5 minutes!");
+        vTaskDelay(60*5000 / portTICK_RATE_MS); // Wait 5 minutes to give time to do an OTA or fetch the log
+        doReboot();
+    }
 }
-

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -220,7 +220,11 @@ extern "C" void app_main(void)
     ESP_LOGD(TAG, "main: sleep for: %ldms", (long) xDelay);
     vTaskDelay( xDelay );   
 
-    setup_time();
+    if (!setup_time()) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "NTP Initialization failed. Will restart in 5 minutes!");
+        initSucessful = false;
+    }
+
     setBootTime();
 
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "=============================================================================================");
@@ -254,14 +258,14 @@ extern "C" void app_main(void)
             vTaskDelay( xDelay ); 
 
             if (camStatus != ESP_OK) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to initialize camera module. "
-                        "Check that your camera module is working and connected properly.");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to initialize camera module. Will restart in 5 minutes!");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Check that your camera module is working and connected properly!");
                 initSucessful = false;
             }
         } else { // Test Camera            
             camera_fb_t * fb = esp_camera_fb_get();
             if (!fb) {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera cannot be initialzed.");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera cannot be initialzed. Will restart in 5 minutes!");
                 initSucessful = false;
             }
             else {
@@ -298,7 +302,10 @@ extern "C" void app_main(void)
     }
     else { // Initialization failed
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Initialization failed. Will restart in 5 minutes!");
-        vTaskDelay(60*5000 / portTICK_RATE_MS); // Wait 5 minutes to give time to do an OTA or fetch the log
+        vTaskDelay(60*4000 / portTICK_RATE_MS); // Wait 4 minutes to give time to do an OTA or fetch the log
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Initialization failed. Will restart in 1 minute!");
+        vTaskDelay(60*1000 / portTICK_RATE_MS); // Wait 1 minute to give time to do an OTA or fetch the log
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Initialization failed. Will restart now!");
         doReboot();
     }
 }


### PR DESCRIPTION
- If a device restarts due to an `exception/panic`, the first round gets delayed by 5 minutes. this gives time to fetch the log or run an OTA DFU. Also, the log level gets set to DEBUG until the next start. 
- If cam initialization fails, it retries once. Usually it successes then.
- If the initialization of the cam, NTP or cam framebuffer fails, it waits 5 minutes and restarts then.