### PR TITLE
Add the timezone to the time output fomat

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -17,7 +17,7 @@ static const char* TAG = "FLOW POSTPROC";
 //#define SERIAL_DEBUG // testing debug on serial enabled
 
 
-#define PREVALUE_TIME_FORMAT_OUTPUT "%Y-%m-%dT%H:%M:%S"
+#define PREVALUE_TIME_FORMAT_OUTPUT "%Y-%m-%dT%H:%M:%S%z"
 #define PREVALUE_TIME_FORMAT_INPUT "%d-%d-%dT%d:%d:%d"
 
 

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -150,11 +150,7 @@ void MQTThomeassistantDiscovery() {
         // sendHomeAssistantDiscoveryTopic(group,   "rate",               "Rate (Unit/Minute)",               "swap-vertical",         "",        "",            "",                 ""); // Legacy, always Unit per Minute
         sendHomeAssistantDiscoveryTopic(group,   "rate_per_time_unit", "Rate (" + rateUnit + ")",          "swap-vertical",         rateUnit,  "",            "",                 "");        
         sendHomeAssistantDiscoveryTopic(group,   "rate_per_digitalization_round",  "Change since last digitalization round", "arrow-expand-vertical", valueUnit, "",            "measurement",      ""); // correctly the Unit is Uint/Interval!
-        /* The timestamp string misses the Timezone, see PREVALUE_TIME_FORMAT_OUTPUT!
-           We need to know the timezone and append it! Until we do this, we simply
-           do not set the device class to "timestamp" to avoid errors in Homeassistant! */
-        // sendHomeAssistantDiscoveryTopic(group,   "timestamp",       "Timestamp",                  "clock-time-eight-outline", "",        "timestamp",   "",                 "diagnostic");
-        sendHomeAssistantDiscoveryTopic(group,   "timestamp",          "Timestamp",                  "clock-time-eight-outline", "",        "",            "",                 "diagnostic");
+        sendHomeAssistantDiscoveryTopic(group,   "timestamp",          "Timestamp",                  "clock-time-eight-outline", "",        "timestamp",   "",                "diagnostic");
         sendHomeAssistantDiscoveryTopic(group,   "json",               "JSON",                       "code-json",                "",        "",            "",                 "diagnostic");
         sendHomeAssistantDiscoveryTopic(group,   "problem",            "Problem",                    "alert-outline",            "",        "",            "",                 ""); // Special binary sensor which is based on error topic
     }


### PR DESCRIPTION
See https://github.com/jomjol/AI-on-the-edge-device/issues/1428

This adds the timezone, eg. `+0100` to the formated time.
It also changes it for the data log:
```
2022-11-30T10:11:00+0100,main,0521.9167,521.9167,521.9167,0.000000,0.0000,no error,0.0,5.0,1.9,1.7,9.2,1.6,6.7,7.7
```

@jomjol Do you think this is ok?

The graph still works correctly


![grafik](https://user-images.githubusercontent.com/1783586/204793840-251fa4c1-e366-44af-b904-00bd3fadbf85.png)
