### PR TITLE
Block REST API calls till resource is ready

### DIFF
--- a/code/components/jomjol_controlcamera/ClassControllCamera.cpp
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.cpp
@@ -164,6 +164,7 @@ static size_t jpg_encode_stream(void * arg, size_t index, const void* data, size
     return len;
 }
 
+
 bool CCamera::SetBrightnessContrastSaturation(int _brightness, int _contrast, int _saturation)
 {
     bool result = false;
@@ -279,7 +280,6 @@ void CCamera::EnableAutoExposure(int flashdauer)
     isFixedExposure = true;
     waitbeforepicture_org = flashdauer;
 }
-
 
 
 esp_err_t CCamera::CaptureToBasisImage(CImageBasis *_Image, int delay)
@@ -543,6 +543,7 @@ esp_err_t CCamera::CaptureToHTTP(httpd_req_t *req, int delay)
     return res;
 }
 
+
 void CCamera::LightOnOff(bool status)
 {
     GpioHandler* gpioHandler = gpio_handler_get();
@@ -577,6 +578,7 @@ void CCamera::LightOnOff(bool status)
     #endif
     }
 }
+
 
 void CCamera::LEDOnOff(bool status)
 {
@@ -638,6 +640,7 @@ void CCamera::GetCameraParameter(httpd_req_t *req, int &qual, framesize_t &resol
     };
 }
 
+
 framesize_t CCamera::TextToFramesize(const char * _size)
 {
     if (strcmp(_size, "QVGA") == 0)
@@ -669,6 +672,7 @@ CCamera::CCamera()
     ledc_init();    
 }
 
+
 esp_err_t CCamera::InitCam()
 {
     ESP_LOGD(TAG, "Init Camera");
@@ -682,8 +686,10 @@ esp_err_t CCamera::InitCam()
         return err;
     }
 
+    CameraInitSuccessful = true;
     return ESP_OK;
 }
+
 
 void CCamera::SetLEDIntensity(float _intrel)
 {
@@ -693,4 +699,10 @@ void CCamera::SetLEDIntensity(float _intrel)
     led_intensity = (int) (_intrel * 8191);
     ESP_LOGD(TAG, "Set led_intensity to %d of 8191", led_intensity);
 
+}
+
+
+bool CCamera::getCameraInitSuccessful() 
+{
+    return CameraInitSuccessful;
 }

--- a/code/components/jomjol_controlcamera/ClassControllCamera.h
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.h
@@ -26,6 +26,7 @@ class CCamera {
         int led_intensity = 4095;
 
         void ledc_init(void);
+        bool CameraInitSuccessful = false;
 
     public:
         int image_height, image_width;
@@ -42,6 +43,7 @@ class CCamera {
         void SetLEDIntensity(float _intrel);
 
         void EnableAutoExposure(int flashdauer);
+        bool getCameraInitSuccessful();
         
 
         framesize_t TextToFramesize(const char * text);

--- a/code/components/jomjol_controlcamera/server_camera.cpp
+++ b/code/components/jomjol_controlcamera/server_camera.cpp
@@ -17,7 +17,8 @@ char scratch2[SCRATCH_BUFSIZE2];
 //#define DEBUG_DETAIL_ON   
 
 
-void PowerResetCamera(){
+void PowerResetCamera()
+{
         ESP_LOGD(TAG, "Resetting camera by power down line");
         gpio_config_t conf;
         conf.intr_type = GPIO_INTR_DISABLE;
@@ -37,182 +38,223 @@ void PowerResetCamera(){
 
 esp_err_t handler_lightOn(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_lightOn - Start");
-    ESP_LOGD(TAG, "handler_lightOn uri: %s", req->uri);
-#endif
+    #ifdef DEBUG_DETAIL_ON   
+        LogFile.WriteHeapInfo("handler_lightOn - Start");
+        ESP_LOGD(TAG, "handler_lightOn uri: %s", req->uri);
+    #endif
 
-    Camera.LightOnOff(true);
-    const char* resp_str = (const char*) req->user_ctx;
-    httpd_resp_send(req, resp_str, strlen(resp_str));  
+    if (Camera.getCameraInitSuccessful()) 
+    {
+        Camera.LightOnOff(true);
+        const char* resp_str = (const char*) req->user_ctx;
+        httpd_resp_send(req, resp_str, strlen(resp_str));
+    }
+    else 
+    {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        return ESP_ERR_NOT_FOUND;
+    }
 
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_lightOn - Done");
-#endif
+    #ifdef DEBUG_DETAIL_ON   
+        LogFile.WriteHeapInfo("handler_lightOn - Done");
+    #endif
 
     return ESP_OK;
-};
+}
+
 
 esp_err_t handler_lightOff(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_lightOff - Start");
-    ESP_LOGD(TAG, "handler_lightOff uri: %s", req->uri);
-#endif
-    Camera.LightOnOff(false);
-    const char* resp_str = (const char*) req->user_ctx;
-    httpd_resp_send(req, resp_str, strlen(resp_str));       
+    #ifdef DEBUG_DETAIL_ON   
+        LogFile.WriteHeapInfo("handler_lightOff - Start");
+        ESP_LOGD(TAG, "handler_lightOff uri: %s", req->uri);
+    #endif
 
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_lightOff - Done");
-#endif
+    if (Camera.getCameraInitSuccessful()) 
+    {
+        Camera.LightOnOff(false);
+        const char* resp_str = (const char*) req->user_ctx;
+        httpd_resp_send(req, resp_str, strlen(resp_str));       
+    }
+    else 
+    {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    #ifdef DEBUG_DETAIL_ON   
+        LogFile.WriteHeapInfo("handler_lightOff - Done");
+    #endif
 
     return ESP_OK;
-};
+}
+
 
 esp_err_t handler_capture(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_capture - Start");
-#endif
+    #ifdef DEBUG_DETAIL_ON   
+        LogFile.WriteHeapInfo("handler_capture - Start");
+    #endif
 
-    int quality;
-    framesize_t res;
+    if (Camera.getCameraInitSuccessful()) 
+    {
+        int quality;
+        framesize_t res;
 
-    Camera.GetCameraParameter(req, quality, res);
+        Camera.GetCameraParameter(req, quality, res);
 
-#ifdef DEBUG_DETAIL_ON   
-    ESP_LOGD(TAG, "Size: %d, Quality: %d", res, quality);
-#endif
+        #ifdef DEBUG_DETAIL_ON   
+            ESP_LOGD(TAG, "Size: %d, Quality: %d", res, quality);
+        #endif
 
-    Camera.SetQualitySize(quality, res);
+        Camera.SetQualitySize(quality, res);
 
-    esp_err_t ressult;
-    ressult = Camera.CaptureToHTTP(req);
+        esp_err_t result;
+        result = Camera.CaptureToHTTP(req);
 
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_capture - Done");
-#endif
+        #ifdef DEBUG_DETAIL_ON   
+            LogFile.WriteHeapInfo("handler_capture - Done");
+        #endif
 
-    return ressult;
-};
+        return result;
+    }
+        else 
+    {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        return ESP_ERR_NOT_FOUND;
+    }
+}
 
 
 esp_err_t handler_capture_with_ligth(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON  
-    LogFile.WriteHeapInfo("handler_capture_with_ligth - Start");
-#endif
-    char _query[100];
-    char _delay[10];
-
-    int quality;
-    framesize_t res;    
-    int delay = 2500;
-
-    if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
+    #ifdef DEBUG_DETAIL_ON  
+        LogFile.WriteHeapInfo("handler_capture_with_ligth - Start");
+    #endif
+    
+    if (Camera.getCameraInitSuccessful()) 
     {
-        ESP_LOGD(TAG, "Query: %s", _query);
-        if (httpd_query_key_value(_query, "delay", _delay, 10) == ESP_OK)
+        char _query[100];
+        char _delay[10];
+
+        int quality;
+        framesize_t res;    
+        int delay = 2500;
+
+        if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
         {
-#ifdef DEBUG_DETAIL_ON   
-            ESP_LOGD(TAG, "Delay: %s", _delay);
-#endif        
-            delay = atoi(_delay);
+            ESP_LOGD(TAG, "Query: %s", _query);
+            if (httpd_query_key_value(_query, "delay", _delay, 10) == ESP_OK)
+            {
+                #ifdef DEBUG_DETAIL_ON   
+                    ESP_LOGD(TAG, "Delay: %s", _delay);
+                #endif        
+                delay = atoi(_delay);
 
-            if (delay < 0)
-                delay = 0;
+                if (delay < 0)
+                    delay = 0;
+            }
         }
-    };
 
-    Camera.GetCameraParameter(req, quality, res);
+        Camera.GetCameraParameter(req, quality, res);
 
-#ifdef DEBUG_DETAIL_ON   
-    ESP_LOGD(TAG, "Size: %d, Quality: %d", res, quality);
-#endif
+        #ifdef DEBUG_DETAIL_ON   
+            ESP_LOGD(TAG, "Size: %d, Quality: %d", res, quality);
+        #endif
 
-    Camera.SetQualitySize(quality, res);
-    Camera.LightOnOff(true);
-    const TickType_t xDelay = delay / portTICK_PERIOD_MS;
-    vTaskDelay( xDelay );
+        Camera.SetQualitySize(quality, res);
+        Camera.LightOnOff(true);
+        const TickType_t xDelay = delay / portTICK_PERIOD_MS;
+        vTaskDelay( xDelay );
 
-    esp_err_t ressult;
-    ressult = Camera.CaptureToHTTP(req);  
+        esp_err_t result;
+        result = Camera.CaptureToHTTP(req);  
 
-    Camera.LightOnOff(false);
+        Camera.LightOnOff(false);
 
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_capture_with_ligth - Done");
-#endif
+        #ifdef DEBUG_DETAIL_ON   
+            LogFile.WriteHeapInfo("handler_capture_with_ligth - Done");
+        #endif
 
-    return ressult;
-};
-
+        return result;
+    }
+        else 
+    {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        return ESP_ERR_NOT_FOUND;
+    }
+}
 
 
 esp_err_t handler_capture_save_to_file(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_capture_save_to_file - Start");
-#endif
+    #ifdef DEBUG_DETAIL_ON   
+        LogFile.WriteHeapInfo("handler_capture_save_to_file - Start");
+    #endif
 
-    char _query[100];
-    char _delay[10];
-    int delay = 0;
-    char filename[100];
-    std::string fn = "/sdcard/";
-
-
-    int quality;
-    framesize_t res;    
-
-    if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
+    if (Camera.getCameraInitSuccessful()) 
     {
-        ESP_LOGD(TAG, "Query: %s", _query);
-        if (httpd_query_key_value(_query, "filename", filename, 100) == ESP_OK)
+        char _query[100];
+        char _delay[10];
+        int delay = 0;
+        char filename[100];
+        std::string fn = "/sdcard/";
+
+
+        int quality;
+        framesize_t res;    
+
+        if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
         {
-            fn.append(filename);
-#ifdef DEBUG_DETAIL_ON   
-            ESP_LOGD(TAG, "Filename: %s", fn.c_str());
-#endif
+            ESP_LOGD(TAG, "Query: %s", _query);
+            if (httpd_query_key_value(_query, "filename", filename, 100) == ESP_OK)
+            {
+                fn.append(filename);
+                #ifdef DEBUG_DETAIL_ON   
+                    ESP_LOGD(TAG, "Filename: %s", fn.c_str());
+                #endif
+            }
+            else
+                fn.append("noname.jpg");
+
+            if (httpd_query_key_value(_query, "delay", _delay, 10) == ESP_OK)
+            {
+                #ifdef DEBUG_DETAIL_ON   
+                    ESP_LOGD(TAG, "Delay: %s", _delay);
+                #endif
+                delay = atoi(_delay);
+
+                if (delay < 0)
+                    delay = 0;
+            }
         }
         else
             fn.append("noname.jpg");
 
-        if (httpd_query_key_value(_query, "delay", _delay, 10) == ESP_OK)
-        {
-#ifdef DEBUG_DETAIL_ON   
-            ESP_LOGD(TAG, "Delay: %s", _delay);
-#endif
-            delay = atoi(_delay);
+        Camera.GetCameraParameter(req, quality, res);
+        #ifdef DEBUG_DETAIL_ON   
+            ESP_LOGD(TAG, "Size: %d, Quality: %d", res, quality);
+        #endif
+        Camera.SetQualitySize(quality, res);
 
-            if (delay < 0)
-                delay = 0;
-        }
+        esp_err_t result;
+        result = Camera.CaptureToFile(fn, delay);  
 
+        const char* resp_str = (const char*) fn.c_str();
+        httpd_resp_send(req, resp_str, strlen(resp_str));
+
+        #ifdef DEBUG_DETAIL_ON   
+            LogFile.WriteHeapInfo("handler_capture_save_to_file - Done");
+        #endif
+
+        return result;
     }
-    else
-        fn.append("noname.jpg");
-
-    Camera.GetCameraParameter(req, quality, res);
-#ifdef DEBUG_DETAIL_ON   
-    ESP_LOGD(TAG, "Size: %d, Quality: %d", res, quality);
-#endif
-    Camera.SetQualitySize(quality, res);
-
-    esp_err_t ressult;
-    ressult = Camera.CaptureToFile(fn, delay);  
-
-    const char* resp_str = (const char*) fn.c_str();
-    httpd_resp_send(req, resp_str, strlen(resp_str));  
-  
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_capture_save_to_file - Done");
-#endif
-
-    return ressult;
-};
-
+    else 
+    {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        return ESP_ERR_NOT_FOUND;
+    }
+}
 
 
 void register_server_camera_uri(httpd_handle_t server)

--- a/code/components/jomjol_controlcamera/server_camera.cpp
+++ b/code/components/jomjol_controlcamera/server_camera.cpp
@@ -78,7 +78,7 @@ esp_err_t handler_lightOff(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera light Off API not yet initialized. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Light Off API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }
 
@@ -120,7 +120,7 @@ esp_err_t handler_capture(httpd_req_t *req)
     }
         else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera capture API not yet initialized. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Capture API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }
 }
@@ -180,7 +180,7 @@ esp_err_t handler_capture_with_ligth(httpd_req_t *req)
     }
         else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera capture + flashlight API not yet initialized. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Capture + flashlight API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }
 }
@@ -251,7 +251,7 @@ esp_err_t handler_capture_save_to_file(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera capture + save API not yet initialized. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Capture + save API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }
 }

--- a/code/components/jomjol_controlcamera/server_camera.cpp
+++ b/code/components/jomjol_controlcamera/server_camera.cpp
@@ -51,7 +51,7 @@ esp_err_t handler_lightOn(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Light On API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }
 
@@ -78,7 +78,7 @@ esp_err_t handler_lightOff(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera light Off API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }
 
@@ -120,7 +120,7 @@ esp_err_t handler_capture(httpd_req_t *req)
     }
         else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera capture API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }
 }
@@ -180,7 +180,7 @@ esp_err_t handler_capture_with_ligth(httpd_req_t *req)
     }
         else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera capture + flashlight API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }
 }
@@ -251,7 +251,7 @@ esp_err_t handler_capture_save_to_file(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not yet fully initialized. Please retry later.");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera capture + save API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }
 }

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -31,7 +31,7 @@ ClassFlowControll tfliteflow;
 TaskHandle_t xHandleblink_task_doFlow = NULL;
 TaskHandle_t xHandletask_autodoFlow = NULL;
 
-bool flowisrunning = false;
+static bool flowisrunning = false;
 
 long auto_intervall = 0;
 bool auto_isrunning = false;
@@ -225,7 +225,8 @@ esp_err_t handler_json(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Service not yet fully initialized. Please retry later.");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "JSON API not yet initialized. Please retry later...");
+        return ESP_ERR_NOT_FOUND;
     }
 
     #ifdef DEBUG_DETAIL_ON       
@@ -377,7 +378,8 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Service not yet fully initialized. Please retry later.");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Value API not yet initialized. Please retry later...");
+        return ESP_ERR_NOT_FOUND;
     }
 
     #ifdef DEBUG_DETAIL_ON       
@@ -613,7 +615,8 @@ esp_err_t handler_statusflow(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Flow not yet fully started. Please retry later.");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Flow status API not yet started. Please retry later...");
+        return ESP_ERR_NOT_FOUND;
     }  
 
     #ifdef DEBUG_DETAIL_ON       
@@ -672,7 +675,8 @@ esp_err_t handler_rssi(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Service not yet fully initialized. Please retry later.");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "RSSI API not yet initialized. Please retry later...");
+        return ESP_ERR_NOT_FOUND;
     }      
 
     #ifdef DEBUG_DETAIL_ON       

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -103,6 +103,7 @@ void doInit(void)
         ESP_LOGD(TAG, "Start tfliteflow.InitFlow(config);");
     #endif
     tfliteflow.InitFlow(CONFIG_FILE);
+    FlowInitDone = true;
     #ifdef DEBUG_DETAIL_ON      
         ESP_LOGD(TAG, "Finished tfliteflow.InitFlow(config);");
     #endif
@@ -110,13 +111,11 @@ void doInit(void)
     #ifdef ENABLE_MQTT
         tfliteflow.StartMQTTService();
     #endif //ENABLE_MQTT
-    FlowInitDone = true;
 }
 
 
 bool doflow(void)
-{
-    
+{   
     std::string zw_time = gettimestring(LOGFILE_TIME_FORMAT);
     ESP_LOGD(TAG, "doflow - start %s", zw_time.c_str());
     flowisrunning = true;
@@ -617,7 +616,7 @@ esp_err_t handler_statusflow(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Flow status API not yet started. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Flowstatus API not yet initialized. Please retry later...");
         return ESP_ERR_NOT_FOUND;
     }  
 

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -31,7 +31,8 @@ ClassFlowControll tfliteflow;
 TaskHandle_t xHandleblink_task_doFlow = NULL;
 TaskHandle_t xHandletask_autodoFlow = NULL;
 
-static bool flowisrunning = false;
+bool FlowInitDone = false;
+bool flowisrunning = false;
 
 long auto_intervall = 0;
 bool auto_isrunning = false;
@@ -109,6 +110,7 @@ void doInit(void)
     #ifdef ENABLE_MQTT
         tfliteflow.StartMQTTService();
     #endif //ENABLE_MQTT
+    FlowInitDone = true;
 }
 
 
@@ -208,7 +210,7 @@ esp_err_t handler_json(httpd_req_t *req)
 
     ESP_LOGD(TAG, "handler_JSON uri: %s", req->uri);
     
-    if (flowisrunning) 
+    if (FlowInitDone) 
     {
         httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
         httpd_resp_set_type(req, "application/json");
@@ -242,7 +244,7 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
         LogFile.WriteHeapInfo("handler_wasserzaehler - Start");    
     #endif
 
-    if (flowisrunning) 
+    if (FlowInitDone) 
     {
         bool _rawValue = false;
         bool _noerror = false;
@@ -597,7 +599,7 @@ esp_err_t handler_statusflow(httpd_req_t *req)
         LogFile.WriteHeapInfo("handler_prevalue - Start");       
     #endif
 
-    if (flowisrunning) 
+    if (FlowInitDone) 
     {
         const char* resp_str;
 
@@ -664,7 +666,7 @@ esp_err_t handler_rssi(httpd_req_t *req)
         const char* resp_str;
         char rssi[20];
 
-    sprintf(rssi, "%idBm", get_WIFI_RSSI());
+        sprintf(rssi, "%idBm", get_WIFI_RSSI());
 
         resp_str = rssi;
 

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -47,16 +47,17 @@ int getCountFlowRounds() {
 }
 
 
-
 esp_err_t GetJPG(std::string _filename, httpd_req_t *req)
 {
     return tfliteflow.GetJPGStream(_filename, req);
 }
 
+
 esp_err_t GetRawJPG(httpd_req_t *req)
 {
     return tfliteflow.SendRawJPG(req);
 }
+
 
 bool isSetupModusActive() {
     return tfliteflow.getStatusSetupModus();
@@ -66,47 +67,48 @@ bool isSetupModusActive() {
 
 void KillTFliteTasks()
 {
-#ifdef DEBUG_DETAIL_ON          
-    ESP_LOGD(TAG, "Handle: xHandleblink_task_doFlow: %ld", (long) xHandleblink_task_doFlow);
-#endif  
+    #ifdef DEBUG_DETAIL_ON          
+        ESP_LOGD(TAG, "Handle: xHandleblink_task_doFlow: %ld", (long) xHandleblink_task_doFlow);
+    #endif  
     if (xHandleblink_task_doFlow != NULL)
     {
         TaskHandle_t xHandleblink_task_doFlowTmp = xHandleblink_task_doFlow;
         xHandleblink_task_doFlow = NULL;
         vTaskDelete(xHandleblink_task_doFlowTmp);
-#ifdef DEBUG_DETAIL_ON      
-        ESP_LOGD(TAG, "Killed: xHandleblink_task_doFlow");
-#endif
+        #ifdef DEBUG_DETAIL_ON      
+            ESP_LOGD(TAG, "Killed: xHandleblink_task_doFlow");
+        #endif
     }
 
-#ifdef DEBUG_DETAIL_ON      
-    ESP_LOGD(TAG, "Handle: xHandletask_autodoFlow: %ld", (long) xHandletask_autodoFlow);
-#endif
+    #ifdef DEBUG_DETAIL_ON      
+        ESP_LOGD(TAG, "Handle: xHandletask_autodoFlow: %ld", (long) xHandletask_autodoFlow);
+    #endif
     if (xHandletask_autodoFlow != NULL)
     {
         TaskHandle_t xHandletask_autodoFlowTmp = xHandletask_autodoFlow;
         xHandletask_autodoFlow = NULL;
         vTaskDelete(xHandletask_autodoFlowTmp);
-#ifdef DEBUG_DETAIL_ON      
-        ESP_LOGD(TAG, "Killed: xHandletask_autodoFlow");
-#endif
+        #ifdef DEBUG_DETAIL_ON      
+            ESP_LOGD(TAG, "Killed: xHandletask_autodoFlow");
+        #endif
     }
 
 }
 
+
 void doInit(void)
 {
-#ifdef DEBUG_DETAIL_ON             
-    ESP_LOGD(TAG, "Start tfliteflow.InitFlow(config);");
-#endif
+    #ifdef DEBUG_DETAIL_ON             
+        ESP_LOGD(TAG, "Start tfliteflow.InitFlow(config);");
+    #endif
     tfliteflow.InitFlow(CONFIG_FILE);
-#ifdef DEBUG_DETAIL_ON      
-    ESP_LOGD(TAG, "Finished tfliteflow.InitFlow(config);");
-#endif
+    #ifdef DEBUG_DETAIL_ON      
+        ESP_LOGD(TAG, "Finished tfliteflow.InitFlow(config);");
+    #endif
     
-#ifdef ENABLE_MQTT
-    tfliteflow.StartMQTTService();
-#endif //ENABLE_MQTT
+    #ifdef ENABLE_MQTT
+        tfliteflow.StartMQTTService();
+    #endif //ENABLE_MQTT
 }
 
 
@@ -119,17 +121,18 @@ bool doflow(void)
     tfliteflow.doFlow(zw_time);
     flowisrunning = false;
 
-#ifdef DEBUG_DETAIL_ON      
-    ESP_LOGD(TAG, "doflow - end %s", zw_time.c_str());
-#endif    
+    #ifdef DEBUG_DETAIL_ON      
+        ESP_LOGD(TAG, "doflow - end %s", zw_time.c_str());
+    #endif    
     return true;
 }
 
+
 void blink_task_doFlow(void *pvParameter)
 {
-#ifdef DEBUG_DETAIL_ON          
-    ESP_LOGD(TAG, "blink_task_doFlow");
-#endif
+    #ifdef DEBUG_DETAIL_ON          
+        ESP_LOGD(TAG, "blink_task_doFlow");
+    #endif
     if (!flowisrunning)
     {
         flowisrunning = true;
@@ -143,10 +146,10 @@ void blink_task_doFlow(void *pvParameter)
 
 esp_err_t handler_init(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON      
-    LogFile.WriteHeapInfo("handler_init - Start");       
-    ESP_LOGD(TAG, "handler_doinit uri: %s", req->uri);
-#endif
+    #ifdef DEBUG_DETAIL_ON      
+        LogFile.WriteHeapInfo("handler_init - Start");       
+        ESP_LOGD(TAG, "handler_doinit uri: %s", req->uri);
+    #endif
 
     const char* resp_str = "Init started<br>";
     httpd_resp_send(req, resp_str, strlen(resp_str));     
@@ -158,18 +161,19 @@ esp_err_t handler_init(httpd_req_t *req)
     /* Respond with an empty chunk to signal HTTP response completion */
     httpd_resp_send_chunk(req, NULL, 0);    
 
-#ifdef DEBUG_DETAIL_ON      
-    LogFile.WriteHeapInfo("handler_init - Done");       
-#endif
+    #ifdef DEBUG_DETAIL_ON      
+        LogFile.WriteHeapInfo("handler_init - Done");       
+    #endif
 
     return ESP_OK;
-};
+}
+
 
 esp_err_t handler_doflow(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON          
-    LogFile.WriteHeapInfo("handler_doflow - Start");       
-#endif
+    #ifdef DEBUG_DETAIL_ON          
+        LogFile.WriteHeapInfo("handler_doflow - Start");       
+    #endif
 
     ESP_LOGD(TAG, "handler_doFlow uri: %s", req->uri);
 
@@ -188,199 +192,206 @@ esp_err_t handler_doflow(httpd_req_t *req)
     /* Respond with an empty chunk to signal HTTP response completion */
     httpd_resp_send_chunk(req, NULL, 0);       
 
-#ifdef DEBUG_DETAIL_ON   
-    LogFile.WriteHeapInfo("handler_doflow - Done");       
-#endif
+    #ifdef DEBUG_DETAIL_ON   
+        LogFile.WriteHeapInfo("handler_doflow - Done");       
+    #endif
 
     return ESP_OK;
-};
+}
 
 
 esp_err_t handler_json(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_json - Start");    
-#endif
-
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_json - Start");    
+    #endif
 
     ESP_LOGD(TAG, "handler_JSON uri: %s", req->uri);
-
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_type(req, "application/json");
-
-    std::string zw = tfliteflow.getJSON();
-    if (zw.length() > 0)
+    
+    if (flowisrunning) 
     {
-        httpd_resp_send(req, zw.c_str(), zw.length());
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+        httpd_resp_set_type(req, "application/json");
+
+        std::string zw = tfliteflow.getJSON();
+        if (zw.length() > 0) 
+        {
+            httpd_resp_send(req, zw.c_str(), zw.length());
+        }
+        else 
+        {
+            httpd_resp_send(req, NULL, 0);
+        }
     }
-    else
+    else 
     {
-        httpd_resp_send(req, NULL, 0);
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Service not yet fully initialized. Please retry later.");
     }
 
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_JSON - Done");   
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_JSON - Done");   
+    #endif
     return ESP_OK;
-};
-
+}
 
 
 esp_err_t handler_wasserzaehler(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_wasserzaehler - Start");    
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_wasserzaehler - Start");    
+    #endif
 
-    bool _rawValue = false;
-    bool _noerror = false;
-    bool _all = false;
-    std::string _type = "value";
-    string zw;
-
-    ESP_LOGD(TAG, "handler_wasserzaehler uri: %s", req->uri);
-
-    char _query[100];
-    char _size[10];
-
-    if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
+    if (flowisrunning) 
     {
-//        ESP_LOGD(TAG, "Query: %s", _query);
-        if (httpd_query_key_value(_query, "all", _size, 10) == ESP_OK)
+        bool _rawValue = false;
+        bool _noerror = false;
+        bool _all = false;
+        std::string _type = "value";
+        string zw;
+
+        ESP_LOGD(TAG, "handler_wasserzaehler uri: %s", req->uri);
+
+        char _query[100];
+        char _size[10];
+
+        if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
         {
-#ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAG, "all is found%s", _size);
-#endif
-            _all = true;
+    //        ESP_LOGD(TAG, "Query: %s", _query);
+            if (httpd_query_key_value(_query, "all", _size, 10) == ESP_OK)
+            {
+                #ifdef DEBUG_DETAIL_ON       
+                    ESP_LOGD(TAG, "all is found%s", _size);
+                #endif
+                _all = true;
+            }
+
+            if (httpd_query_key_value(_query, "type", _size, 10) == ESP_OK)
+            {
+                #ifdef DEBUG_DETAIL_ON       
+                    ESP_LOGD(TAG, "all is found: %s", _size);
+                #endif
+                _type = std::string(_size);
+            }
+
+            if (httpd_query_key_value(_query, "rawvalue", _size, 10) == ESP_OK)
+            {
+                #ifdef DEBUG_DETAIL_ON       
+                    ESP_LOGD(TAG, "rawvalue is found: %s", _size);
+                #endif
+                _rawValue = true;
+            }
+            if (httpd_query_key_value(_query, "noerror", _size, 10) == ESP_OK)
+            {
+                #ifdef DEBUG_DETAIL_ON       
+                    ESP_LOGD(TAG, "noerror is found: %s", _size);
+                #endif
+                _noerror = true;
+            }        
+        }  
+
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+
+        if (_all)
+        {
+            httpd_resp_set_type(req, "text/plain");
+            ESP_LOGD(TAG, "TYPE: %s", _type.c_str());
+            int _intype = READOUT_TYPE_VALUE;
+            if (_type == "prevalue")
+                _intype = READOUT_TYPE_PREVALUE;
+            if (_type == "raw")
+                _intype = READOUT_TYPE_RAWVALUE;
+            if (_type == "error")
+                _intype = READOUT_TYPE_ERROR;
+
+
+            zw = tfliteflow.getReadoutAll(_intype);
+            ESP_LOGD(TAG, "ZW: %s", zw.c_str());
+            if (zw.length() > 0)
+                httpd_resp_sendstr_chunk(req, zw.c_str()); 
+            httpd_resp_sendstr_chunk(req, NULL);   
+            return ESP_OK;
         }
 
-        if (httpd_query_key_value(_query, "type", _size, 10) == ESP_OK)
-        {
-#ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAG, "all is found: %s", _size);
-#endif
-            _type = std::string(_size);
-        }
-
-        if (httpd_query_key_value(_query, "rawvalue", _size, 10) == ESP_OK)
-        {
-#ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAG, "rawvalue is found: %s", _size);
-#endif
-            _rawValue = true;
-        }
-        if (httpd_query_key_value(_query, "noerror", _size, 10) == ESP_OK)
-        {
-#ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAG, "noerror is found: %s", _size);
-#endif
-            _noerror = true;
-        }        
-    }  
-
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-
-    if (_all)
-    {
-        httpd_resp_set_type(req, "text/plain");
-        ESP_LOGD(TAG, "TYPE: %s", _type.c_str());
-        int _intype = READOUT_TYPE_VALUE;
-        if (_type == "prevalue")
-            _intype = READOUT_TYPE_PREVALUE;
-        if (_type == "raw")
-            _intype = READOUT_TYPE_RAWVALUE;
-        if (_type == "error")
-            _intype = READOUT_TYPE_ERROR;
-
-
-        zw = tfliteflow.getReadoutAll(_intype);
-        ESP_LOGD(TAG, "ZW: %s", zw.c_str());
+        zw = tfliteflow.getReadout(_rawValue, _noerror);
         if (zw.length() > 0)
             httpd_resp_sendstr_chunk(req, zw.c_str()); 
-        httpd_resp_sendstr_chunk(req, NULL);   
-        return ESP_OK;
-    }
 
-    zw = tfliteflow.getReadout(_rawValue, _noerror);
-    if (zw.length() > 0)
-        httpd_resp_sendstr_chunk(req, zw.c_str()); 
-
-    string query = std::string(_query);
-//    ESP_LOGD(TAG, "Query: %s, query.c_str());
-    if (query.find("full") != std::string::npos)
-    {
-        string txt, zw;
-        
-        txt = "<p>Aligned Image: <p><img src=\"/img_tmp/alg_roi.jpg\"> <p>\n";
-        txt = txt + "Digital Counter: <p> ";
-        httpd_resp_sendstr_chunk(req, txt.c_str()); 
-        
-        std::vector<HTMLInfo*> htmlinfodig;
-        htmlinfodig = tfliteflow.GetAllDigital();  
-
-        for (int i = 0; i < htmlinfodig.size(); ++i)
+        string query = std::string(_query);
+    //    ESP_LOGD(TAG, "Query: %s, query.c_str());
+        if (query.find("full") != std::string::npos)
         {
-            if (tfliteflow.GetTypeDigital() == Digital)
-            {
-                if (htmlinfodig[i]->val == 10)
-                    zw = "NaN";
-                else
-                    zw = to_string((int) htmlinfodig[i]->val);
+            string txt, zw;
+            
+            txt = "<p>Aligned Image: <p><img src=\"/img_tmp/alg_roi.jpg\"> <p>\n";
+            txt = txt + "Digital Counter: <p> ";
+            httpd_resp_sendstr_chunk(req, txt.c_str()); 
+            
+            std::vector<HTMLInfo*> htmlinfodig;
+            htmlinfodig = tfliteflow.GetAllDigital();  
 
-                txt = "<img src=\"/img_tmp/" +  htmlinfodig[i]->filename + "\"> " + zw;
+            for (int i = 0; i < htmlinfodig.size(); ++i)
+            {
+                if (tfliteflow.GetTypeDigital() == Digital)
+                {
+                    if (htmlinfodig[i]->val == 10)
+                        zw = "NaN";
+                    else
+                        zw = to_string((int) htmlinfodig[i]->val);
+
+                    txt = "<img src=\"/img_tmp/" +  htmlinfodig[i]->filename + "\"> " + zw;
+                }
+                else
+                {
+                    std::stringstream stream;
+                    stream << std::fixed << std::setprecision(1) << htmlinfodig[i]->val;
+                    zw = stream.str();
+
+                    txt = "<img src=\"/img_tmp/" +  htmlinfodig[i]->filename + "\"> " + zw;
+                }
+                httpd_resp_sendstr_chunk(req, txt.c_str()); 
+                delete htmlinfodig[i];
             }
-            else
+            htmlinfodig.clear();
+        
+            txt = " <p> Analog Meter: <p> ";
+            httpd_resp_sendstr_chunk(req, txt.c_str()); 
+            
+            std::vector<HTMLInfo*> htmlinfoana;
+            htmlinfoana = tfliteflow.GetAllAnalog();
+            for (int i = 0; i < htmlinfoana.size(); ++i)
             {
                 std::stringstream stream;
-                stream << std::fixed << std::setprecision(1) << htmlinfodig[i]->val;
+                stream << std::fixed << std::setprecision(1) << htmlinfoana[i]->val;
                 zw = stream.str();
 
-                txt = "<img src=\"/img_tmp/" +  htmlinfodig[i]->filename + "\"> " + zw;
+                txt = "<img src=\"/img_tmp/" +  htmlinfoana[i]->filename + "\"> " + zw;
+                httpd_resp_sendstr_chunk(req, txt.c_str()); 
+                delete htmlinfoana[i];
             }
-            httpd_resp_sendstr_chunk(req, txt.c_str()); 
-            delete htmlinfodig[i];
-        }
-        htmlinfodig.clear();
-      
-        txt = " <p> Analog Meter: <p> ";
-        httpd_resp_sendstr_chunk(req, txt.c_str()); 
-        
-        std::vector<HTMLInfo*> htmlinfoana;
-        htmlinfoana = tfliteflow.GetAllAnalog();
-        for (int i = 0; i < htmlinfoana.size(); ++i)
-        {
-            std::stringstream stream;
-            stream << std::fixed << std::setprecision(1) << htmlinfoana[i]->val;
-            zw = stream.str();
+            htmlinfoana.clear();   
 
-            txt = "<img src=\"/img_tmp/" +  htmlinfoana[i]->filename + "\"> " + zw;
-            httpd_resp_sendstr_chunk(req, txt.c_str()); 
-            delete htmlinfoana[i];
-        }
-        htmlinfoana.clear();   
+        }   
 
-    }   
+        /* Respond with an empty chunk to signal HTTP response completion */
+        httpd_resp_sendstr_chunk(req, NULL);   
+    }
+    else 
+    {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Service not yet fully initialized. Please retry later.");
+    }
 
-  
-
-
-
-
-    /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_sendstr_chunk(req, NULL);   
-
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_wasserzaehler - Done");   
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_wasserzaehler - Done");   
+    #endif
     return ESP_OK;
-};
+}
 
 
 esp_err_t handler_editflow(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_editflow - Start");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_editflow - Start");       
+    #endif
 
     ESP_LOGD(TAG, "handler_editflow uri: %s", req->uri);
 
@@ -392,9 +403,9 @@ esp_err_t handler_editflow(httpd_req_t *req)
     {
         if (httpd_query_key_value(_query, "task", _valuechar, 30) == ESP_OK)
         {
-#ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAG, "task is found: %s", _valuechar);
-#endif
+            #ifdef DEBUG_DETAIL_ON       
+                ESP_LOGD(TAG, "task is found: %s", _valuechar);
+            #endif
             _task = string(_valuechar);
         }
     }  
@@ -427,10 +438,10 @@ esp_err_t handler_editflow(httpd_req_t *req)
         httpd_query_key_value(_query, "out", _valuechar, 30);         
         out = string(_valuechar);  
 
-#ifdef DEBUG_DETAIL_ON       
-        ESP_LOGD(TAG, "in: %s", in.c_str());
-        ESP_LOGD(TAG, "out: %s", out.c_str());
-#endif
+        #ifdef DEBUG_DETAIL_ON       
+            ESP_LOGD(TAG, "in: %s", in.c_str());
+            ESP_LOGD(TAG, "out: %s", out.c_str());
+        #endif
 
         in = "/sdcard" + in;
         out = "/sdcard" + out;
@@ -469,14 +480,14 @@ esp_err_t handler_editflow(httpd_req_t *req)
         zw = string(_valuechar);  
         dy = stoi(zw);          
 
-#ifdef DEBUG_DETAIL_ON       
-        ESP_LOGD(TAG, "in: %s", in.c_str());
-        ESP_LOGD(TAG, "out: %s", out.c_str());
-        ESP_LOGD(TAG, "x: %s", zw.c_str());
-        ESP_LOGD(TAG, "y: %s", zw.c_str());
-        ESP_LOGD(TAG, "dx: %s", zw.c_str());
-        ESP_LOGD(TAG, "dy: %s", zw.c_str());
-#endif
+        #ifdef DEBUG_DETAIL_ON       
+            ESP_LOGD(TAG, "in: %s", in.c_str());
+            ESP_LOGD(TAG, "out: %s", out.c_str());
+            ESP_LOGD(TAG, "x: %s", zw.c_str());
+            ESP_LOGD(TAG, "y: %s", zw.c_str());
+            ESP_LOGD(TAG, "dx: %s", zw.c_str());
+            ESP_LOGD(TAG, "dy: %s", zw.c_str());
+        #endif
 
         if (httpd_query_key_value(_query, "enhance", _valuechar, 10) == ESP_OK)
         {
@@ -570,46 +581,54 @@ esp_err_t handler_editflow(httpd_req_t *req)
     /* Respond with an empty chunk to signal HTTP response completion */
     httpd_resp_sendstr_chunk(req, NULL);   
 
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_editflow - Done");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_editflow - Done");       
+    #endif
 
     return ESP_OK;
-};
+}
 
 
 esp_err_t handler_statusflow(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_prevalue - Start");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_prevalue - Start");       
+    #endif
 
-    const char* resp_str;
+    if (flowisrunning) 
+    {
+        const char* resp_str;
 
-#ifdef DEBUG_DETAIL_ON       
-    ESP_LOGD(TAG, "handler_prevalue: %s", req->uri);
-#endif
+        #ifdef DEBUG_DETAIL_ON       
+            ESP_LOGD(TAG, "handler_prevalue: %s", req->uri);
+        #endif
 
-    string* zw = tfliteflow.getActStatus();
-    resp_str = zw->c_str();
+        string* zw = tfliteflow.getActStatus();
+        resp_str = zw->c_str();
 
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_send(req, resp_str, strlen(resp_str));   
-    /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_send_chunk(req, NULL, 0);      
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+        httpd_resp_send(req, resp_str, strlen(resp_str));   
+        /* Respond with an empty chunk to signal HTTP response completion */
+        httpd_resp_send_chunk(req, NULL, 0); 
+    }
+    else 
+    {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Flow not yet fully started. Please retry later.");
+    }  
 
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_prevalue - Start");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_prevalue - Done");       
+    #endif
 
     return ESP_OK;
-};
+}
+
 
 esp_err_t handler_cputemp(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_cputemp - Start");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_cputemp - Start");       
+    #endif
 
     const char* resp_str;
     char cputemp[20];
@@ -621,39 +640,47 @@ esp_err_t handler_cputemp(httpd_req_t *req)
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
     httpd_resp_send(req, resp_str, strlen(resp_str));   
     /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_send_chunk(req, NULL, 0);      
+    httpd_resp_send_chunk(req, NULL, 0);  
 
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_cputemp - End");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_cputemp - End");       
+    #endif
 
     return ESP_OK;
-};
+}
+
 
 esp_err_t handler_rssi(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_rssi - Start");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_rssi - Start");       
+    #endif
 
-    const char* resp_str;
-    char rssi[20];
+    if (getWIFIisConnected()) 
+    {
+        const char* resp_str;
+        char rssi[20];
 
     sprintf(rssi, "%idBm", get_WIFI_RSSI());
 
-    resp_str = rssi;
+        resp_str = rssi;
 
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_send(req, resp_str, strlen(resp_str));   
-    /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_send_chunk(req, NULL, 0);      
+        httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+        httpd_resp_send(req, resp_str, strlen(resp_str));   
+        /* Respond with an empty chunk to signal HTTP response completion */
+        httpd_resp_send_chunk(req, NULL, 0);
+    }
+    else 
+    {
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Service not yet fully initialized. Please retry later.");
+    }      
 
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_rssi - End");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_rssi - End");       
+    #endif
 
     return ESP_OK;
-};
+}
 
 
 esp_err_t handler_uptime(httpd_req_t *req)
@@ -680,16 +707,16 @@ esp_err_t handler_uptime(httpd_req_t *req)
 
 esp_err_t handler_prevalue(httpd_req_t *req)
 {
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_prevalue - Start");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_prevalue - Start");       
+    #endif
 
     const char* resp_str;
     string zw;
 
-#ifdef DEBUG_DETAIL_ON       
-    ESP_LOGD(TAG, "handler_prevalue: %s", req->uri);
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        ESP_LOGD(TAG, "handler_prevalue: %s", req->uri);
+    #endif
 
     char _query[100];
     char _size[10] = "";
@@ -697,15 +724,15 @@ esp_err_t handler_prevalue(httpd_req_t *req)
 
     if (httpd_req_get_url_query_str(req, _query, 100) == ESP_OK)
     {
-#ifdef DEBUG_DETAIL_ON       
-        ESP_LOGD(TAG, "Query: %s", _query);
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+            ESP_LOGD(TAG, "Query: %s", _query);
+    #endif
 
         if (httpd_query_key_value(_query, "value", _size, 10) == ESP_OK)
         {
-#ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAG, "Value: %s", _size);
-#endif
+            #ifdef DEBUG_DETAIL_ON       
+                ESP_LOGD(TAG, "Value: %s", _size);
+            #endif
         }
 
         httpd_query_key_value(_query, "numbers", _numbers, 50);
@@ -729,12 +756,13 @@ esp_err_t handler_prevalue(httpd_req_t *req)
     /* Respond with an empty chunk to signal HTTP response completion */
     httpd_resp_send_chunk(req, NULL, 0);      
 
-#ifdef DEBUG_DETAIL_ON       
-    LogFile.WriteHeapInfo("handler_prevalue - End");       
-#endif
+    #ifdef DEBUG_DETAIL_ON       
+        LogFile.WriteHeapInfo("handler_prevalue - End");       
+    #endif
 
     return ESP_OK;
-};
+}
+
 
 void task_autodoFlow(void *pvParameter)
 {
@@ -768,20 +796,20 @@ void task_autodoFlow(void *pvParameter)
 
         if (flowisrunning)
         {
-#ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAG, "Autoflow: doFlow is already running!");
-#endif
+            #ifdef DEBUG_DETAIL_ON       
+                ESP_LOGD(TAG, "Autoflow: doFlow is already running!");
+            #endif
         }
         else
         {
-#ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAG, "Autoflow: doFlow is started");
-#endif
+            #ifdef DEBUG_DETAIL_ON       
+                ESP_LOGD(TAG, "Autoflow: doFlow is started");
+            #endif
             flowisrunning = true;
             doflow();
-#ifdef DEBUG_DETAIL_ON       
-            ESP_LOGD(TAG, "Remove older log files");
-#endif
+            #ifdef DEBUG_DETAIL_ON       
+                ESP_LOGD(TAG, "Remove older log files");
+            #endif
             LogFile.RemoveOldLogFile();
             LogFile.RemoveOldDataLog();
         }
@@ -808,6 +836,7 @@ void task_autodoFlow(void *pvParameter)
     ESP_LOGD(TAG, "task_autodoFlow: end");
 }
 
+
 void TFliteDoAutoStart()
 {
     BaseType_t xReturned;
@@ -825,9 +854,8 @@ void TFliteDoAutoStart()
        ESP_LOGD(TAG, "ERROR task_autodoFlow konnte nicht erzeugt werden!");
     }
     ESP_LOGD(TAG, "getESPHeapInfo: %s", getESPHeapInfo().c_str());
-
-
 }
+
 
 #ifdef ENABLE_MQTT
 std::string GetMQTTMainTopic()


### PR DESCRIPTION
Fix for #1574:

- Block REST API calls until needed resource is ready to use --> prevent unhandled execption and crash of device

@caco3, @jomjol:
Which HTML error code should to be returned in such a case? --> HTTPD_403_FORBIDDEN?
Is it even better to return no error code?