### PR TITLE
Update defines.h for rolling

### DIFF
--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -83,7 +83,7 @@
     //#define STB_IMAGE_IMPLEMENTATION
     //#define STB_IMAGE_WRITE_IMPLEMENTATION
     //#define STB_IMAGE_RESIZE_IMPLEMENTATION
-    #define STBI_ONLY_JPEG //added 17.12.2022 (save 2% of Flash)
+    //#define STBI_ONLY_JPEG // (save 2% of Flash)
 
     //interface_influxdb
     #define MAX_HTTP_OUTPUT_BUFFER 2048
@@ -119,14 +119,6 @@
     #define Digital_Transition_Area_Predecessor 0.7 // 9.3 - 0.7
     #define Digital_Transition_Area_Forward 9.7 // Pre-run zero crossing only happens from approx. 9.7 onwards
 
-
-    #define AnalogFehler 3
-    #define AnalogToDigtalFehler 0.8
-    #define DigitalUnschaerfe 0.2
-    #define DigitalBand 3
-    #define DigitalAnalogerVorgaengerUebergangsbereich 2
-    #define DigitalUebergangsbereichVorgaenger 0.7 // 9.3 - 0.7
-    #define DigitalUebergangsbereichVorlauf 9.7 // Pre-run zero crossing only happens from approx. 9.7 onwards
 
     //#define DEBUG_DETAIL_ON 
 


### PR DESCRIPTION
comment `#define STBI_ONLY_JPEG` as you do no want it in rolling but in rolling-minimize-firmware-size

delete old reference to DE :

``` #define AnalogFehler 3
    #define AnalogToDigtalFehler 0.8
    #define DigitalUnschaerfe 0.2
    #define DigitalBand 3
    #define DigitalAnalogerVorgaengerUebergangsbereich 2
    #define DigitalUebergangsbereichVorgaenger 0.7 // 9.3 - 0.7
    #define DigitalUebergangsbereichVorlauf 9.7
```
