### PR TITLE
Fix regression of reboot handler / reboot waiting script

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -604,6 +604,8 @@ void task_reboot(void *KillAutoFlow)
     fwrite(_s_zw.c_str(), strlen(_s_zw.c_str()), 1, pfile);
     fclose(pfile);
 
+    vTaskDelay(3000 / portTICK_PERIOD_MS);
+
     if ((bool)KillAutoFlow) {
         KillTFliteTasks();  // Kill autoflow task if executed in extra task, if not don't kill parent task
     }

--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -93,7 +93,7 @@ void task_do_Update_ZIP(void *pvParameter)
         }
 
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Trigger reboot due to firmware update.");
-        doReboot();
+        doRebootOTA();
     }
     else
     {

--- a/code/components/jomjol_fileserver_ota/server_ota.h
+++ b/code/components/jomjol_fileserver_ota/server_ota.h
@@ -13,6 +13,7 @@
 void register_server_ota_sdcard_uri(httpd_handle_t server);
 void CheckOTAUpdate();
 void doReboot();
+void doRebootOTA();
 void hard_restart();
 void CheckUpdate();
 

--- a/code/main/softAP.cpp
+++ b/code/main/softAP.cpp
@@ -180,7 +180,7 @@ esp_err_t reboot_handlerAP(httpd_req_t *req)
     LogFile.WriteHeapInfo("handler_ota_update - Start");    
 #endif
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Trigger reboot due to firmware update.");
-    doReboot();
+    doRebootOTA();
     return ESP_OK;
 };
 

--- a/sd-card/html/overview.html
+++ b/sd-card/html/overview.html
@@ -81,45 +81,43 @@ function addZero(i) {
 	}
 
 
+	$(document).ready(function() {
+		LoadData();
+		LoadROIImage();
+	});
+
+
 	function LoadData(){
-	loadStatus();
-	loadCPUTemp();
-	loadRSSI();
-	loadUptime();
-	loadRoundCounter();
 		loadValue("value", "value");
 		loadValue("raw", "raw");
 		loadValue("prevalue", "prevalue");
 		loadValue("error", "error", "font-size:8px");
+		loadStatus();
+		loadCPUTemp();
+		loadRSSI();
+		loadUptime();
+		loadRoundCounter();
 	}
 
 
 	function LoadROIImage(){
 		var d = new Date();
+		var timestamp = d.getTime();
 		var h = addZero(d.getHours());
 		var m = addZero(d.getMinutes());
 		var s = addZero(d.getSeconds());
-		$('#img').html('<img src="/img_tmp/alg_roi.jpg" style="max-height:555px; display:block; margin-left:auto;  margin-right:auto;"></img>');
+		$('#img').html('<img src="/img_tmp/alg_roi.jpg?timestamp='+ timestamp +'" max-height:555px; display:block; margin-left:auto;  margin-right:auto;"></img>');
 		$('#timestamp').html("Last Page Refresh:" + (h + ":" + m + ":" + s));
 	}
 
 
 	function Refresh() {
-	setTimeout (function() {
+		setTimeout (function() {
 			LoadData();
-
-	var d = new Date();
-			var timestamp = d.getTime();
-	var h = addZero(d.getHours());
-	var m = addZero(d.getMinutes());
-	var s = addZero(d.getSeconds());	
-			// reassign the url to be like alg_roi.jpg?timestamp=456784512 based on timestamp to ensure image is getting reloaded
-			$('#img').html('<img src="/img_tmp/alg_roi.jpg?timestamp='+ timestamp +'" max-height:555px; display:block; margin-left:auto;  margin-right:auto;"></img>');
-	$('#timestamp').html("Last Page Refresh:" + (h + ":" + m + ":" + s));
-
+			LoadROIImage();
 			Refresh();
-	}, 300000);
-  }
+		}, 300000);
+	}
 
 
 	function loadStatus() {
@@ -235,8 +233,6 @@ function addZero(i) {
 
 	function init(){
 		basepath = getbasepath();
-		LoadData();
-		LoadROIImage();
 		Refresh();
 	}
 


### PR DESCRIPTION
Clean up the reboot handler topics comming up after my last changes (sorry guys for messing up).

- Fix regression after OTA reboot mentioned here #1715
- Restart ignored (mentioned also in #1715) was already fixesd with #1713
- Reboot waiting script (#1705):
   --> Revert ping time of 5s and set it back 1s
   --> Changed ping resource to ensure more reliable page reloading
- Optimization of overview.html (in addition to #1711)

@caco3 : Please test reboot behaviour, especially in terms of page reloading of overview after reboot
