### PR TITLE
Disable #define STBI_ONLY_JPEG again

### DIFF
--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -93,7 +93,7 @@
     //#define STB_IMAGE_IMPLEMENTATION
     //#define STB_IMAGE_WRITE_IMPLEMENTATION
     //#define STB_IMAGE_RESIZE_IMPLEMENTATION
-    #define STBI_ONLY_JPEG // (save 2% of Flash)
+    //#define STBI_ONLY_JPEG // (save 2% of Flash, but breaks the alignment mark generation, see https://github.com/jomjol/AI-on-the-edge-device/issues/1721)
 
     //interface_influxdb
     #define MAX_HTTP_OUTPUT_BUFFER 2048


### PR DESCRIPTION
The `#define STBI_ONLY_JPEG` breaks the alignment mark generation, see https://github.com/jomjol/AI-on-the-edge-device/issues/1721