### PR TITLE
Fix for securing wlan.ini

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -829,7 +829,7 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
             return ESP_FAIL;
         }
 
-        if (filename == 'wlan.ini') {
+        if (filename == "wlan.ini") {
             ESP_LOGE(TAG, "Trying to delete protected file : %s", filename);
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Not allowed to delete wlan.ini");
             return ESP_FAIL;

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -831,7 +831,7 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
 
         if (filename == "wlan.ini") {
             ESP_LOGE(TAG, "Trying to delete protected file : %s", filename);
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Not allowed to delete wlan.ini");
+            httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Not allowed to delete wlan.ini");
             return ESP_FAIL;
         }
 

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -829,6 +829,12 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
             return ESP_FAIL;
         }
 
+        if (filename == 'wlan.ini') {
+            ESP_LOGE(TAG, "Trying to delete protected file : %s", filename);
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Not allowed to delete wlan.ini");
+            return ESP_FAIL;
+        }
+
         if (stat(filepath, &file_stat) == -1) {
             ESP_LOGE(TAG, "File does not exist : %s", filename);
             /* Respond with 400 Bad Request */

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -829,7 +829,7 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
             return ESP_FAIL;
         }
 
-        if (filename == "wlan.ini") {
+        if (strcmp(filename, "wlan.ini") == 0) {
             ESP_LOGE(TAG, "Trying to delete protected file : %s", filename);
             httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Not allowed to delete wlan.ini");
             return ESP_FAIL;


### PR DESCRIPTION
This SHOULD prevent from deleting the wlan.ini file with URL request as of #1390 

Have not been able to test it properly..