### PR TITLE
Prevent auto restart on cam framebuffer init error

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -239,7 +239,7 @@ bool ClassFlowMQTT::doFlow(string zwtime)
     {
         std::vector<NumberPost*>* NUMBERS = flowpostprocessing->GetNumbers();
 
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Publishing MQTT topics...");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Publishing MQTT topics...");
 
         for (int i = 0; i < (*NUMBERS).size(); ++i)
         {

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -239,7 +239,7 @@ bool ClassFlowMQTT::doFlow(string zwtime)
     {
         std::vector<NumberPost*>* NUMBERS = flowpostprocessing->GetNumbers();
 
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Publishing MQTT topics...");
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Publishing MQTT topics...");
 
         for (int i = 0; i < (*NUMBERS).size(); ++i)
         {

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -255,7 +255,10 @@ extern "C" void app_main(void)
             camera_fb_t * fb = esp_camera_fb_get();
             if (!fb) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera Framebuffer cannot be initialized!");
-                initSucessful = false;
+                /* Easiest would be to simply restart here and try again,
+                   how ever there seem to be systems where it fails at startup but still work corectly later.
+                   Therefore we treat it still as successed!
+                   //initSucessful = false; */
             }
             else {
                 esp_camera_fb_return(fb);   


### PR DESCRIPTION
Note that we still restart after 5 minutes if the camera module failed to get initialized!

See https://github.com/jomjol/AI-on-the-edge-device/issues/1513