### PR TITLE
Don't autofail if NTP server can't be reached during initalization

### DIFF
--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -214,7 +214,6 @@ extern "C" void app_main(void)
 
     if (!setup_time()) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "NTP Initialization failed!");
-        initSucessful = false;
     }
 
     setBootTime();


### PR DESCRIPTION
This fixes an issue with a restricted network without internet access, where the hardcoded ntp server can't be reached and thus the esp resets, as it's not able to finish initalization.

As far as I understand the code, the ntp servername get's only changed later (with reset_servername), it would probably be cooler if the ntp setting could be applied earlier.