### PR TITLE
Fetch an available resource after reboot

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -628,7 +628,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_reboot");
     ESP_LOGI(TAG, "!!! System will restart within 5 sec!!!");
-    const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s<br>(in case of a firmware update it can take up to 180s).<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch(window.location.hostname,{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 1000);</script>";
+    const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s<br>(in case of a firmware update it can take up to 180s).<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch('/index.html',{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 5000);</script>";
     httpd_resp_send(req, resp_str, strlen(resp_str)); 
     
     doReboot();


### PR DESCRIPTION
Reduce 404 errors at startup phase:

- Fetch an available resource instead of hostname after reboot initiated to avoid a ton of 404 errors at startup phase
- Lower frequency of "pings" -> only every 5s