### PR TITLE
De-init camera on startup. This solves init errors in cause it was already initialized in a prevous run

### DIFF
--- a/code/components/jomjol_controlcamera/ClassControllCamera.cpp
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.cpp
@@ -675,6 +675,7 @@ esp_err_t CCamera::InitCam()
     ActualQuality = camera_config.jpeg_quality;
     ActualResolution = camera_config.frame_size;
     //initialize the camera
+    esp_camera_deinit(); // De-init in case it was already initialized
     esp_err_t err = esp_camera_init(&camera_config);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Camera Init Failed");


### PR DESCRIPTION
I have a device which always shows the "Camera Framebuffer cannot be initialized!" on a **restart**.
How ever on a cold start (power off -> power on) it is fine for one startup.
