### PR TITLE
Improve NTP handling

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -45,6 +45,7 @@ static char ota_write_data[SERVER_OTA_SCRATCH_BUFSIZE + 1] = { 0 };
 static const char *TAG = "OTA";
 
 esp_err_t handler_reboot(httpd_req_t *req);
+static bool ota_update_task(std::string fn);
 
 std::string _file_name_update;
 

--- a/code/components/jomjol_fileserver_ota/server_ota.h
+++ b/code/components/jomjol_fileserver_ota/server_ota.h
@@ -15,6 +15,5 @@ void CheckOTAUpdate();
 void doReboot();
 void hard_restart();
 void CheckUpdate();
-static bool ota_update_task(std::string fn);
 
 #endif //SERVEROTA_H

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -727,7 +727,7 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time)
                             GENERAL[n]->ROI[roi]->isReject = true;
                             result = -1;
                             _result_save_file+= 100;     // In case fit is not sufficient, the result should still be saved with "-10x.y".
-                            string zw = "Value Rejected due to Threshold (Fit: " + to_string(_fit) + "Threshold: " + to_string(CNNGoodThreshold) + ")";
+                            string zw = "Value Rejected due to Threshold (Fit: " + to_string(_fit) + ", Threshold: " + to_string(CNNGoodThreshold) + ")";
                             LogFile.WriteToFile(ESP_LOG_WARN, TAG, zw);
                         }
                         else

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -292,7 +292,7 @@ void ClassFlowControll::doFlowMakeImageOnly(string time){
     for (int i = 0; i < FlowControll.size(); ++i)
     {
         if (FlowControll[i]->name() == "ClassFlowMakeImage") {
-            zw_time = gettimestring("%H:%M:%S");
+            zw_time = getCurrentTimeString("%H:%M:%S");
             std::string flowStatus = TranslateAktstatus(FlowControll[i]->name());
             aktstatus = flowStatus + " (" + zw_time + ")";
 #ifdef ENABLE_MQTT
@@ -315,16 +315,19 @@ bool ClassFlowControll::doFlow(string time)
 #endif
 
     /* Check if we have a valid date/time and if not restart the NTP client */
-    if (! getTimeIsSet()) {
+   /* if (! getTimeIsSet()) {
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Time not set, restarting NTP Client!");
         restartNtpClient();
-    }
+    }*/
+
+    //checkNtpStatus(0);
 
     for (int i = 0; i < FlowControll.size(); ++i)
     {
-        zw_time = gettimestring("%H:%M:%S");
+        zw_time = getCurrentTimeString("%H:%M:%S");
         std::string flowStatus = TranslateAktstatus(FlowControll[i]->name());
         aktstatus = flowStatus + " (" + zw_time + ")";
+        //LogFile.WriteToFile(ESP_LOG_INFO, TAG, aktstatus);
 #ifdef ENABLE_MQTT
         MQTTPublish(mqttServer_getMainTopic() + "/" + "status", flowStatus, false);
 #endif //ENABLE_MQTT
@@ -355,9 +358,10 @@ bool ClassFlowControll::doFlow(string time)
 #endif
 
     }
-    zw_time = gettimestring("%H:%M:%S");
+    zw_time = getCurrentTimeString("%H:%M:%S");
     std::string flowStatus = "Flow finished";
     aktstatus = flowStatus + " (" + zw_time + ")";
+    //LogFile.WriteToFile(ESP_LOG_INFO, TAG, aktstatus);
 #ifdef ENABLE_MQTT
     MQTTPublish(mqttServer_getMainTopic() + "/" + "status", flowStatus, false);
 #endif //ENABLE_MQTT
@@ -541,17 +545,7 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, string& aktparamgraph)
             LogFile.SetLogFileRetention(std::stoi(splitted[1]));
         }
 
-        if ((toUpper(splitted[0]) == "TIMEZONE") && (splitted.size() > 1))
-        {
-            string zw = "Set TimeZone: " + splitted[1];
-            setTimeZone(splitted[1]);
-        }      
-
-        if ((toUpper(splitted[0]) == "TIMESERVER") && (splitted.size() > 1))
-        {
-            string zw = "Set TimeZone: " + splitted[1];
-            reset_servername(splitted[1]);
-        }  
+        /* TimeServer and TimeZone got already read from the config, see setupTime () */
 
         if ((toUpper(splitted[0]) == "RSSITHREASHOLD") && (splitted.size() > 1))
         {

--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -785,11 +785,17 @@ bool isSetSystemStatusFlag(SystemStatusFlag_t flag) {
 	}
 }
 
+
+time_t getUpTime(void) {
+    return (uint32_t)(esp_timer_get_time()/1000/1000); // in seconds
+}
+
+
 string getResetReason(void) {
 	std::string reasonText;
 
 	switch(esp_reset_reason()) {
-		case ESP_RST_POWERON: reasonText = "Power-on event"; break;    //!< Reset due to power-on event
+		case ESP_RST_POWERON: reasonText = "Power-on event (or reset button)"; break;    //!< Reset due to power-on event
 		case ESP_RST_EXT: reasonText = "External pin"; break;        //!< Reset by external pin (not applicable for ESP32)
 		case ESP_RST_SW: reasonText = "Via esp_restart"; break;         //!< Software reset via esp_restart
 		case ESP_RST_PANIC: reasonText = "Exception/panic"; break;      //!< Software reset due to exception/panic
@@ -814,7 +820,7 @@ std::string getFormatedUptime(bool compact) {
 	char buf[20];
 	#pragma GCC diagnostic ignored "-Wformat-truncation"
 
-    int uptime = (uint32_t)(esp_timer_get_time()/1000/1000); // in seconds
+    int uptime = getUpTime(); // in seconds
 
     int days = int(floor(uptime / (3600*24)));
     int hours = int(floor((uptime - days * 3600*24) / (3600)));

--- a/code/components/jomjol_helper/Helper.h
+++ b/code/components/jomjol_helper/Helper.h
@@ -85,6 +85,7 @@ void clearSystemStatusFlag(SystemStatusFlag_t flag);
 int getSystemStatus(void);
 bool isSetSystemStatusFlag(SystemStatusFlag_t flag);
 
+time_t getUpTime(void);
 string getResetReason(void);
 std::string getFormatedUptime(bool compact);
 

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -91,7 +91,13 @@ void sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
         }
     }
     else {
+        if (field == "problem") { // Special binary sensor which is based on error topic
+            payload += "\"state_topic\": \"~/error\"," + nl;
+            payload += "\"value_template\": \"{{ 'OFF' if 'no error' in value else 'ON'}}\"," + nl;
+        }
+        else {
             payload += "\"state_topic\": \"~/" + field + "\"," + nl;
+        }
     }
 
     if (unit != "") {
@@ -149,7 +155,11 @@ void MQTThomeassistantDiscovery() {
 
 
     for (int i = 0; i < (*NUMBERS).size(); ++i) {
-         std::string group = (*NUMBERS)[i]->name;
+        std::string group = (*NUMBERS)[i]->name;
+        if (group == "default") {
+            group = "";
+        }
+
     //                                  Group | Field                 | User Friendly Name                | Icon                   | Unit     | Device Class | State Class       | Entity Category
         sendHomeAssistantDiscoveryTopic(group,   "value",              "Value",                            "gauge",                 valueUnit, meterType,     "total_increasing", "");
         sendHomeAssistantDiscoveryTopic(group,   "raw",                "Raw Value",                        "raw",                   valueUnit, "",            "total_increasing", "diagnostic");

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -101,7 +101,7 @@ void doInit(void)
 
 bool doflow(void)
 {   
-    std::string zw_time = gettimestring(LOGFILE_TIME_FORMAT);
+    std::string zw_time = getCurrentTimeString(LOGFILE_TIME_FORMAT);
     ESP_LOGD(TAG, "doflow - start %s", zw_time.c_str());
     flowisrunning = true;
     tfliteflow.doFlow(zw_time);
@@ -787,7 +787,7 @@ void task_autodoFlow(void *pvParameter)
     auto_isrunning = tfliteflow.isAutoStart(auto_intervall);
     if (isSetupModusActive()) {
         auto_isrunning = false;
-        std::string zw_time = gettimestring(LOGFILE_TIME_FORMAT);
+        std::string zw_time = getCurrentTimeString(LOGFILE_TIME_FORMAT);
         tfliteflow.doFlowMakeImageOnly(zw_time);
 
     }

--- a/code/components/jomjol_time_sntp/CMakeLists.txt
+++ b/code/components/jomjol_time_sntp/CMakeLists.txt
@@ -2,6 +2,6 @@ FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."
-                    REQUIRES tflite-lib jomjol_logfile)
+                    REQUIRES tflite-lib jomjol_logfile jomjol_configfile)
 
 

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -16,18 +16,20 @@
 
 #include "ClassLogFile.h"
 
+#include "configFile.h"
+#include "Helper.h"
+
+
 static const char *TAG = "SNTP";
 
-time_t bootTime;
+static std::string timeZone = "";
+static std::string timeServer = "undefined";
+static bool useNtp = true;
 
-static bool obtain_time(void);
-static void initialize_sntp(void);
-static void logNtpStatus(sntp_sync_status_t status);
+std::string getNtpStatusText(sntp_sync_status_t status);
+static void setTimeZone(std::string _tzstring);
+static std::string getServerName(void);
 
-void time_sync_notification_cb(struct timeval *tv)
-{
-    ESP_LOGI(TAG, "Notification of a time synchronization event");
-}
 
 std::string ConvertTimeToString(time_t _time, const char * frm)
 {
@@ -40,7 +42,8 @@ std::string ConvertTimeToString(time_t _time, const char * frm)
     return result;
 }
 
-std::string gettimestring(const char * frm)
+
+std::string getCurrentTimeString(const char * frm)
 {
     time_t now;
     struct tm timeinfo;
@@ -53,39 +56,13 @@ std::string gettimestring(const char * frm)
     return result;
 }
 
-bool setup_time()
+
+void time_sync_notification_cb(struct timeval *tv)
 {
-    time_t now;
-    struct tm timeinfo;
-    time(&now);
-    localtime_r(&now, &timeinfo);
-    char strftime_buf[64];
-    bool success = true;
-
-    // Is time set? If not, tm_year will be (1970 - 1900).
-    if (!getTimeIsSet()) {
-        initialize_sntp();
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is not set yet. Getting time over NTP server " + std::string(sntp_getservername(0)));
-        if (!obtain_time()) {
-            success = false;
-        }
-
-        // update 'now' variable with current time
-        time(&now);
-
-        setTimeZone("CET-1CEST,M3.5.0,M10.5.0/3");
-
-        localtime_r(&now, &timeinfo);
-        strftime(strftime_buf, sizeof(strftime_buf), "%Y-%m-%d_%H:%M:%S", &timeinfo);
-        ESP_LOGI(TAG, "The current date/time in Berlin is: %s", strftime_buf);
-    }
-    else {
-        localtime_r(&now, &timeinfo);
-        strftime(strftime_buf, sizeof(strftime_buf), "%Y-%m-%d_%H:%M:%S", &timeinfo);
-        ESP_LOGI(TAG, "Time is already set (%s)", strftime_buf);
-    }
-    return success;
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is now successfully synced with NTP Server " +
+            getServerName() + ": " + getCurrentTimeString("%Y-%m-%d %H:%M:%S"));
 }
+
 
 void setTimeZone(std::string _tzstring)
 {
@@ -95,100 +72,25 @@ void setTimeZone(std::string _tzstring)
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, _tzstring);
 }
 
-static bool obtain_time(void)
-{
-    time_t now = 0;
-    struct tm timeinfo = {};
-    int retry = 0;
-    const int retry_count = 10;
-    bool success = true;
 
-    time(&now);
-    localtime_r(&now, &timeinfo);
-
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Waiting until we get a time from the NTP server " + std::string(sntp_getservername(0)));
-    while (true) {
-        retry++;
-
-        if (retry == retry_count) {
-            ESP_LOGW(TAG, "NTP time fetching seems to take longer, will check again on next round!"); // The NTP client will automatically retry periodically!
-            success = false;
-            break;
-        }
-
-        sntp_sync_status_t status = sntp_get_sync_status();
-        logNtpStatus(status);
-        if (status == SNTP_SYNC_STATUS_COMPLETED) {
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is synced with NTP Server " + std::string(sntp_getservername(0)));
-            break;
-        }
-
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
-    }
-    
-    time(&now);
-    localtime_r(&now, &timeinfo);
-    return success;
-}
-
-
-void logNtpStatus(sntp_sync_status_t status) {
+std::string getNtpStatusText(sntp_sync_status_t status) {
     if (status == SNTP_SYNC_STATUS_COMPLETED) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Status OK");
+        return "Synchronized";
     }
     else if (status == SNTP_SYNC_STATUS_IN_PROGRESS) {
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Status: In Progress");
+        return "In Progress";
     }
     else { // SNTP_SYNC_STATUS_RESET
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Status: Reset");
+        return "Reset";
     }
 }
 
-
-void reset_servername(std::string _servername)
-{
-    sntp_stop();
-    sntp_setoperatingmode(SNTP_OPMODE_POLL);
-    sntp_setservername(0, _servername.c_str());
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Set SNTP-Server to " + std::string(sntp_getservername(0)));
-    sntp_init();
-    obtain_time();
-    std::string zw = gettimestring("%Y%m%d-%H%M%S");
-    ESP_LOGD(TAG, "Time ist %s", zw.c_str());
-}
-
-static void initialize_sntp(void)
-{
-    ESP_LOGI(TAG, "Initializing SNTP");
-    sntp_setoperatingmode(SNTP_OPMODE_POLL);
-    sntp_setservername(0, "pool.ntp.org");
-//    sntp_set_time_sync_notification_cb(time_sync_notification_cb);
-    sntp_init();
-}
-
-void setBootTime() 
-{
-    time(&bootTime);
-}
-
-time_t getUpTime() 
-{
-    time_t now;
-    time(&now);
-
-    return now - bootTime;
-}
 
 bool getTimeIsSet(void) {
     time_t now;
     struct tm timeinfo;
     time(&now);
     localtime_r(&now, &timeinfo);
-    char strftime_buf[64];
-
-    localtime_r(&now, &timeinfo);
-    strftime(strftime_buf, sizeof(strftime_buf), "%Y-%m-%d_%H:%M:%S", &timeinfo);
-    ESP_LOGD(TAG, "The current date/time in Berlin is: %s", strftime_buf);
 
     // Is time set? If not, tm_year will be (1970 - 1900).
     if ((timeinfo.tm_year < (2022 - 1900))) {
@@ -199,7 +101,127 @@ bool getTimeIsSet(void) {
     }
 }
 
-void restartNtpClient(void) {
-    sntp_restart();
-    obtain_time();
+/*void restartNtpClient(void) {
+//    sntp_restart();
+ //   obtain_time();
+}*/
+
+
+bool getUseNtp(void) {
+    return useNtp;
+}
+
+
+std::string getServerName(void) {
+    char buf[100];
+
+    if (sntp_getservername(0)){
+        snprintf(buf, sizeof(buf), "%s", sntp_getservername(0));
+        return std::string(buf);
+    }
+    else { // we have either IPv4 or IPv6 address
+        ip_addr_t const *ip = sntp_getserver(0);
+        if (ipaddr_ntoa_r(ip, buf, sizeof(buf)) != NULL) {
+            return std::string(buf);
+        }
+    }
+    return "";
+}
+
+
+/**
+ * Load the TimeZone and TimeServer from the config file and initialize the NTP client
+ */
+bool setupTime() {
+    time_t now;
+    struct tm timeinfo;
+    char strftime_buf[64];
+
+    ConfigFile configFile = ConfigFile(CONFIG_FILE); 
+
+    std::vector<std::string> splitted;
+    std::string line = "";
+    bool disabledLine = false;
+    bool eof = false;
+
+    /* Load config from config file */
+    while ((!configFile.GetNextParagraph(line, disabledLine, eof) || 
+            (line.compare("[System]") != 0)) && !eof) {}
+    if (eof) {
+        return false;
+    }
+
+    if (disabledLine) {
+        return false;
+    }
+
+    while (configFile.getNextLine(&line, disabledLine, eof) && 
+            !configFile.isNewParagraph(line)) {
+        splitted = ZerlegeZeile(line);
+
+        if (toUpper(splitted[0]) == "TIMEZONE") {
+            timeZone = splitted[1];
+        }
+
+        if (toUpper(splitted[0]) == "TIMESERVER") {
+            if (splitted.size() <= 1) { // Key has no value => we use this to show it as disabled
+                timeServer = "";
+            }
+            else {
+                timeServer = splitted[1];
+            }
+        }
+    }
+
+
+    /* Setup NTP Server and Timezone */
+    if (timeServer == "undefined") {
+        timeServer = "pool.ntp.org";
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "TimeServer not defined, using default: " + timeServer);
+    }
+    else if (timeServer == "") {
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "TimeServer config empty, disabling NTP");
+        useNtp = false;
+    }
+    else {
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "TimeServer: " + timeServer);
+    }
+    
+    if (timeZone == "") {
+        timeZone = "CET-1CEST,M3.5.0,M10.5.0/3";
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "TimeZone not set, using default: " + timeZone);
+    }
+
+
+    if (useNtp) {
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Configuring NTP Client...");        
+        sntp_setoperatingmode(SNTP_OPMODE_POLL);
+        sntp_setservername(0, timeServer.c_str());
+        sntp_init();
+
+        sntp_set_time_sync_notification_cb(time_sync_notification_cb);
+
+        setTimeZone(timeZone);
+    }
+
+
+    /* The RTC keeps the time after a restart (Except on Power On or Pin Reset) 
+     * There should only be a minor correction through NTP */
+
+    // Get current time from RTC
+    time(&now);
+    localtime_r(&now, &timeinfo);
+    strftime(strftime_buf, sizeof(strftime_buf), "%Y-%m-%d %H:%M:%S", &timeinfo);
+
+    if (getTimeIsSet()) {
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is already set: " + std::string(strftime_buf));
+    }
+    else {
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "The local time is unknown, starting with " + std::string(strftime_buf));
+        if (useNtp) {
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Once the NTP server provides a time, we will switch to that one");
+        }
+    }
+
+    return true;
 }

--- a/code/components/jomjol_time_sntp/time_sntp.h
+++ b/code/components/jomjol_time_sntp/time_sntp.h
@@ -15,20 +15,15 @@
 #include "esp_log.h"
 #include "esp_attr.h"
 #include "esp_sleep.h"
-// #include "nvs_flash.h"
 #include "esp_sntp.h"
 
-bool setup_time(void);
-
-std::string gettimestring(const char * frm);
+std::string getCurrentTimeString(const char * frm);
 std::string ConvertTimeToString(time_t _time, const char * frm);
 
-void setTimeZone(std::string _tzstring);
-void reset_servername(std::string _servername);
 
-void setBootTime();
-time_t getUpTime();
 bool getTimeIsSet(void);
-void restartNtpClient(void);
+
+bool getUseNtp(void);
+bool setupTime();
 
 #endif //TIMESNTP_H

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -156,6 +156,8 @@ extern "C" void app_main(void)
         return; // No way to continue without SD-Card!
     }
 
+    setupTime();
+
     string versionFormated = getFwVersion() + ", Date/Time: " + std::string(BUILD_TIME) + \
         ", Web UI: " + getHTMLversion();
 
@@ -207,13 +209,6 @@ extern "C" void app_main(void)
     ESP_LOGD(TAG, "main: sleep for: %ldms", (long) xDelay);
     vTaskDelay( xDelay );   
 
-    if (!setup_time()) {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "NTP Initialization failed!");
-        setSystemStatusFlag(SYSTEM_STATUS_NTP_BAD);
-    }
-
-    setBootTime();
-
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "=================================================");
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "================== Main Started =================");
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "=================================================");
@@ -222,7 +217,7 @@ extern "C" void app_main(void)
         LogFile.WriteToFile(ESP_LOG_WARN, TAG, std::string("Web UI version (") + getHTMLcommit() + ") does not match firmware version (" + std::string(GIT_REV) + ") !");
     }
 
-    std::string zw = gettimestring("%Y%m%d-%H%M%S");
+    std::string zw = getCurrentTimeString("%Y%m%d-%H%M%S");
     ESP_LOGD(TAG, "time %s", zw.c_str());
 
     /* Check if PSRAM can be initalized */

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -468,7 +468,7 @@ httpd_handle_t start_webserver(void)
 //    config.uri_match_fn = NULL;                            
     config.uri_match_fn = httpd_uri_match_wildcard;
 
-    starttime = gettimestring("%Y%m%d-%H%M%S");
+    starttime = getCurrentTimeString("%Y%m%d-%H%M%S");
 
     // Start the httpd server
     ESP_LOGI(TAG, "Starting server on port: '%d'", config.server_port);

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -1345,7 +1345,8 @@ textarea {
 				<input type="text" id="System_TimeZone_value1">
 			</td>
 			<td class="description">
-				Time zone in POSIX syntax (Europe/Berlin = "CET-1CEST,M3.5.0,M10.5.0/3" - incl. daylight saving)
+				Time zone in POSIX syntax (Europe/Berlin = "CET-1CEST,M3.5.0,M10.5.0/3" - incl. daylight saving)<br>
+				Use this <a href=timezones.html target=_blank>table</a> to find the settings for your region. 
 			</td>
 		</tr>
 		<tr class="expert"  id="ex16">
@@ -1357,7 +1358,11 @@ textarea {
 				<input type="text" id="System_TimeServer_value1">
 			</td>
 			<td class="description">
-				Time server to synchronize system time (default: "pool.ntp.org" - used if nothing is specified)
+				Time server to synchronize system time. If it is disabled or "undefined", "pool.ntp.org" will be used.<br>
+				You can also set it to the IP of your router. Many routers like 
+				<a href=https://en.avm.de/service/knowledge-base/dok/FRITZ-Box-7590-AX/336_Configuring-time-synchronization-NTP-for-FRITZ-Box-and-network-devices/
+				target=_blank>Fritzboxes</a> can act as a local NTP server.<br>
+				To disable NTP, you need to activate it but set the TimeServer config to be empty. In such case the time always starts at 01.01.1970 after each power cycle!
 			</td>
 		</tr>
 		<tr class="expert"  id="System_Hostname">

--- a/sd-card/html/timezones.html
+++ b/sd-card/html/timezones.html
@@ -1,0 +1,542 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+* {
+  box-sizing: border-box;
+}
+
+#myInput {
+  background-image: url('/css/searchicon.png');
+  background-position: 10px 10px;
+  background-repeat: no-repeat;
+  width: 100%;
+  font-size: 16px;
+  padding: 12px 20px 12px 40px;
+  border: 1px solid #ddd;
+  margin-bottom: 12px;
+}
+
+#data {
+  border-collapse: collapse;
+  width: 100%;
+  border: 1px solid #ddd;
+  font-size: 18px;
+}
+
+#data th, #data td {
+  text-align: left;
+  padding: 12px;
+}
+
+#data tr {
+  border-bottom: 1px solid #ddd;
+}
+
+#data tr.header, #data tr:hover {
+  background-color: #f1f1f1;
+}
+</style>
+</head>
+<body>
+
+<h2>Timezones</h2>
+
+<input type="text" id="myInput" onkeyup="myFunction()" placeholder="Search for your region..." title="Type in a region">
+
+
+<table id="data">
+    <tr class="header">
+        <th>Region</th>
+        <th>Code</th>
+      </tr>
+    <tr><td>Africa/Abidjan</td><td>GMT0</td></tr>
+    <tr><td>Africa/Accra</td><td>GMT0</td></tr>
+    <tr><td>Africa/Addis_Ababa</td><td>EAT-3</td></tr>
+    <tr><td>Africa/Algiers</td><td>CET-1</td></tr>
+    <tr><td>Africa/Asmara</td><td>EAT-3</td></tr>
+    <tr><td>Africa/Bamako</td><td>GMT0</td></tr>
+    <tr><td>Africa/Bangui</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Banjul</td><td>GMT0</td></tr>
+    <tr><td>Africa/Bissau</td><td>GMT0</td></tr>
+    <tr><td>Africa/Blantyre</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Brazzaville</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Bujumbura</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Cairo</td><td>EET-2</td></tr>
+    <tr><td>Africa/Casablanca</td><td>&lt;+01>-1</td></tr>
+    <tr><td>Africa/Ceuta</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Africa/Conakry</td><td>GMT0</td></tr>
+    <tr><td>Africa/Dakar</td><td>GMT0</td></tr>
+    <tr><td>Africa/Dar_es_Salaam</td><td>EAT-3</td></tr>
+    <tr><td>Africa/Djibouti</td><td>EAT-3</td></tr>
+    <tr><td>Africa/Douala</td><td>WAT-1</td></tr>
+    <tr><td>Africa/El_Aaiun</td><td>&lt;+01>-1</td></tr>
+    <tr><td>Africa/Freetown</td><td>GMT0</td></tr>
+    <tr><td>Africa/Gaborone</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Harare</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Johannesburg</td><td>SAST-2</td></tr>
+    <tr><td>Africa/Juba</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Kampala</td><td>EAT-3</td></tr>
+    <tr><td>Africa/Khartoum</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Kigali</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Kinshasa</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Lagos</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Libreville</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Lome</td><td>GMT0</td></tr>
+    <tr><td>Africa/Luanda</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Lubumbashi</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Lusaka</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Malabo</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Maputo</td><td>CAT-2</td></tr>
+    <tr><td>Africa/Maseru</td><td>SAST-2</td></tr>
+    <tr><td>Africa/Mbabane</td><td>SAST-2</td></tr>
+    <tr><td>Africa/Mogadishu</td><td>EAT-3</td></tr>
+    <tr><td>Africa/Monrovia</td><td>GMT0</td></tr>
+    <tr><td>Africa/Nairobi</td><td>EAT-3</td></tr>
+    <tr><td>Africa/Ndjamena</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Niamey</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Nouakchott</td><td>GMT0</td></tr>
+    <tr><td>Africa/Ouagadougou</td><td>GMT0</td></tr>
+    <tr><td>Africa/Porto-Novo</td><td>WAT-1</td></tr>
+    <tr><td>Africa/Sao_Tome</td><td>GMT0</td></tr>
+    <tr><td>Africa/Tripoli</td><td>EET-2</td></tr>
+    <tr><td>Africa/Tunis</td><td>CET-1</td></tr>
+    <tr><td>Africa/Windhoek</td><td>CAT-2</td></tr>
+    <tr><td>America/Adak</td><td>HST10HDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Anchorage</td><td>AKST9AKDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Anguilla</td><td>AST4</td></tr>
+    <tr><td>America/Antigua</td><td>AST4</td></tr>
+    <tr><td>America/Araguaina</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/Buenos_Aires</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/Catamarca</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/Cordoba</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/Jujuy</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/La_Rioja</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/Mendoza</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/Rio_Gallegos</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/Salta</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/San_Juan</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/San_Luis</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/Tucuman</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Argentina/Ushuaia</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Aruba</td><td>AST4</td></tr>
+    <tr><td>America/Asuncion</td><td>&lt;-04>4&lt;-03>,M10.1.0/0,M3.4.0/0</td></tr>
+    <tr><td>America/Atikokan</td><td>EST5</td></tr>
+    <tr><td>America/Bahia</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Bahia_Banderas</td><td>CST6CDT,M4.1.0,M10.5.0</td></tr>
+    <tr><td>America/Barbados</td><td>AST4</td></tr>
+    <tr><td>America/Belem</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Belize</td><td>CST6</td></tr>
+    <tr><td>America/Blanc-Sablon</td><td>AST4</td></tr>
+    <tr><td>America/Boa_Vista</td><td>&lt;-04>4</td></tr>
+    <tr><td>America/Bogota</td><td>&lt;-05>5</td></tr>
+    <tr><td>America/Boise</td><td>MST7MDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Cambridge_Bay</td><td>MST7MDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Campo_Grande</td><td>&lt;-04>4</td></tr>
+    <tr><td>America/Cancun</td><td>EST5</td></tr>
+    <tr><td>America/Caracas</td><td>&lt;-04>4</td></tr>
+    <tr><td>America/Cayenne</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Cayman</td><td>EST5</td></tr>
+    <tr><td>America/Chicago</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Chihuahua</td><td>MST7MDT,M4.1.0,M10.5.0</td></tr>
+    <tr><td>America/Costa_Rica</td><td>CST6</td></tr>
+    <tr><td>America/Creston</td><td>MST7</td></tr>
+    <tr><td>America/Cuiaba</td><td>&lt;-04>4</td></tr>
+    <tr><td>America/Curacao</td><td>AST4</td></tr>
+    <tr><td>America/Danmarkshavn</td><td>GMT0</td></tr>
+    <tr><td>America/Dawson</td><td>MST7</td></tr>
+    <tr><td>America/Dawson_Creek</td><td>MST7</td></tr>
+    <tr><td>America/Denver</td><td>MST7MDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Detroit</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Dominica</td><td>AST4</td></tr>
+    <tr><td>America/Edmonton</td><td>MST7MDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Eirunepe</td><td>&lt;-05>5</td></tr>
+    <tr><td>America/El_Salvador</td><td>CST6</td></tr>
+    <tr><td>America/Fort_Nelson</td><td>MST7</td></tr>
+    <tr><td>America/Fortaleza</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Glace_Bay</td><td>AST4ADT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Godthab</td><td>&lt;-03>3&lt;-02>,M3.5.0/-2,M10.5.0/-1</td></tr>
+    <tr><td>America/Goose_Bay</td><td>AST4ADT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Grand_Turk</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Grenada</td><td>AST4</td></tr>
+    <tr><td>America/Guadeloupe</td><td>AST4</td></tr>
+    <tr><td>America/Guatemala</td><td>CST6</td></tr>
+    <tr><td>America/Guayaquil</td><td>&lt;-05>5</td></tr>
+    <tr><td>America/Guyana</td><td>&lt;-04>4</td></tr>
+    <tr><td>America/Halifax</td><td>AST4ADT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Havana</td><td>CST5CDT,M3.2.0/0,M11.1.0/1</td></tr>
+    <tr><td>America/Hermosillo</td><td>MST7</td></tr>
+    <tr><td>America/Indiana/Indianapolis</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Indiana/Knox</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Indiana/Marengo</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Indiana/Petersburg</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Indiana/Tell_City</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Indiana/Vevay</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Indiana/Vincennes</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Indiana/Winamac</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Inuvik</td><td>MST7MDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Iqaluit</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Jamaica</td><td>EST5</td></tr>
+    <tr><td>America/Juneau</td><td>AKST9AKDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Kentucky/Louisville</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Kentucky/Monticello</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Kralendijk</td><td>AST4</td></tr>
+    <tr><td>America/La_Paz</td><td>&lt;-04>4</td></tr>
+    <tr><td>America/Lima</td><td>&lt;-05>5</td></tr>
+    <tr><td>America/Los_Angeles</td><td>PST8PDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Lower_Princes</td><td>AST4</td></tr>
+    <tr><td>America/Maceio</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Managua</td><td>CST6</td></tr>
+    <tr><td>America/Manaus</td><td>&lt;-04>4</td></tr>
+    <tr><td>America/Marigot</td><td>AST4</td></tr>
+    <tr><td>America/Martinique</td><td>AST4</td></tr>
+    <tr><td>America/Matamoros</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Mazatlan</td><td>MST7MDT,M4.1.0,M10.5.0</td></tr>
+    <tr><td>America/Menominee</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Merida</td><td>CST6CDT,M4.1.0,M10.5.0</td></tr>
+    <tr><td>America/Metlakatla</td><td>AKST9AKDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Mexico_City</td><td>CST6CDT,M4.1.0,M10.5.0</td></tr>
+    <tr><td>America/Miquelon</td><td>&lt;-03>3&lt;-02>,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Moncton</td><td>AST4ADT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Monterrey</td><td>CST6CDT,M4.1.0,M10.5.0</td></tr>
+    <tr><td>America/Montevideo</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Montreal</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Montserrat</td><td>AST4</td></tr>
+    <tr><td>America/Nassau</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/New_York</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Nipigon</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Nome</td><td>AKST9AKDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Noronha</td><td>&lt;-02>2</td></tr>
+    <tr><td>America/North_Dakota/Beulah</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/North_Dakota/Center</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/North_Dakota/New_Salem</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Nuuk</td><td>&lt;-03>3&lt;-02>,M3.5.0/-2,M10.5.0/-1</td></tr>
+    <tr><td>America/Ojinaga</td><td>MST7MDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Panama</td><td>EST5</td></tr>
+    <tr><td>America/Pangnirtung</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Paramaribo</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Phoenix</td><td>MST7</td></tr>
+    <tr><td>America/Port_of_Spain</td><td>AST4</td></tr>
+    <tr><td>America/Port-au-Prince</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Porto_Velho</td><td>&lt;-04>4</td></tr>
+    <tr><td>America/Puerto_Rico</td><td>AST4</td></tr>
+    <tr><td>America/Punta_Arenas</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Rainy_River</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Rankin_Inlet</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Recife</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Regina</td><td>CST6</td></tr>
+    <tr><td>America/Resolute</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Rio_Branco</td><td>&lt;-05>5</td></tr>
+    <tr><td>America/Santarem</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Santiago</td><td>&lt;-04>4&lt;-03>,M9.1.6/24,M4.1.6/24</td></tr>
+    <tr><td>America/Santo_Domingo</td><td>AST4</td></tr>
+    <tr><td>America/Sao_Paulo</td><td>&lt;-03>3</td></tr>
+    <tr><td>America/Scoresbysund</td><td>&lt;-01>1&lt;+00>,M3.5.0/0,M10.5.0/1</td></tr>
+    <tr><td>America/Sitka</td><td>AKST9AKDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/St_Barthelemy</td><td>AST4</td></tr>
+    <tr><td>America/St_Johns</td><td>NST3:30NDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/St_Kitts</td><td>AST4</td></tr>
+    <tr><td>America/St_Lucia</td><td>AST4</td></tr>
+    <tr><td>America/St_Thomas</td><td>AST4</td></tr>
+    <tr><td>America/St_Vincent</td><td>AST4</td></tr>
+    <tr><td>America/Swift_Current</td><td>CST6</td></tr>
+    <tr><td>America/Tegucigalpa</td><td>CST6</td></tr>
+    <tr><td>America/Thule</td><td>AST4ADT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Thunder_Bay</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Tijuana</td><td>PST8PDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Toronto</td><td>EST5EDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Tortola</td><td>AST4</td></tr>
+    <tr><td>America/Vancouver</td><td>PST8PDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Whitehorse</td><td>MST7</td></tr>
+    <tr><td>America/Winnipeg</td><td>CST6CDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Yakutat</td><td>AKST9AKDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>America/Yellowknife</td><td>MST7MDT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>Antarctica/Casey</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Antarctica/Davis</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Antarctica/DumontDUrville</td><td>&lt;+10>-10</td></tr>
+    <tr><td>Antarctica/Macquarie</td><td>AEST-10AEDT,M10.1.0,M4.1.0/3</td></tr>
+    <tr><td>Antarctica/Mawson</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Antarctica/McMurdo</td><td>NZST-12NZDT,M9.5.0,M4.1.0/3</td></tr>
+    <tr><td>Antarctica/Palmer</td><td>&lt;-03>3</td></tr>
+    <tr><td>Antarctica/Rothera</td><td>&lt;-03>3</td></tr>
+    <tr><td>Antarctica/Syowa</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Antarctica/Troll</td><td>&lt;+00>0&lt;+02>-2,M3.5.0/1,M10.5.0/3</td></tr>
+    <tr><td>Antarctica/Vostok</td><td>&lt;+06>-6</td></tr>
+    <tr><td>Arctic/Longyearbyen</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Asia/Aden</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Asia/Almaty</td><td>&lt;+06>-6</td></tr>
+    <tr><td>Asia/Amman</td><td>EET-2EEST,M2.5.4/24,M10.5.5/1</td></tr>
+    <tr><td>Asia/Anadyr</td><td>&lt;+12>-12</td></tr>
+    <tr><td>Asia/Aqtau</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Aqtobe</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Ashgabat</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Atyrau</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Baghdad</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Asia/Bahrain</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Asia/Baku</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Asia/Bangkok</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Barnaul</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Beirut</td><td>EET-2EEST,M3.5.0/0,M10.5.0/0</td></tr>
+    <tr><td>Asia/Bishkek</td><td>&lt;+06>-6</td></tr>
+    <tr><td>Asia/Brunei</td><td>&lt;+08>-8</td></tr>
+    <tr><td>Asia/Chita</td><td>&lt;+09>-9</td></tr>
+    <tr><td>Asia/Choibalsan</td><td>&lt;+08>-8</td></tr>
+    <tr><td>Asia/Colombo</td><td>&lt;+0530>-5:30</td></tr>
+    <tr><td>Asia/Damascus</td><td>EET-2EEST,M3.5.5/0,M10.5.5/0</td></tr>
+    <tr><td>Asia/Dhaka</td><td>&lt;+06>-6</td></tr>
+    <tr><td>Asia/Dili</td><td>&lt;+09>-9</td></tr>
+    <tr><td>Asia/Dubai</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Asia/Dushanbe</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Famagusta</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Asia/Gaza</td><td>EET-2EEST,M3.4.4/48,M10.5.5/1</td></tr>
+    <tr><td>Asia/Hebron</td><td>EET-2EEST,M3.4.4/48,M10.5.5/1</td></tr>
+    <tr><td>Asia/Ho_Chi_Minh</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Hong_Kong</td><td>HKT-8</td></tr>
+    <tr><td>Asia/Hovd</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Irkutsk</td><td>&lt;+08>-8</td></tr>
+    <tr><td>Asia/Jakarta</td><td>WIB-7</td></tr>
+    <tr><td>Asia/Jayapura</td><td>WIT-9</td></tr>
+    <tr><td>Asia/Jerusalem</td><td>IST-2IDT,M3.4.4/26,M10.5.0</td></tr>
+    <tr><td>Asia/Kabul</td><td>&lt;+0430>-4:30</td></tr>
+    <tr><td>Asia/Kamchatka</td><td>&lt;+12>-12</td></tr>
+    <tr><td>Asia/Karachi</td><td>PKT-5</td></tr>
+    <tr><td>Asia/Kathmandu</td><td>&lt;+0545>-5:45</td></tr>
+    <tr><td>Asia/Khandyga</td><td>&lt;+09>-9</td></tr>
+    <tr><td>Asia/Kolkata</td><td>IST-5:30</td></tr>
+    <tr><td>Asia/Krasnoyarsk</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Kuala_Lumpur</td><td>&lt;+08>-8</td></tr>
+    <tr><td>Asia/Kuching</td><td>&lt;+08>-8</td></tr>
+    <tr><td>Asia/Kuwait</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Asia/Macau</td><td>CST-8</td></tr>
+    <tr><td>Asia/Magadan</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Asia/Makassar</td><td>WITA-8</td></tr>
+    <tr><td>Asia/Manila</td><td>PST-8</td></tr>
+    <tr><td>Asia/Muscat</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Asia/Nicosia</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Asia/Novokuznetsk</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Novosibirsk</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Omsk</td><td>&lt;+06>-6</td></tr>
+    <tr><td>Asia/Oral</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Phnom_Penh</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Pontianak</td><td>WIB-7</td></tr>
+    <tr><td>Asia/Pyongyang</td><td>KST-9</td></tr>
+    <tr><td>Asia/Qatar</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Asia/Qyzylorda</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Riyadh</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Asia/Sakhalin</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Asia/Samarkand</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Seoul</td><td>KST-9</td></tr>
+    <tr><td>Asia/Shanghai</td><td>CST-8</td></tr>
+    <tr><td>Asia/Singapore</td><td>&lt;+08>-8</td></tr>
+    <tr><td>Asia/Srednekolymsk</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Asia/Taipei</td><td>CST-8</td></tr>
+    <tr><td>Asia/Tashkent</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Tbilisi</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Asia/Tehran</td><td>&lt;+0330>-3:30&lt;+0430>,J79/24,J263/24</td></tr>
+    <tr><td>Asia/Thimphu</td><td>&lt;+06>-6</td></tr>
+    <tr><td>Asia/Tokyo</td><td>JST-9</td></tr>
+    <tr><td>Asia/Tomsk</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Ulaanbaatar</td><td>&lt;+08>-8</td></tr>
+    <tr><td>Asia/Urumqi</td><td>&lt;+06>-6</td></tr>
+    <tr><td>Asia/Ust-Nera</td><td>&lt;+10>-10</td></tr>
+    <tr><td>Asia/Vientiane</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Asia/Vladivostok</td><td>&lt;+10>-10</td></tr>
+    <tr><td>Asia/Yakutsk</td><td>&lt;+09>-9</td></tr>
+    <tr><td>Asia/Yangon</td><td>&lt;+0630>-6:30</td></tr>
+    <tr><td>Asia/Yekaterinburg</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Asia/Yerevan</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Atlantic/Azores</td><td>&lt;-01>1&lt;+00>,M3.5.0/0,M10.5.0/1</td></tr>
+    <tr><td>Atlantic/Bermuda</td><td>AST4ADT,M3.2.0,M11.1.0</td></tr>
+    <tr><td>Atlantic/Canary</td><td>WET0WEST,M3.5.0/1,M10.5.0</td></tr>
+    <tr><td>Atlantic/Cape_Verde</td><td>&lt;-01>1</td></tr>
+    <tr><td>Atlantic/Faroe</td><td>WET0WEST,M3.5.0/1,M10.5.0</td></tr>
+    <tr><td>Atlantic/Madeira</td><td>WET0WEST,M3.5.0/1,M10.5.0</td></tr>
+    <tr><td>Atlantic/Reykjavik</td><td>GMT0</td></tr>
+    <tr><td>Atlantic/South_Georgia</td><td>&lt;-02>2</td></tr>
+    <tr><td>Atlantic/St_Helena</td><td>GMT0</td></tr>
+    <tr><td>Atlantic/Stanley</td><td>&lt;-03>3</td></tr>
+    <tr><td>Australia/Adelaide</td><td>ACST-9:30ACDT,M10.1.0,M4.1.0/3</td></tr>
+    <tr><td>Australia/Brisbane</td><td>AEST-10</td></tr>
+    <tr><td>Australia/Broken_Hill</td><td>ACST-9:30ACDT,M10.1.0,M4.1.0/3</td></tr>
+    <tr><td>Australia/Currie</td><td>AEST-10AEDT,M10.1.0,M4.1.0/3</td></tr>
+    <tr><td>Australia/Darwin</td><td>ACST-9:30</td></tr>
+    <tr><td>Australia/Eucla</td><td>&lt;+0845>-8:45</td></tr>
+    <tr><td>Australia/Hobart</td><td>AEST-10AEDT,M10.1.0,M4.1.0/3</td></tr>
+    <tr><td>Australia/Lindeman</td><td>AEST-10</td></tr>
+    <tr><td>Australia/Lord_Howe</td><td>&lt;+1030>-10:30&lt;+11>-11,M10.1.0,M4.1.0</td></tr>
+    <tr><td>Australia/Melbourne</td><td>AEST-10AEDT,M10.1.0,M4.1.0/3</td></tr>
+    <tr><td>Australia/Perth</td><td>AWST-8</td></tr>
+    <tr><td>Australia/Sydney</td><td>AEST-10AEDT,M10.1.0,M4.1.0/3</td></tr>
+    <tr><td>Etc/GMT</td><td>GMT0</td></tr>
+    <tr><td>Etc/GMT-0</td><td>GMT0</td></tr>
+    <tr><td>Etc/GMT-1</td><td>&lt;+01>-1</td></tr>
+    <tr><td>Etc/GMT-10</td><td>&lt;+10>-10</td></tr>
+    <tr><td>Etc/GMT-11</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Etc/GMT-12</td><td>&lt;+12>-12</td></tr>
+    <tr><td>Etc/GMT-13</td><td>&lt;+13>-13</td></tr>
+    <tr><td>Etc/GMT-14</td><td>&lt;+14>-14</td></tr>
+    <tr><td>Etc/GMT-2</td><td>&lt;+02>-2</td></tr>
+    <tr><td>Etc/GMT-3</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Etc/GMT-4</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Etc/GMT-5</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Etc/GMT-6</td><td>&lt;+06>-6</td></tr>
+    <tr><td>Etc/GMT-7</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Etc/GMT-8</td><td>&lt;+08>-8</td></tr>
+    <tr><td>Etc/GMT-9</td><td>&lt;+09>-9</td></tr>
+    <tr><td>Etc/GMT+0</td><td>GMT0</td></tr>
+    <tr><td>Etc/GMT+1</td><td>&lt;-01>1</td></tr>
+    <tr><td>Etc/GMT+10</td><td>&lt;-10>10</td></tr>
+    <tr><td>Etc/GMT+11</td><td>&lt;-11>11</td></tr>
+    <tr><td>Etc/GMT+12</td><td>&lt;-12>12</td></tr>
+    <tr><td>Etc/GMT+2</td><td>&lt;-02>2</td></tr>
+    <tr><td>Etc/GMT+3</td><td>&lt;-03>3</td></tr>
+    <tr><td>Etc/GMT+4</td><td>&lt;-04>4</td></tr>
+    <tr><td>Etc/GMT+5</td><td>&lt;-05>5</td></tr>
+    <tr><td>Etc/GMT+6</td><td>&lt;-06>6</td></tr>
+    <tr><td>Etc/GMT+7</td><td>&lt;-07>7</td></tr>
+    <tr><td>Etc/GMT+8</td><td>&lt;-08>8</td></tr>
+    <tr><td>Etc/GMT+9</td><td>&lt;-09>9</td></tr>
+    <tr><td>Etc/GMT0</td><td>GMT0</td></tr>
+    <tr><td>Etc/Greenwich</td><td>GMT0</td></tr>
+    <tr><td>Etc/UCT</td><td>UTC0</td></tr>
+    <tr><td>Etc/Universal</td><td>UTC0</td></tr>
+    <tr><td>Etc/UTC</td><td>UTC0</td></tr>
+    <tr><td>Etc/Zulu</td><td>UTC0</td></tr>
+    <tr><td>Europe/Amsterdam</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Andorra</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Astrakhan</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Europe/Athens</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Belgrade</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Berlin</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Bratislava</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Brussels</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Bucharest</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Budapest</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Busingen</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Chisinau</td><td>EET-2EEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Copenhagen</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Dublin</td><td>IST-1GMT0,M10.5.0,M3.5.0/1</td></tr>
+    <tr><td>Europe/Gibraltar</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Guernsey</td><td>GMT0BST,M3.5.0/1,M10.5.0</td></tr>
+    <tr><td>Europe/Helsinki</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Isle_of_Man</td><td>GMT0BST,M3.5.0/1,M10.5.0</td></tr>
+    <tr><td>Europe/Istanbul</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Europe/Jersey</td><td>GMT0BST,M3.5.0/1,M10.5.0</td></tr>
+    <tr><td>Europe/Kaliningrad</td><td>EET-2</td></tr>
+    <tr><td>Europe/Kiev</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Kirov</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Europe/Lisbon</td><td>WET0WEST,M3.5.0/1,M10.5.0</td></tr>
+    <tr><td>Europe/Ljubljana</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/London</td><td>GMT0BST,M3.5.0/1,M10.5.0</td></tr>
+    <tr><td>Europe/Luxembourg</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Madrid</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Malta</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Mariehamn</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Minsk</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Europe/Monaco</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Moscow</td><td>MSK-3</td></tr>
+    <tr><td>Europe/Oslo</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Paris</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Podgorica</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Prague</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Riga</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Rome</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Samara</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Europe/San_Marino</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Sarajevo</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Saratov</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Europe/Simferopol</td><td>MSK-3</td></tr>
+    <tr><td>Europe/Skopje</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Sofia</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Stockholm</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Tallinn</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Tirane</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Ulyanovsk</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Europe/Uzhgorod</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Vaduz</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Vatican</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Vienna</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Vilnius</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Volgograd</td><td>&lt;+03>-3</td></tr>
+    <tr><td>Europe/Warsaw</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Zagreb</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Europe/Zaporozhye</td><td>EET-2EEST,M3.5.0/3,M10.5.0/4</td></tr>
+    <tr><td>Europe/Zurich</td><td>CET-1CEST,M3.5.0,M10.5.0/3</td></tr>
+    <tr><td>Indian/Antananarivo</td><td>EAT-3</td></tr>
+    <tr><td>Indian/Chagos</td><td>&lt;+06>-6</td></tr>
+    <tr><td>Indian/Christmas</td><td>&lt;+07>-7</td></tr>
+    <tr><td>Indian/Cocos</td><td>&lt;+0630>-6:30</td></tr>
+    <tr><td>Indian/Comoro</td><td>EAT-3</td></tr>
+    <tr><td>Indian/Kerguelen</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Indian/Mahe</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Indian/Maldives</td><td>&lt;+05>-5</td></tr>
+    <tr><td>Indian/Mauritius</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Indian/Mayotte</td><td>EAT-3</td></tr>
+    <tr><td>Indian/Reunion</td><td>&lt;+04>-4</td></tr>
+    <tr><td>Pacific/Apia</td><td>&lt;+13>-13</td></tr>
+    <tr><td>Pacific/Auckland</td><td>NZST-12NZDT,M9.5.0,M4.1.0/3</td></tr>
+    <tr><td>Pacific/Bougainville</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Pacific/Chatham</td><td>&lt;+1245>-12:45&lt;+1345>,M9.5.0/2:45,M4.1.0/3:45</td></tr>
+    <tr><td>Pacific/Chuuk</td><td>&lt;+10>-10</td></tr>
+    <tr><td>Pacific/Easter</td><td>&lt;-06>6&lt;-05>,M9.1.6/22,M4.1.6/22</td></tr>
+    <tr><td>Pacific/Efate</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Pacific/Enderbury</td><td>&lt;+13>-13</td></tr>
+    <tr><td>Pacific/Fakaofo</td><td>&lt;+13>-13</td></tr>
+    <tr><td>Pacific/Fiji</td><td>&lt;+12>-12&lt;+13>,M11.2.0,M1.2.3/99</td></tr>
+    <tr><td>Pacific/Funafuti</td><td>&lt;+12>-12</td></tr>
+    <tr><td>Pacific/Galapagos</td><td>&lt;-06>6</td></tr>
+    <tr><td>Pacific/Gambier</td><td>&lt;-09>9</td></tr>
+    <tr><td>Pacific/Guadalcanal</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Pacific/Guam</td><td>ChST-10</td></tr>
+    <tr><td>Pacific/Honolulu</td><td>HST10</td></tr>
+    <tr><td>Pacific/Kiritimati</td><td>&lt;+14>-14</td></tr>
+    <tr><td>Pacific/Kosrae</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Pacific/Kwajalein</td><td>&lt;+12>-12</td></tr>
+    <tr><td>Pacific/Majuro</td><td>&lt;+12>-12</td></tr>
+    <tr><td>Pacific/Marquesas</td><td>&lt;-0930>9:30</td></tr>
+    <tr><td>Pacific/Midway</td><td>SST11</td></tr>
+    <tr><td>Pacific/Nauru</td><td>&lt;+12>-12</td></tr>
+    <tr><td>Pacific/Niue</td><td>&lt;-11>11</td></tr>
+    <tr><td>Pacific/Norfolk</td><td>&lt;+11>-11&lt;+12>,M10.1.0,M4.1.0/3</td></tr>
+    <tr><td>Pacific/Noumea</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Pacific/Pago_Pago</td><td>SST11</td></tr>
+    <tr><td>Pacific/Palau</td><td>&lt;+09>-9</td></tr>
+    <tr><td>Pacific/Pitcairn</td><td>&lt;-08>8</td></tr>
+    <tr><td>Pacific/Pohnpei</td><td>&lt;+11>-11</td></tr>
+    <tr><td>Pacific/Port_Moresby</td><td>&lt;+10>-10</td></tr>
+    <tr><td>Pacific/Rarotonga</td><td>&lt;-10>10</td></tr>
+    <tr><td>Pacific/Saipan</td><td>ChST-10</td></tr>
+    <tr><td>Pacific/Tahiti</td><td>&lt;-10>10</td></tr>
+    <tr><td>Pacific/Tarawa</td><td>&lt;+12>-12</td></tr>
+    <tr><td>Pacific/Tongatapu</td><td>&lt;+13>-13</td></tr>
+    <tr><td>Pacific/Wake</td><td>&lt;+12>-12</td></tr>
+    <tr><td>Pacific/Wallis</td><td>&lt;+12>-12</td></tr>
+</table>
+
+<p>Source: <a href=https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv target=_blank>https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv</a></p>
+
+<script>
+    function myFunction() {
+      var input, filter, table, tr, td, i, txtValue;
+      input = document.getElementById("myInput");
+      filter = input.value.toUpperCase();
+      table = document.getElementById("data");
+      tr = table.getElementsByTagName("tr");
+      for (i = 0; i < tr.length; i++) {
+        td = tr[i].getElementsByTagName("td")[0];
+        if (td) {
+          txtValue = td.textContent || td.innerText;
+          if (txtValue.toUpperCase().indexOf(filter) > -1) {
+            tr[i].style.display = "";
+          } else {
+            tr[i].style.display = "none";
+          }
+        }       
+      }
+    }
+    </script>
+    
+    </body>
+    </html>
+    


### PR DESCRIPTION
This PR does:
 - Re-implement NTP Client handling (mainly a simplification)
 - Read the NTP config as early as possible so we have it available when we initialize the NTP Client
 - Allow to disable the NTP client completely by setting the TimeServer Config to "" (make it empty)
   This has following impact:
   - No Network requests to any NTP Server
   - On a power cycle (or button/pin reset) the time starts at 01.01.1970
   - Adds a html page with common timezones

Notes:
 - The ESP32 has no RTC, thus on a power cycle (or button/pin reset) the time starts at 01.01.1970
 - A logfile will initially also use this for the time and filename!
 - As soon as the NTC Client gets a time from the server, it sets the time. The next logfile entry goes to a new filename with the current data as name.
 - On a software restart (manually triggered or due to a crash), the time stays in the memory, this will continue instead of going back to 01.01.1970
 -  - The NTP Client runs as a thread and synchronizes every 1 hour, see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/system_time.html
 