### PR TITLE
make button titles consistent

### DIFF
--- a/sd-card/html/edit_alignment.html
+++ b/sd-card/html/edit_alignment.html
@@ -86,10 +86,10 @@ select {
 
 	<table>
 	  <tr>
-		<td><input class="button" type="submit" name="saveroi" onclick="SaveToConfig()" value="Save all to Config.ini"></td>
+		<td><input class="button" type="submit" name="saveroi" onclick="SaveToConfig()" value="Save"></td>
 	  </tr> 
 	  <tr>
-                <td><button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate saved config</button></td>
+                <td><button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate changes</button></td>
 	  </tr>  
 	</table>
 

--- a/sd-card/html/edit_analog.html
+++ b/sd-card/html/edit_analog.html
@@ -132,10 +132,10 @@ th, td {
 
 	<table>
 	  <tr>
-		<td><input class="button" type="submit" id="saveroi" name="saveroi" onclick="SaveToConfig()" value="Save all to Config.ini" tabindex=9></td>
+		<td><input class="button" type="submit" id="saveroi" name="saveroi" onclick="SaveToConfig()" value="Save" tabindex=9></td>
 	  </tr>  
 	  <tr>
-                <td><button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate saved config</button></td>
+                <td><button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate changes</button></td>
 	  </tr>  
     </table>	
 

--- a/sd-card/html/edit_config.html
+++ b/sd-card/html/edit_config.html
@@ -34,10 +34,10 @@ textarea {
         </td>
     </tr>
     <tr>
-		<td><button class="button" onclick="saveTextAsFile()">Update Config.ini</button></td>
+		<td><button class="button" onclick="saveTextAsFile()">Save</button></td>
 	</tr>
 	<tr>
-		<td><button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate updates</button></td>
+		<td><button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate changes</button></td>
 	</tr>
 </table>
 

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -1375,16 +1375,16 @@ textarea {
 	</table>
 
 	<p>
-		<button class="button" onclick="saveTextAsFile()">Update Config.ini</button>
+		<button class="button" onclick="saveTextAsFile()">Save</button>
 	</p>
 	<p>
 		
 	</p>
 	<div id="doreboot">
 		<p>
-			<button class="button" id="Edit_Config_Direct" onclick="editConfigDirect()" style="display:none">Edit Config.ini direct</button>
+			<button class="button" id="Edit_Config_Direct" onclick="editConfigDirect()" style="display:none">Edit Config file directly</button>
 			
-			<button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate updates</button>
+			<button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate changes</button>
 		</p>
 	</div>
 

--- a/sd-card/html/edit_digits.html
+++ b/sd-card/html/edit_digits.html
@@ -124,10 +124,10 @@ th, td {
 			 
 	<table>
 	  <tr>
-		<td><input class="button" type="submit" id="saveroi" name="saveroi" onclick="SaveToConfig()" value="Save all to Config.ini" tabindex=10></td>
+		<td><input class="button" type="submit" id="saveroi" name="saveroi" onclick="SaveToConfig()" value="Save" tabindex=10></td>
 	  </tr> 
 	  <tr>
-                <td><button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate saved config</button></td>
+                <td><button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate changes</button></td>
 	  </tr>  
 	</table>
 

--- a/sd-card/html/edit_explain_6.html
+++ b/sd-card/html/edit_explain_6.html
@@ -34,11 +34,11 @@ p {font-size: 1em;}
         <br>
         The Web Interface will automatically reload. It will take two to four minutes, until you get the first reading. 
         <br>
-        All settings can be changed as well in the configuration menu in normal operation mode.
+        All settings can be changed as well in the configuration menu in the Normal modus.
     </p>
 
     <p>
-        <button class="button" onclick="reboot()">Leave Setup Modus and Reboot to Normal</button>
+        <button class="button" onclick="reboot()">Leave Setup Modus and Reboot to Normal modus</button>
     </p>
 
     <script type="text/javascript" src="./gethost.js"></script> 

--- a/sd-card/html/edit_reference.html
+++ b/sd-card/html/edit_reference.html
@@ -85,7 +85,7 @@ table {
 			<td><canvas id="canvas"></canvas></td>
 		</tr>			
 		<tr>		
-			<td><input class="button" type="button" id="updatereferenceimage" value="Update Reference Image" onclick="SaveReference()"></td>
+			<td><input class="button" type="button" id="updatereferenceimage" value="Save" onclick="SaveReference()"></td>
 		</tr>		
 		<tr>		
 			<td><button class="button" id="reboot" type="button" onclick="doReboot()">Reboot to activate saved Reference</button></td>

--- a/sd-card/html/explain_2.html
+++ b/sd-card/html/explain_2.html
@@ -27,7 +27,7 @@ Two opposite alignment references are needed to identify unique fix points on th
     You can switch between the two reference with <b>"Select Reference"</b>.
 </p>
 <p>
-    Don't forget to save your changes with <b>"Save to Config.ini"</b>! A reboot is not yet required.
+    Don't forget to save your changes! A reboot is not yet required.
 </p>
 
 </body>

--- a/sd-card/html/explain_3.html
+++ b/sd-card/html/explain_3.html
@@ -29,7 +29,7 @@ Here you define your digits you want to read. If you have more than one number o
     You can change it with <b>"move Next" / "move Previous"</b>.
 </p>
 <p>
-    Don't forget to save your changes with <b>"Save all to Config.ini"</b>! A reboot is not yet required.
+    Don't forget to save your changes! A reboot is not yet required.
 </p>
 
 </body>

--- a/sd-card/html/explain_5.html
+++ b/sd-card/html/explain_5.html
@@ -23,7 +23,7 @@ p {font-size: 1em;}
 <p>Here you can define additional settings. The settings should fit for a normal setup.</p>
 <p>You will also be availabl</p>
 <p>
-    Don't forget to save your changes with <b>"Update Config.ini"</b>!.
+    Don't forget to save your changes!
     <br><span color=red>You should not reboot here, but leave the setup modus on the next page!</span>
 </p>
 


### PR DESCRIPTION
- rename all save buttons from eg. `Save all to Config.ini` to be title `save`. Normal users do not need to edit the ini file manually, thus do not care about its name.
- changed all reboot buttons related to configs to `Reboot to activate changes` to have it consistent.