### PR TITLE
Deinit components before reboot

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -634,7 +634,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_reboot");
     ESP_LOGI(TAG, "!!! System will restart within 5 sec!!!");
-    const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s<br>(in case of a firmware update it can take up to 180s).<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch('/index.html',{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 5000);</script>";
+    const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s<br>(in case of a firmware update it can take up to 180s).<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch(window.location.hostname,{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 1000);</script>";
     httpd_resp_send(req, resp_str, strlen(resp_str)); 
     
     doReboot();

--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -32,6 +32,8 @@
 #ifdef ENABLE_MQTT
     #include "interface_mqtt.h"
 #endif //ENABLE_MQTT
+#include "ClassControllCamera.h"
+#include "connect_wlan.h"
 
 
 #include "ClassLogFile.h"
@@ -133,8 +135,6 @@ void CheckUpdate()
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
 }
-
-
 
 
 static bool ota_update_task(std::string fn)
@@ -289,6 +289,7 @@ static bool diagnostic(void)
     return true;
 }
 
+
 void CheckOTAUpdate(void)
 {
     ESP_LOGI(TAG, "Start CheckOTAUpdateCheck...");
@@ -361,7 +362,6 @@ void CheckOTAUpdate(void)
 }
 
 
-
 esp_err_t handler_ota_update(httpd_req_t *req)
 {
 #ifdef DEBUG_DETAIL_ON     
@@ -398,7 +398,7 @@ esp_err_t handler_ota_update(httpd_req_t *req)
             ESP_LOGD(TAG, "Delete Default File: %s", fn.c_str());
         }
 
-    };
+    }
 
     if (_task.compare("emptyfirmwaredir") == 0)
     {
@@ -578,45 +578,51 @@ esp_err_t handler_ota_update(httpd_req_t *req)
     }
 
     httpd_resp_send(req, resp_str, strlen(resp_str));  
-
-#ifdef DEBUG_DETAIL_ON 
-    LogFile.WriteHeapInfo("handler_ota_update - Done");    
-#endif
 */
 
-    return ESP_OK;
-};
+    #ifdef DEBUG_DETAIL_ON 
+        LogFile.WriteHeapInfo("handler_ota_update - Done");    
+    #endif
 
-void hard_restart() {
+    return ESP_OK;
+}
+
+
+void hard_restart() 
+{
   esp_task_wdt_init(1,true);
   esp_task_wdt_add(NULL);
   while(true);
 }
 
+
 void task_reboot(void *pvParameter)
 {
-    while(1)
-    {
+    KillTFliteTasks();  // Kill autoflow task
+
+    /* Stop service tasks */
+    #ifdef ENABLE_MQTT
+        MQTTdestroy_client(true);
+    #endif //ENABLE_MQTT
+    gpio_handler_destroy();
+    esp_camera_deinit();
+    WIFIDestroy();
+
         vTaskDelay(5000 / portTICK_PERIOD_MS);
-        esp_restart();
-        hard_restart();
-    }
+    esp_restart();      // Reset type: CPU Reset (Reset both CPUs)
+
+    vTaskDelay(5000 / portTICK_PERIOD_MS);
+    hard_restart();     // Reset type: System reset (Triggered by watchdog), if esp_restart stalls (WDT needs to be activated)
 
     vTaskDelete(NULL); //Delete this task if it exits from the loop above
 }
 
-void doReboot(){
+
+void doReboot()
+{
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Reboot triggered by Software (5s).");
     LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Reboot in 5sec");
-    xTaskCreate(&task_reboot, "reboot", configMINIMAL_STACK_SIZE * 64, NULL, 10, NULL);
-    // KillTFliteTasks(); // kills itself 
-    gpio_handler_destroy();
-    #ifdef ENABLE_MQTT
-        MQTTdestroy_client();
-    #endif //ENABLE_MQTT
-    vTaskDelay(5000 / portTICK_PERIOD_MS);
-    esp_restart();
-    hard_restart();
+    xTaskCreate(&task_reboot, "task_reboot", 4 * 1024, NULL, 10, NULL);
 }
 
 
@@ -628,7 +634,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_reboot");
     ESP_LOGI(TAG, "!!! System will restart within 5 sec!!!");
-    const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s<br>(in case of a firmware update it can take up to 180s).<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch(window.location.hostname,{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 1000);</script>";
+    const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s<br>(in case of a firmware update it can take up to 180s).<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch('/index.html',{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 5000);</script>";
     httpd_resp_send(req, resp_str, strlen(resp_str)); 
     
     doReboot();
@@ -639,6 +645,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
 
     return ESP_OK;
 }
+
 
 void register_server_ota_sdcard_uri(httpd_handle_t server)
 {

--- a/code/components/jomjol_mqtt/interface_mqtt.cpp
+++ b/code/components/jomjol_mqtt/interface_mqtt.cpp
@@ -206,7 +206,7 @@ int MQTT_Init() {
     }
 
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init");
-    MQTTdestroy_client();
+    MQTTdestroy_client(false);
 
     esp_mqtt_client_config_t mqtt_cfg = {
         .uri = uri.c_str(),
@@ -270,7 +270,7 @@ int MQTT_Init() {
 }
 
 
-void MQTTdestroy_client() {
+void MQTTdestroy_client(bool _disable = false) {
     if (client) {
         if (mqtt_connected) {
             MQTTdestroySubscribeFunction();      
@@ -282,6 +282,9 @@ void MQTTdestroy_client() {
         client = NULL;
         mqtt_initialized = false;
     }
+
+    if (_disable) // Disable MQTT service, avoid restart with MQTTPublish
+        mqtt_configOK = false;
 }
 
 
@@ -328,11 +331,11 @@ void MQTTconnected(){
                 LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "topic " + it->first + " subscribe successful, msg_id=" + std::to_string(msg_id));
             }
         }
-    }
-    
-    vTaskDelay(10000 / portTICK_PERIOD_MS);                 // Delay execution of callback routine after connection got established   
-    if (callbackOnConnected) {                              // Call onConnected callback routine --> mqtt_server
-        callbackOnConnected(maintopic, SetRetainFlag);
+
+        vTaskDelay(2000 / portTICK_PERIOD_MS);                  // Delay execution of callback routine after connection got established   
+        if (callbackOnConnected) {                              // Call onConnected callback routine --> mqtt_server
+            callbackOnConnected(maintopic, SetRetainFlag);
+        }
     }
 }
 

--- a/code/components/jomjol_mqtt/interface_mqtt.cpp
+++ b/code/components/jomjol_mqtt/interface_mqtt.cpp
@@ -332,7 +332,7 @@ void MQTTconnected(){
             }
         }
 
-        vTaskDelay(2000 / portTICK_PERIOD_MS);                  // Delay execution of callback routine after connection got established   
+        vTaskDelay(10000 / portTICK_PERIOD_MS);                 // Delay execution of callback routine after connection got established   
         if (callbackOnConnected) {                              // Call onConnected callback routine --> mqtt_server
             callbackOnConnected(maintopic, SetRetainFlag);
         }

--- a/code/components/jomjol_mqtt/interface_mqtt.h
+++ b/code/components/jomjol_mqtt/interface_mqtt.h
@@ -13,7 +13,7 @@ bool MQTT_Configure(std::string _mqttURI, std::string _clientid, std::string _us
                     std::string _maintopic, std::string _lwt, std::string _lwt_connected, std::string _lwt_disconnected,
                     int _keepalive, int SetRetainFlag, void *callbackOnConnected);
 int MQTT_Init();
-void MQTTdestroy_client();
+void MQTTdestroy_client(bool _disable);
 
 bool MQTTPublish(std::string _key, std::string _content, int retained_flag = 1);            // retained Flag as Standart
 

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -65,17 +65,16 @@ bool isSetupModusActive() {
 void KillTFliteTasks()
 {
     #ifdef DEBUG_DETAIL_ON      
-        ESP_LOGD(TAG, "Handle: xHandletask_autodoFlow: %ld", (long) xHandletask_autodoFlow);
+        ESP_LOGD(TAG, "KillTFliteTasks: xHandletask_autodoFlow: %ld", (long) xHandletask_autodoFlow);
     #endif
-    if (xHandletask_autodoFlow != NULL)
+    if( xHandletask_autodoFlow != NULL )
     {
-        TaskHandle_t xHandletask_autodoFlowTmp = xHandletask_autodoFlow;
+        vTaskDelete(xHandletask_autodoFlow);
         xHandletask_autodoFlow = NULL;
-        vTaskDelete(xHandletask_autodoFlowTmp);
-        #ifdef DEBUG_DETAIL_ON      
-            ESP_LOGD(TAG, "Killed: xHandletask_autodoFlow");
-        #endif
     }
+    #ifdef DEBUG_DETAIL_ON      
+    	ESP_LOGD(TAG, "Killed: xHandletask_autodoFlow");
+    #endif
 }
 
 

--- a/code/components/jomjol_wlan/connect_wlan.h
+++ b/code/components/jomjol_wlan/connect_wlan.h
@@ -13,6 +13,7 @@ std::string* getIPAddress();
 std::string* getSSID();
 int get_WIFI_RSSI();
 bool getWIFIisConnected();
+void WIFIDestroy();
 
 extern std::string hostname;
 extern std::string std_hostname;


### PR DESCRIPTION
Ensure a proper reboot without/less execeptions to avoid/reduce delayed flow start after system is back online

- Deinit components before reboot gets initiated (esp_restart --> this is only a CPU reset)
- The hard_reset call shouldn' t be needed (only if esp_restart would be stalled, WDT needs to be enabled)