### PR TITLE
consolidate remote test ip definition

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -212,6 +212,8 @@ static esp_err_t http_resp_dir_html(httpd_req_t *req, const char *dirpath, const
         return ESP_FAIL;
     }
 
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+
     /* Send HTML file header */
     httpd_resp_sendstr_chunk(req, "<!DOCTYPE html><html><body>");
 
@@ -344,12 +346,6 @@ static esp_err_t send_datafile(httpd_req_t *req, bool send_full_file)
 
     ESP_LOGD(TAG, "uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
 
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-
-
-    // Since the log file is still could open for writing, we need to close it first
-    LogFile.CloseLogFileAppendHandle();
-
     fd = fopen(currentfilename.c_str(), "r");
     if (!fd) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to read existing file: " + std::string(filepath) +"!");
@@ -434,6 +430,8 @@ static esp_err_t send_logfile(httpd_req_t *req, bool send_full_file)
 
     ESP_LOGD(TAG, "uri: %s, filename: %s, filepath: %s", req->uri, filename, filepath);
 
+    // Since the log file is still could open for writing, we need to close it first
+    LogFile.CloseLogFileAppendHandle();
 
     fd = fopen(currentfilename.c_str(), "r");
     if (!fd) {
@@ -614,6 +612,8 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
     FILE *fd = NULL;
     struct stat file_stat;
 
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+
     /* Skip leading "/upload" from URI to get filename */
     /* Note sizeof() counts NULL termination hence the -1 */
     const char *filename = get_path_from_uri(filepath, ((struct file_server_data *)req->user_ctx)->base_path,
@@ -763,6 +763,8 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
     std::string _task;
     std::string directory;
     std::string zw; 
+
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
 
     if (httpd_req_get_url_query_str(req, _query, 200) == ESP_OK)
     {

--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -666,7 +666,7 @@ esp_err_t handler_reboot(httpd_req_t *req)
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_reboot");
     ESP_LOGI(TAG, "!!! System will restart within 5 sec!!!");
-    const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s<br>(in case of a firmware update it can take up to 180s).<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch('/reboot_page.html',{mode: 'no-cors'}).then(r=>{parent.location.href=('/index.html');})}, 1000);</script>";
+    const char* resp_str = "<body style='font-family: arial'> <h3 id=t></h3></body><script>var h='Rebooting!<br>The page will automatically reload in around 25..60s<br>(in case of a firmware update it can take up to 180s).<br>'; document.getElementById('t').innerHTML=h; setInterval(function (){h +='.'; document.getElementById('t').innerHTML=h; fetch('reboot_page.html',{mode: 'no-cors'}).then(r=>{parent.location.href=('index.html');})}, 1000);</script>";
     httpd_resp_send(req, resp_str, strlen(resp_str)); 
     
     doReboot();

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -147,6 +147,7 @@ esp_err_t handler_init(httpd_req_t *req)
     doInit();
 
     resp_str = "Init done<br>";
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
     httpd_resp_send(req, resp_str, strlen(resp_str));     
     /* Respond with an empty chunk to signal HTTP response completion */
     httpd_resp_send_chunk(req, NULL, 0);    
@@ -178,6 +179,8 @@ esp_err_t handler_flow_start(httpd_req_t *req) {
         const char* resp_str = "WARNING: Flow start triggered by REST API, but flow is not active";
         httpd_resp_send(req, resp_str, strlen(resp_str));  
     }
+
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
 
     /* Respond with an empty chunk to signal HTTP response completion */
     httpd_resp_send_chunk(req, NULL, 0);    
@@ -420,6 +423,8 @@ esp_err_t handler_editflow(httpd_req_t *req)
     char _query[200];
     char _valuechar[30];
     string _task;
+
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
 
     if (httpd_req_get_url_query_str(req, _query, 200) == ESP_OK)
     {

--- a/sd-card/html/backup.html
+++ b/sd-card/html/backup.html
@@ -40,12 +40,10 @@ input[type=number] {
 </body>
 
 
+<script src="common.js"></script>
 <script src="jszip.min.js"></script>
 <script src="FileSaver.min.js"></script>
 <script>
-
-//var domain = "http://192.168.1.153"; // Testing
-var domain = "";
 
 function startBackup() {  
     document.getElementById("progress").innerHTML = "Creating backup...<br>\n";
@@ -53,7 +51,7 @@ function startBackup() {
     // Get hostname
     try {
         var xhttp = new XMLHttpRequest();
-        xhttp.open("GET", domain + "/info?type=Hostname", false);
+        xhttp.open("GET", getDomainname() + "/info?type=Hostname", false);
         xhttp.send();
         hostname = xhttp.responseText;
     }
@@ -72,7 +70,7 @@ function startBackup() {
     setStatus("Fetching File List...");
     try {
         var xhttp = new XMLHttpRequest();
-        xhttp.open("GET", domain + "/fileserver/config/", false);
+        xhttp.open("GET", getDomainname() + "/fileserver/config/", false);
         xhttp.send();
         
         var parser = new DOMParser();
@@ -88,7 +86,7 @@ function startBackup() {
     
     for (a of list) {
         url = a.getAttribute("href");
-        urls.push(domain + url);
+        urls.push(getDomainname() + url);
     }
     
     // Pack as zip and download

--- a/sd-card/html/common.js
+++ b/sd-card/html/common.js
@@ -1,8 +1,52 @@
  
-var basepath = "http://192.168.178.22";
+/* The UI can also be run locally, but you have to set the IP of your devide accordingly.
+ * And you also might have to disable CORS in your webbrowser! */
+var domainname_for_testing = "192.168.1.153";
+
+
+
+function gethost_Version(){
+    return "1.0.0 - 20200910";
+}
+
+
+/* Returns the domainname with prepended protocol.
+Eg. http://watermeter.fritz.box or http://192.168.1.5 */
+function getDomainname(){
+    var host = window.location.hostname;
+    if (((host == "127.0.0.1") || (host == "localhost") || (host == "")) 
+//       && ((window.location.port == "80") || (window.location.port == ""))
+       )
+    
+    {
+        console.log("Using pre-defined domainname for testing: " + domainname_for_testing);
+        domainname = "http://" + domainname_for_testing
+    }
+    else
+    {
+        domainname = window.location.protocol + "//" + host;
+        if (window.location.port != "") {
+            domainname = domainname + ":" + window.location.port;
+        }
+    }
+
+    return domainname;
+}
+
+function UpdatePage(_dosession = true){
+    var zw = location.href;
+    zw = zw.substr(0, zw.indexOf("?"));
+    if (_dosession) {
+        window.location = zw + '?session=' + Math.floor((Math.random() * 1000000) + 1); 
+    }
+    else {
+        window.location = zw; 
+    }
+}
+
         
 function LoadHostname() {
-    _basepath = getbasepath(); 
+    _domainname = getDomainname(); 
 
 
     var xhttp = new XMLHttpRequest();
@@ -19,7 +63,7 @@ function LoadHostname() {
 
 //     var xhttp = new XMLHttpRequest();
     try {
-            url = _basepath + '/info?type=Hostname';     
+            url = _domainname + '/info?type=Hostname';     
             xhttp.open("GET", url, true);
             xhttp.send();
 
@@ -35,7 +79,7 @@ var fwVersion = "";
 var webUiVersion = "";
 
 function LoadFwVersion() {
-    _basepath = getbasepath(); 
+    _domainname = getDomainname(); 
 
     var xhttp = new XMLHttpRequest();
     xhttp.addEventListener('load', function(event) {
@@ -52,7 +96,7 @@ function LoadFwVersion() {
     });
 
     try {
-        url = _basepath + '/info?type=FirmwareVersion';     
+        url = _domainname + '/info?type=FirmwareVersion';     
         xhttp.open("GET", url, true);
         xhttp.send();
     }
@@ -62,7 +106,7 @@ function LoadFwVersion() {
 }
 
 function LoadWebUiVersion() {
-    _basepath = getbasepath(); 
+    _domainname = getDomainname(); 
 
     var xhttp = new XMLHttpRequest();
     xhttp.addEventListener('load', function(event) {
@@ -78,7 +122,8 @@ function LoadWebUiVersion() {
     });
 
     try {
-        url = _basepath + '/info?type=HTMLVersion';     
+        url = _domainname + '/info?type=HTMLVersion';     
+        console.log("url");
         xhttp.open("GET", url, true);
         xhttp.send();
     }

--- a/sd-card/html/data.html
+++ b/sd-card/html/data.html
@@ -30,21 +30,22 @@
                 font-size: small;
             }
         </style>
+        <script type="text/javascript" src="common.js"></script> 
     </head>
     <body>
         <div class="box">
             <div class="row header">
                 <button onClick="reload();">Reload</button>
-                <button onClick="window.open('datafileact');">Show full data</button>
-                <button onClick="window.location.href = 'fileserver/log/data/'">Show older data files</button>
-                <a href="graph.html" target="_self">Show graph</a>
+                <button onClick="window.open(getDomainname() + '/datafileact');">Show full data</button>
+                <button onClick="window.location.href = getDomainname() + '/fileserver/log/data/'">Show older data files</button>
+                <button onClick="window.location.href = 'graph.html'">Show graph</button>
             </div>
             <div class="row content" id="data"><br><br><br><b>Loading Data file, please wait...</b></div>
             <div class="row footer">
                 <button onClick="reload();">Reload</button>
-                <button onClick="window.open('datafileact');">Show full data</button>
-                <button onClick="window.location.href = 'fileserver/log/data/'">Show older data files</button>
-                <a href="graph.html" target="_self">Show graph</a>
+                <button onClick="window.open(getDomainname() + '/datafileact');">Show full data</button>
+                <button onClick="window.location.href = getDomainname() + '/fileserver/log/data/'">Show older data files</button>
+                <button onClick="window.location.href = 'graph.html'">Show graph</button>
             </div>
           </div>
     </body>
@@ -53,7 +54,7 @@
         function reload() {
             document.getElementById('data').innerHTML += "<br><b>Reloading...<b><br><br>";
             window.scrollBy(0,document.body.scrollHeight);
-            funcRequest('data');
+            funcRequest(getDomainname() + '/data');
         } 
 
         async function funcRequest(url){
@@ -76,7 +77,7 @@
             });
         }
 
-        funcRequest('data');
+        funcRequest(getDomainname() + '/data');
 
     </script>
 </html>

--- a/sd-card/html/edit_alignment.html
+++ b/sd-card/html/edit_alignment.html
@@ -93,9 +93,9 @@ select {
 	  </tr>  
 	</table>
 
-<script type="text/javascript" src="./gethost.js"></script> 
-<script type="text/javascript" src="./readconfigcommon.js"></script>
-<script type="text/javascript" src="./readconfigparam.js"></script>  
+<script type="text/javascript" src="common.js"></script> 
+<script type="text/javascript" src="readconfigcommon.js"></script>
+<script type="text/javascript" src="readconfigparam.js"></script>  
 
 <script language="JavaScript">
         var canvas = document.getElementById('canvas'),
@@ -107,13 +107,12 @@ select {
             refInfo,
             enhanceCon = false,
             param;
-            basepath = "http://192.168.178.26";
-            basepath = "",
+            domainname = getDomainname();
             param;
     
 function doReboot() {
     if (confirm("Are you sure you want to reboot? Did you save the config?")) {
-            var stringota = "/reboot";
+            var stringota = getDomainname() + "/reboot";
             window.location = stringota;
             window.location.href = stringota;
             window.location.assign(stringota);
@@ -128,8 +127,8 @@ function ChangeSelection(){
 
 function SaveToConfig(){
     WriteConfigININew();
-    UpdateConfigReference(basepath)
-    SaveConfigToServer(basepath);
+    UpdateConfigReference(domainname)
+    SaveConfigToServer(domainname);
 	alert("Config.ini is updated!");
 }
 
@@ -141,7 +140,7 @@ function EnhanceContrast(){
     refInfo[aktindex]["dy"] = document.getElementById("refdy").value;       
 
     enhanceCon = true;
-    MakeContrastImageZW(refInfo[aktindex], enhanceCon, basepath);
+    MakeContrastImageZW(refInfo[aktindex], enhanceCon, domainname);
     UpdateReference();
 }
 
@@ -158,11 +157,11 @@ function UpdateReference(){
 
     _filenameurl = refInfo[aktindex]["name"].replace("/config/", "/img_tmp/");
 
-    var url = basepath + "/fileserver" + _filenameurl + "?"  + Date.now();
+    var url = domainname + "/fileserver" + _filenameurl + "?"  + Date.now();
     document.getElementById("img_ref").src = url;
 
     _filenameurl = _filenameurl.replace(".jpg", "_org.jpg");
-    var url = basepath + "/fileserver" + _filenameurl +  "?" + Date.now();
+    var url = domainname + "/fileserver" + _filenameurl +  "?" + Date.now();
     document.getElementById("img_ref_org").src = url;
 
     document.getElementById("name").value = refInfo[aktindex]["name"];
@@ -214,17 +213,17 @@ function dataURLtoBlob(dataurl) {
     
     
         function init() { 
-            basepath = getbasepath();
-            loadConfig(basepath); 
+            domainname = getDomainname();
+            loadConfig(domainname); 
             ParseConfig();
             param = getConfigParameters();
 
             canvas.addEventListener('mousedown', mouseDown, false);
             canvas.addEventListener('mouseup', mouseUp, false);
             canvas.addEventListener('mousemove', mouseMove, false);
-            loadCanvas(basepath + "/fileserver/config/reference.jpg");
+            loadCanvas(domainname + "/fileserver/config/reference.jpg");
 
-            CopyReferenceToImgTmp(basepath);
+            CopyReferenceToImgTmp(domainname);
             refInfo = GetReferencesInfo();
 
             UpdateReference();
@@ -247,7 +246,7 @@ function dataURLtoBlob(dataurl) {
             refInfo[aktindex]["y"] = document.getElementById("refy").value; 
             refInfo[aktindex]["dx"] = document.getElementById("refdx").value;
             refInfo[aktindex]["dy"] = document.getElementById("refdy").value;   
-            MakeRefZW(refInfo[aktindex], basepath); 
+            MakeRefZW(refInfo[aktindex], domainname); 
             UpdateReference();
             document.getElementById("enhancecontrast").disabled = false;
         }

--- a/sd-card/html/edit_analog.html
+++ b/sd-card/html/edit_analog.html
@@ -140,9 +140,9 @@ th, td {
     </table>	
 
 
-    <script type="text/javascript" src="./gethost.js"></script> 
-    <script type="text/javascript" src="./readconfigcommon.js"></script>
-    <script type="text/javascript" src="./readconfigparam.js"></script>  
+    <script type="text/javascript" src="common.js"></script> 
+    <script type="text/javascript" src="readconfigcommon.js"></script>
+    <script type="text/javascript" src="readconfigparam.js"></script>  
     
 <script language="JavaScript">
         var canvas = document.getElementById('canvas'),
@@ -155,11 +155,11 @@ th, td {
             enhanceCon = false;
             lockAR = true;
             lockSizes = true;
-            basepath = "http://192.168.178.26";
+            domainname = getDomainname();
     
 function doReboot() {
     if (confirm("Are you sure you want to reboot? Did you save the config?")) {
-            var stringota = "/reboot";
+            var stringota = getDomainname() + "/reboot";
             window.location = stringota;
             window.location.href = stringota;
             window.location.assign(stringota);
@@ -280,7 +280,7 @@ function SaveToConfig(){
     _zwcat = getConfigCategory();
     _zwcat["Analog"]["enabled"] = document.getElementById("Category_Analog_enabled").checked;
     WriteConfigININew();
-    SaveConfigToServer(basepath);  
+    SaveConfigToServer(domainname);  
 	alert("Config.ini is updated!");
 }
 
@@ -398,12 +398,12 @@ function UpdateROIs(_sel){
     
     
         function init() {
-            basepath = getbasepath();
+            domainname = getDomainname();
             canvas.addEventListener('mousedown', mouseDown, false);
             canvas.addEventListener('mouseup', mouseUp, false);
             canvas.addEventListener('mousemove', mouseMove, false);
-            loadCanvas(basepath + "/fileserver/config/reference.jpg");
-            loadConfig(basepath); 
+            loadCanvas(domainname + "/fileserver/config/reference.jpg");
+            loadConfig(domainname); 
             ParseConfig();
             param = getConfigParameters(); 
             UpdateNUMBERS();

--- a/sd-card/html/edit_check.html
+++ b/sd-card/html/edit_check.html
@@ -50,22 +50,22 @@ p {font-size: 1em;}
     </tr>
 </table>
 
-<script type="text/javascript" src="./gethost.js"></script> 
-<script type="text/javascript" src="./readconfig.js"></script>  
+<script type="text/javascript" src="common.js"></script> 
+<script type="text/javascript" src="readconfig.js"></script>  
  
 <script type="text/javascript">
-    var basepath = "http://192.168.178.26";
+    var domainname = getDomainname();
 
     function doAnalog(){
         var xhttp = new XMLHttpRequest();
-        url = basepath + "/editflow?task=test_analog";
-        if (basepath.length > 0){
-            url = url + "&host=" + basepath;
+        url = domainname + "/editflow?task=test_analog";
+        if (domainname.length > 0){
+            url = url + "&host=" + domainname;
         }        
         xhttp.open("GET", url, false);
         xhttp.send();
         var html = xhttp.responseText;
-        html = html.replace("src=\"/", "src=\"" + basepath + "/");
+        html = html.replace("src=\"/", "src=\"" + domainname + "/");
 
         document.getElementById("maincontent").src = 'data:text/html,' + encodeURIComponent(html);
     }
@@ -73,14 +73,14 @@ p {font-size: 1em;}
 
     function doDigits(){
         var xhttp = new XMLHttpRequest();
-        url = basepath + "/editflow?task=test_digits";
-        if (basepath.length > 0){
-            url = url + "&host=" + basepath;
+        url = domainname + "/editflow?task=test_digits";
+        if (domainname.length > 0){
+            url = url + "&host=" + domainname;
         }        
         xhttp.open("GET", url, false);
         xhttp.send();
         var html = xhttp.responseText;
-        html = html.replace("src=\"/", "src=\"" + basepath + "/");
+        html = html.replace("src=\"/", "src=\"" + domainname + "/");
 
         document.getElementById("maincontent").src = 'data:text/html,' + encodeURIComponent(html);
     }
@@ -88,14 +88,14 @@ p {font-size: 1em;}
 
     function doAlign(){
         var xhttp = new XMLHttpRequest();
-        url = basepath + "/editflow?task=test_align";
-        if (basepath.length > 0){
-            url = url + "&host=" + basepath;
+        url = domainname + "/editflow?task=test_align";
+        if (domainname.length > 0){
+            url = url + "&host=" + domainname;
         }        
         xhttp.open("GET", url, false);
         xhttp.send();
         var html = xhttp.responseText;
-        html = html.replace("src=\"/", "src=\"" + basepath + "/");
+        html = html.replace("src=\"/", "src=\"" + domainname + "/");
 
         document.getElementById("maincontent").src = 'data:text/html,' + encodeURIComponent(html);
 
@@ -107,9 +107,9 @@ p {font-size: 1em;}
 
     function doTake(){
         var xhttp = new XMLHttpRequest();
-        url = basepath + "/editflow?task=test_take";
-        if (basepath.length > 0){
-            url = url + "&host=" + basepath;
+        url = domainname + "/editflow?task=test_take";
+        if (domainname.length > 0){
+            url = url + "&host=" + domainname;
         }
         xhttp.open("GET", url, false);
         xhttp.send();
@@ -122,7 +122,7 @@ p {font-size: 1em;}
     }
 
     function Init(){
-        basepath = getbasepath();
+        domainname = getDomainname();
         document.getElementById("align").disabled = true;
         document.getElementById("digits").disabled = true;
         document.getElementById("analog").disabled = true;

--- a/sd-card/html/edit_config.html
+++ b/sd-card/html/edit_config.html
@@ -41,26 +41,26 @@ textarea {
 	</tr>
 </table>
 
-<script type="text/javascript" src="./gethost.js"></script> 
-<script type="text/javascript" src="./readconfigcommon.js"></script>  
+<script type="text/javascript" src="common.js"></script> 
+<script type="text/javascript" src="readconfigcommon.js"></script>  
  
 <script type="text/javascript">
 	var canvas = document.getElementById('canvas'),
-		basepath = "http://192.168.178.26"; 
+		domainname = getDomainname(); 
 
 
 function LoadConfigNeu() {
-	basepath = getbasepath();  
-    loadConfig(basepath); 	
+	domainname = getDomainname();  
+    loadConfig(domainname); 	
 	document.getElementById("inputTextToSave").value = getConfig();
 	}
 
 function saveTextAsFile()
 {
 	if (confirm("Are you sure you want to update \"config.ini\"?")) {
-		FileDeleteOnServer("/config/config.ini", basepath);
+		FileDeleteOnServer("/config/config.ini", domainname);
 		var textToSave = document.getElementById("inputTextToSave").value;
-		FileSendContent(textToSave, "/config/config.ini", basepath);
+		FileSendContent(textToSave, "/config/config.ini", domainname);
 		alert("Config.ini is updated!")
 	}
 }

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -1427,13 +1427,13 @@ textarea {
 
 </div>
 
-<script type="text/javascript" src="./gethost.js"></script> 
-<script type="text/javascript" src="./readconfigcommon.js"></script>  
-<script type="text/javascript" src="./readconfigparam.js"></script>  
+<script type="text/javascript" src="common.js"></script> 
+<script type="text/javascript" src="readconfigcommon.js"></script>  
+<script type="text/javascript" src="readconfigparam.js"></script>  
  
 <script type="text/javascript">
 	var canvas = document.getElementById('canvas'),
-		basepath = "http://192.168.178.22"; 
+		domainname = getDomainname(); 
 		param;
 		category;
 		NUNBERSAkt = -1;
@@ -1448,8 +1448,8 @@ function LoadConfigNeu() {
 	}
 
 
-	basepath = getbasepath(); 
-	if (!loadConfig(basepath)) {
+	domainname = getDomainname(); 
+	if (!loadConfig(domainname)) {
 		alert("Config.ini could not be loaded!\nPlease reload the page.");
 		return;
 	} 
@@ -2064,14 +2064,14 @@ function saveTextAsFile()
 	if (confirm("Are you sure you want to update \"config.ini\"?")) {
 		ReadParameterAll();
 		WriteConfigININew();
-	    SaveConfigToServer(basepath);
+	    SaveConfigToServer(domainname);
 		alert("Config.ini is updated!")
 	}
 }
 
 function doReboot() {
 	if (confirm("Are you sure you want to reboot the ESP32?")) {
-		var stringota = "/reboot";
+		var stringota = getDomainname() + "/reboot";
 		window.location = stringota;
 		window.location.href = stringota;
 		window.location.assign(stringota);
@@ -2081,7 +2081,7 @@ function doReboot() {
 
 function editConfigDirect() {
 	if (confirm("Did you save your changes?")) {
-		var stringota = "/edit_config.html";
+		var stringota = getDomainname() + "/edit_config.html";
 		window.location = stringota;
 		window.location.href = stringota;
 		window.location.assign(stringota);

--- a/sd-card/html/edit_digits.html
+++ b/sd-card/html/edit_digits.html
@@ -131,11 +131,11 @@ th, td {
 	  </tr>  
 	</table>
 
-<script type="text/javascript" src="./gethost.js"></script> 
-<script type="text/javascript" src="./readconfigcommon.js"></script>
-<script type="text/javascript" src="./readconfigparam.js"></script>  
+<script type="text/javascript" src="common.js"></script> 
+<script type="text/javascript" src="readconfigcommon.js"></script>
+<script type="text/javascript" src="readconfigparam.js"></script>  
 
-<script type="text/javascript" src="./jquery-3.6.0.min.js"></script>  
+<script type="text/javascript" src="jquery-3.6.0.min.js"></script>  
 
 <script language="JavaScript">
         var canvas = document.getElementById('canvas'),
@@ -149,11 +149,11 @@ th, td {
             lockSizes = true;
             lockSpaceEquidistant = true;
             space = 3;
-            basepath = "http://192.168.1.151";
+            domainname = getDomainname();
 
     function doReboot() {
         if (confirm("Are you sure you want to reboot? Did you save the config?")) {
-                var stringota = "/reboot";
+                var stringota = getDomainname() + "/reboot";
                 window.location = stringota;
                 window.location.href = stringota;
                 window.location.assign(stringota);
@@ -283,7 +283,7 @@ function SaveToConfig(){
     _zwcat = getConfigCategory();
     _zwcat["Digits"]["enabled"] = document.getElementById("Category_Digits_enabled").checked;
     WriteConfigININew();
-    SaveConfigToServer(basepath); 
+    SaveConfigToServer(domainname); 
 	alert("Config.ini is updated!");
 }
 
@@ -400,12 +400,12 @@ function UpdateROIs(_sel){
         }
     
         function init() {
-            basepath = getbasepath();
+            domainname = getDomainname();
             canvas.addEventListener('mousedown', mouseDown, false);
             canvas.addEventListener('mouseup', mouseUp, false);
             canvas.addEventListener('mousemove', mouseMove, false);
-            loadCanvas(basepath + "/fileserver/config/reference.jpg");
-            loadConfig(basepath); 
+            loadCanvas(domainname + "/fileserver/config/reference.jpg");
+            loadConfig(domainname); 
             ParseConfig();
             param = getConfigParameters(); 
             UpdateNUMBERS();

--- a/sd-card/html/edit_explain_6.html
+++ b/sd-card/html/edit_explain_6.html
@@ -41,19 +41,19 @@ p {font-size: 1em;}
         <button class="button" onclick="reboot()">Leave Setup Modus and Reboot to Normal modus</button>
     </p>
 
-    <script type="text/javascript" src="./gethost.js"></script> 
-    <script type="text/javascript" src="./readconfigparam.js"></script> 
-    <script type="text/javascript" src="./readconfigcommon.js"></script> 
+    <script type="text/javascript" src="common.js"></script> 
+    <script type="text/javascript" src="readconfigparam.js"></script> 
+    <script type="text/javascript" src="readconfigcommon.js"></script> 
 
     <script type="text/javascript">
         var canvas = document.getElementById('canvas'),
-            basepath = "http://192.168.178.22"; 
+            domainname = getDomainname(); 
             aktstatu = 0;
     
     function reboot() {
         if (confirm("Do you want to leave the configuration mode and restart the ESP32?\n\nPlease reload the page in about 30s.")) {
-            basepath = getbasepath(); 
-            if (!loadConfig(basepath)) {
+            domainname = getDomainname(); 
+            if (!loadConfig(domainname)) {
                 alert("Setup Modus could not be deactivated!\Please retry.");
                 return;
             } 
@@ -63,7 +63,7 @@ p {font-size: 1em;}
             param["System"]["SetupMode"]["value1"] = "false";
 
             WriteConfigININew();
-            SaveConfigToServer(basepath);    
+            SaveConfigToServer(domainname);    
 
 
             var stringota = "/reboot";

--- a/sd-card/html/edit_reference.html
+++ b/sd-card/html/edit_reference.html
@@ -93,9 +93,9 @@ table {
 	</table>
 
 
-    <script type="text/javascript" src="./gethost.js"></script> 
-    <script type="text/javascript" src="./readconfigcommon.js"></script>  
-    <script type="text/javascript" src="./readconfigparam.js"></script>  
+    <script type="text/javascript" src="common.js"></script> 
+    <script type="text/javascript" src="readconfigcommon.js"></script>  
+    <script type="text/javascript" src="readconfigparam.js"></script>  
     
     
 
@@ -103,13 +103,13 @@ table {
         var canvas = document.getElementById('canvas'),
             ctx = canvas.getContext('2d'),
             imageObj = new Image()
-            basepath = "http://192.168.178.26";   
+            domainname = getDomainname();   
             isActReference = false;
             param;
             
         function doReboot() {
             if (confirm("Are you sure you want to reboot? Did you save the config?")) {
-                    var stringota = "/reboot";
+                    var stringota = getDomainname() + "/reboot";
                     window.location = stringota;
                     window.location.href = stringota;
                     window.location.assign(stringota);
@@ -126,15 +126,15 @@ table {
                 _brightness = document.getElementById("MakeImage_Brightness_value1").value;
                 _contrast = document.getElementById("MakeImage_Contrast_value1").value;
                 _saturation = document.getElementById("MakeImage_Saturation_value1").value;
-                url = basepath + "/editflow?task=test_take&bri=" + _brightness;
+                url = getDomainname() + "/editflow?task=test_take&bri=" + _brightness;
                 url = url + "&con=" + _saturation + "&sat=" + _saturation + "&int=" + _intensity;
             }
             else
             {
-                url = basepath + "/editflow?task=test_take";
+                url = domainname + "/editflow?task=test_take";
             }
-            if (basepath.length > 0){
-                url = url + "&host=" + basepath;
+            if (domainname.length > 0){
+                url = url + "&host=" + domainname;
             }
 
             xhttp.open("GET", url, false);
@@ -145,7 +145,7 @@ table {
         }
             
         function loadRawImage(){
-            url = basepath + "/img_tmp/raw.jpg" + "?session=" + Math.floor((Math.random() * 1000000) + 1);
+            url = getDomainname() + "/img_tmp/raw.jpg" + "?session=" + Math.floor((Math.random() * 1000000) + 1);
             document.getElementById("finerotate").disabled = false;
             document.getElementById("prerotateangle").disabled = false;  
             document.getElementById("updatereferenceimage").disabled = false;
@@ -189,7 +189,7 @@ table {
         }    
 
         function showReference(_param){
-            url = basepath + "/fileserver/config/reference.jpg" + "?session=" + Math.floor((Math.random() * 1000000) + 1);;
+            url = getDomainname() + "/fileserver/config/reference.jpg" + "?session=" + Math.floor((Math.random() * 1000000) + 1);;
             document.getElementById("finerotate").value = 0;
             document.getElementById("prerotateangle").value = _param["Alignment"]["InitialRotate"].value1;
 
@@ -263,9 +263,9 @@ table {
                 drawRotated(false);
 
                 WriteConfigININew();
-                SaveConfigToServer(basepath);    
+                SaveConfigToServer(getDomainname());    
 
-                SaveCanvasToImage(canvas, "/config/reference.jpg", true, basepath);
+                SaveCanvasToImage(canvas, "/config/reference.jpg", true, getDomainname());
                 showReference(param);
                 UpdatePage();
                 alert("Reference is updated!");
@@ -301,8 +301,7 @@ table {
 
         function init() {
             canvas.addEventListener('mousemove', mouseMove, false);    
-            basepath = getbasepath();  
-            loadConfig(basepath); 
+            loadConfig(getDomainname()); 
             ParseConfig();
             param = getConfigParameters();
 

--- a/sd-card/html/graph.html
+++ b/sd-card/html/graph.html
@@ -2,9 +2,9 @@
     <head>
     <script src='https://cdn.plot.ly/plotly-2.14.0.min.js'></script>
 
-    <script type="text/javascript" src="./gethost.js"></script> 
-    <script type="text/javascript" src="./readconfigcommon.js"></script>  
-    <script type="text/javascript" src="./readconfigparam.js"></script>  
+    <script type="text/javascript" src="common.js"></script> 
+    <script type="text/javascript" src="readconfigcommon.js"></script>  
+    <script type="text/javascript" src="readconfigparam.js"></script>  
 
     <style>
         textarea {
@@ -31,7 +31,7 @@
             <option value="6">Change-Absolut</option>
         </select>
         
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href=fileserver/log/data/>Download</a>
+        <button onClick="window.location.href = getDomainname() + '/fileserver/log/data/'">Show data files</button>
 
   <!-- <button onclick="document.getElementById('editor').hidden = false; this.hidden = true;" >Editor</button> -->
     <div id='editor' hidden='true'>
@@ -41,8 +41,8 @@ numbername = document.getElementById("numbers").value;
 datatype = document.getElementById("datatype").value;
 //alert("Auslesen: " + datefile + " " + numbername);
 
-_basepath = getbasepath(); 
-fetch(_basepath + '/fileserver/log/data/' + datefile)
+_domainname = getDomainname(); 
+fetch(_domainname + '/fileserver/log/data/' + datefile)
 .then(response => {
     // handle the response
     if (response.status == 404) {

--- a/sd-card/html/index.html
+++ b/sd-card/html/index.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="style.css" type="text/css" >
 
 <script type="text/javascript" src="common.js"></script>
-<script type="text/javascript" src="gethost.js"></script>
+<script type="text/javascript" src="common.js"></script>
 <script type="text/javascript" src="readconfigcommon.js"></script>
 <script type="text/javascript" src="readconfigparam.js"></script>
 
@@ -79,9 +79,9 @@
         </li>
       </ul>
 
-    <li><a href="#" onclick="loadPage('value?full');">Recognition</a></li>
+    <li><a href="#" onclick="loadPage(getDomainname() + '/value?full');">Recognition</a></li>
     <li><a href="#" onclick="loadPage('graph.html');">Data Graph</a></li>
-    <li><a href="#" onclick="loadPage('fileserver/');">File Server</a></li>
+    <li><a href="#" onclick="loadPage(getDomainname() + '/fileserver/');">File Server</a></li>
     <li><a>System <i class="arrow down"></i></a>
         <ul class="submenu">
             <li><a href="#" onclick="loadPage('backup.html');">Backup/Restore</a></li>

--- a/sd-card/html/log.html
+++ b/sd-card/html/log.html
@@ -30,19 +30,20 @@
                 font-size: small;
             }
         </style>
+        <script type="text/javascript" src="common.js"></script> 
     </head>
     <body>
         <div class="box">
             <div class="row header">
                 <button onClick="reload();">Reload</button>
-                <button onClick="window.open('logfileact');">Show full log</button>
-                <button onClick="window.location.href = 'fileserver/log/message/'">Show older log files</button>
+                <button onClick="window.open(getDomainname() + '/logfileact');">Show full log</button>
+                <button onClick="window.location.href = getDomainname() + '/fileserver/log/message/'">Show older log files</button>
             </div>
             <div class="row content" id="log"><br><br><br><b>Loading Logfile, please wait...</b></div>
             <div class="row footer">
                 <button onClick="reload();">Reload</button>
-                <button onClick="window.open('logfileact');">Show full log</button>
-                <button onClick="window.location.href = 'fileserver/log/message/'">Show older log files</button>
+                <button onClick="window.open(getDomainname() + '/logfileact');">Show full log</button>
+                <button onClick="window.location.href = getDomainname() + '/fileserver/log/message/'">Show older log files</button>
             </div>
           </div>
     </body>
@@ -52,7 +53,7 @@
           //  document.getElementById('log').innerHTML += "<br><b>Reloading...<b><br><br>";
             document.getElementById('log').innerHTML += "<b>Reloading...</b>";
             window.scrollBy(0,document.body.scrollHeight);
-            funcRequest('log');
+            funcRequest(getDomainname() + '/log');
         } 
 
 
@@ -102,7 +103,7 @@
             });
         }
 
-        funcRequest('log');
+        funcRequest(getDomainname() + '/log');
 
     </script>
 </html>

--- a/sd-card/html/ota_page.html
+++ b/sd-card/html/ota_page.html
@@ -5,7 +5,7 @@
 <title>OTA Update</title>
 <meta charset="utf-8">
 
-<script type="text/javascript" src="./gethost.js"></script> 
+<script type="text/javascript" src="common.js"></script> 
 <style>
 h1 {font-size: 2em;}
 h2 {font-size: 1.5em;}
@@ -69,7 +69,7 @@ web interface (<i><span style="font-family:monospace">html__*.zip</span></i>). H
 
 <script language="JavaScript">
 
-var basepath = "http://192.168.178.26";
+var domainname = getDomainname();
 
 
 /* Max size of an individual file. Make sure this
@@ -82,7 +82,7 @@ var progressTimerHandle = null;
 
 
 function init(){
-    basepath = getbasepath();
+    domainname = getDomainname();
 
     document.getElementById("doUpdate").disabled = true;
 }
@@ -159,7 +159,7 @@ function prepareOnServer() {
 
     startProgressTimer("Server preparations...");
 
-    var _toDo = basepath + "/ota?task=emptyfirmwaredir";
+    var _toDo = domainname + "/ota?task=emptyfirmwaredir";
 	xhttp.open("GET", _toDo, true);
 	xhttp.send();
 }
@@ -235,7 +235,7 @@ function extract() {
 
     var nameneu = document.getElementById("newfile").value;
     filePath = nameneu.split(/[\\\/]/).pop();
-    var _toDo = basepath + "/ota?task=update&file=" + filePath;
+    var _toDo = domainname + "/ota?task=update&file=" + filePath;
     xhttp.open("GET", _toDo, true);
     xhttp.send();
 }

--- a/sd-card/html/overview.html
+++ b/sd-card/html/overview.html
@@ -68,12 +68,12 @@
 </table>
 
 
-<script src="/jquery-3.6.0.min.js"></script>
-<script type="text/javascript" src="./gethost.js"></script> 
-<script type="text/javascript" src="./readconfigcommon.js"></script> 
+<script src="jquery-3.6.0.min.js"></script>
+<script type="text/javascript" src="common.js"></script> 
+<script type="text/javascript" src="readconfigcommon.js"></script> 
 <script type="text/javascript">
 
-function addZero(i) {
+	function addZero(i) {
 	  if (i < 10) {
 		i = "0" + i;
 	  }
@@ -106,7 +106,7 @@ function addZero(i) {
 		var h = addZero(d.getHours());
 		var m = addZero(d.getMinutes());
 		var s = addZero(d.getSeconds());
-		$('#img').html('<img src="/img_tmp/alg_roi.jpg?timestamp='+ timestamp +'" max-height:555px; display:block; margin-left:auto;  margin-right:auto;"></img>');
+		$('#img').html('<img src=' + getDomainname() + '/img_tmp/alg_roi.jpg?timestamp='+ timestamp +'" max-height:555px; display:block; margin-left:auto;  margin-right:auto;"></img>');
 		$('#timestamp').html("Last Page Refresh:" + (h + ":" + m + ":" + s));
 	}
 
@@ -121,7 +121,7 @@ function addZero(i) {
 
 
 	function loadStatus() {
-		url = basepath + '/statusflow';     
+		url = domainname + '/statusflow';     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
@@ -135,7 +135,7 @@ function addZero(i) {
 
 
 	function loadCPUTemp() {
-		url = basepath + '/cpu_temperature';     
+		url = domainname + '/cpu_temperature';     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
@@ -149,7 +149,7 @@ function addZero(i) {
 
 
 	function loadRSSI() {
-		url = basepath + '/rssi';     
+		url = domainname + '/rssi';     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
@@ -163,7 +163,7 @@ function addZero(i) {
 
 
 	function loadUptime() {
-		url = basepath + '/uptime';     
+		url = domainname + '/uptime';     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
@@ -177,7 +177,7 @@ function addZero(i) {
 
 
 	function loadRoundCounter() {
-		url = basepath + '/info?type=Round';     
+		url = domainname + '/info?type=Round';     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
@@ -191,7 +191,7 @@ function addZero(i) {
 		
 	
 	function loadValue(_type, _div, _style) {
-		url = basepath + '/value?all=true&type=' + _type;     
+		url = domainname + '/value?all=true&type=' + _type;     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {
@@ -232,7 +232,7 @@ function addZero(i) {
 
 
 	function init(){
-		basepath = getbasepath();
+		domainname = getDomainname();
 		Refresh();
 	}
 

--- a/sd-card/html/prevalue_set.html
+++ b/sd-card/html/prevalue_set.html
@@ -69,12 +69,12 @@ input[type=number] {
 </body></html>
 
 
-<script type="text/javascript" src="./gethost.js"></script> 
-<script type="text/javascript" src="./readconfigcommon.js"></script>  
-<script type="text/javascript" src="./readconfigparam.js"></script>  
+<script type="text/javascript" src="common.js"></script> 
+<script type="text/javascript" src="readconfigcommon.js"></script>  
+<script type="text/javascript" src="readconfigparam.js"></script>  
 
 <script type="text/javascript">
- 	var basepath = "http://192.168.178.22"; 
+ 	var domainname = getDomainname(); 
   var	NUMBERS;
 
 function setprevalue() {
@@ -84,7 +84,7 @@ function setprevalue() {
 	inputVal = inputVal.replace(",", ".");
   	var xhttp = new XMLHttpRequest();
     try {
-          url = basepath + "/setPreValue?value=" + inputVal + "&numbers=" + _number;     
+          url = domainname + "/setPreValue?value=" + inputVal + "&numbers=" + _number;     
           xhttp.open("GET", url, false);
           xhttp.send();
           response = xhttp.responseText;
@@ -96,14 +96,14 @@ function setprevalue() {
     }
 }
 
-function loadPrevalue(_basepath) {
+function loadPrevalue(_domainname) {
   // Get current Pre Value
   var sel = document.getElementById("Numbers_value1");
   var _number = sel.options[sel.selectedIndex].text;
 
   var xhttp = new XMLHttpRequest();
   try {
-      url = _basepath + '/setPreValue?numbers=' + _number;
+      url = _domainname + '/setPreValue?numbers=' + _number;
       xhttp.open("GET", url, false);
       xhttp.send();
       response = xhttp.responseText;
@@ -120,7 +120,7 @@ function loadPrevalue(_basepath) {
 
   var xhttp = new XMLHttpRequest();
   try {
-    url = _basepath + '/value?all=true&type=raw';
+    url = _domainname + '/value?all=true&type=raw';
     xhttp.open("GET", url, false);
     xhttp.send();
     response = xhttp.responseText;
@@ -144,7 +144,7 @@ function loadPrevalue(_basepath) {
 
 
 function numberChanged(){
-  loadPrevalue(basepath);
+  loadPrevalue(domainname);
 }
 
 function UpdateNUMBERS(_sel){
@@ -170,16 +170,16 @@ function UpdateNUMBERS(_sel){
     }
     _index.selectedIndex = index;
 
-    loadPrevalue(basepath);
+    loadPrevalue(domainname);
 }
 
 
 function init(){
-	basepath = getbasepath();
-  loadConfig(basepath); 
+	domainname = getDomainname();
+  loadConfig(domainname); 
   ParseConfig();
   UpdateNUMBERS();
-  loadPrevalue(basepath);
+  loadPrevalue(domainname);
 }
 
 init();

--- a/sd-card/html/readconfigcommon.js
+++ b/sd-card/html/readconfigcommon.js
@@ -1,8 +1,4 @@
-function readconfig_Version(){
-     return "1.0.0 - 20200910";
- }
-
-function SaveConfigToServer(_basepath){
+function SaveConfigToServer(_domainname){
      // leere Zeilen am Ende löschen
      var zw = config_split.length - 1;
      while (config_split[zw] == "") {
@@ -15,16 +11,16 @@ function SaveConfigToServer(_basepath){
           config_gesamt = config_gesamt + config_split[i] + "\n";
      } 
 
-     FileDeleteOnServer("/config/config.ini", _basepath);
+     FileDeleteOnServer("/config/config.ini", _domainname);
 
-     FileSendContent(config_gesamt, "/config/config.ini", _basepath);          
+     FileSendContent(config_gesamt, "/config/config.ini", _domainname);          
 }
 
-function UpdateConfig(zw, _index, _enhance, _basepath){
+function UpdateConfig(zw, _index, _enhance, _domainname){
      var namezw = zw["name"];
-     FileCopyOnServer("/img_tmp/ref_zw.jpg", namezw, _basepath);
+     FileCopyOnServer("/img_tmp/ref_zw.jpg", namezw, _domainname);
      var namezw = zw["name"].replace(".jpg", "_org.jpg");
-     FileCopyOnServer("/img_tmp/ref_zw_org.jpg", namezw, _basepath);     
+     FileCopyOnServer("/img_tmp/ref_zw_org.jpg", namezw, _domainname);     
 }
 
 
@@ -134,10 +130,10 @@ function getConfig()
 }
 
      
-function loadConfig(_basepath) {
+function loadConfig(_domainname) {
      var xhttp = new XMLHttpRequest();
      try {
-          url = _basepath + '/fileserver/config/config.ini';     
+          url = _domainname + '/fileserver/config/config.ini';     
           xhttp.open("GET", url, false);
           xhttp.send();
           config_gesamt = xhttp.responseText;
@@ -162,8 +158,8 @@ function dataURLtoBlob(dataurl) {
      return new Blob([u8arr], {type:mime});
      }	
      
-function FileCopyOnServer(_source, _target, _basepath = ""){
-     url = _basepath + "/editflow?task=copy&in=" + _source + "&out=" + _target;
+function FileCopyOnServer(_source, _target, _domainname = ""){
+     url = _domainname + "/editflow?task=copy&in=" + _source + "&out=" + _target;
      var xhttp = new XMLHttpRequest();  
      try {
           xhttp.open("GET", url, false);
@@ -174,7 +170,7 @@ function FileCopyOnServer(_source, _target, _basepath = ""){
      }
 }
 
-function FileDeleteOnServer(_filename, _basepath = ""){
+function FileDeleteOnServer(_filename, _domainname = ""){
      var xhttp = new XMLHttpRequest();
      var okay = false;
 
@@ -192,7 +188,7 @@ function FileDeleteOnServer(_filename, _basepath = ""){
           }
      };
      try {
-          var url = _basepath + "/delete" + _filename;
+          var url = _domainname + "/delete" + _filename;
           xhttp.open("POST", url, false);
           xhttp.send();
      }
@@ -204,7 +200,7 @@ function FileDeleteOnServer(_filename, _basepath = ""){
      return okay;
 }
 
-function FileSendContent(_content, _filename, _basepath = ""){
+function FileSendContent(_content, _filename, _domainname = ""){
      var xhttp = new XMLHttpRequest();  
      var okay = false;
 
@@ -221,7 +217,7 @@ function FileSendContent(_content, _filename, _basepath = ""){
      };
 
      try {
-          upload_path = _basepath + "/upload" + _filename;
+          upload_path = _domainname + "/upload" + _filename;
           xhttp.open("POST", upload_path, false);
           xhttp.send(_content);
      }
@@ -233,21 +229,21 @@ function FileSendContent(_content, _filename, _basepath = ""){
 }
 
 
-function SaveCanvasToImage(_canvas, _filename, _delete = true, _basepath = ""){
+function SaveCanvasToImage(_canvas, _filename, _delete = true, _domainname = ""){
      var JPEG_QUALITY=0.8;
      var dataUrl = _canvas.toDataURL('image/jpeg', JPEG_QUALITY);	
      var rtn = dataURLtoBlob(dataUrl);
 
      if (_delete) {
-          FileDeleteOnServer(_filename, _basepath);
+          FileDeleteOnServer(_filename, _domainname);
      }
 	
-     FileSendContent(rtn, _filename, _basepath);
+     FileSendContent(rtn, _filename, _domainname);
 }
 
-function MakeContrastImageZW(zw, _enhance, _basepath){
+function MakeContrastImageZW(zw, _enhance, _domainname){
      _filename = zw["name"].replace("/config/", "/img_tmp/");
-     url = _basepath + "/editflow?task=cutref&in=/config/reference.jpg&out=" + _filename + "&x=" + zw["x"] + "&y="  + zw["y"] + "&dx=" + zw["dx"] + "&dy=" + zw["dy"];
+     url = _domainname + "/editflow?task=cutref&in=/config/reference.jpg&out=" + _filename + "&x=" + zw["x"] + "&y="  + zw["y"] + "&dx=" + zw["dx"] + "&dy=" + zw["dy"];
      if (_enhance == true){
           url = url + "&enhance=true";
      }
@@ -264,10 +260,10 @@ function MakeContrastImageZW(zw, _enhance, _basepath){
 
 
 
-function MakeRefZW(zw, _basepath){
+function MakeRefZW(zw, _domainname){
      _filetarget = zw["name"].replace("/config/", "/img_tmp/");
      _filetarget = _filetarget.replace(".jpg", "_org.jpg");
-     url = _basepath + "/editflow?task=cutref&in=/config/reference.jpg&out="+_filetarget+"&x=" + zw["x"] + "&y="  + zw["y"] + "&dx=" + zw["dx"] + "&dy=" + zw["dy"];
+     url = _domainname + "/editflow?task=cutref&in=/config/reference.jpg&out="+_filetarget+"&x=" + zw["x"] + "&y="  + zw["y"] + "&dx=" + zw["dx"] + "&dy=" + zw["dy"];
      var xhttp = new XMLHttpRequest();  
      try {
           xhttp.open("GET", url, false);
@@ -278,6 +274,6 @@ function MakeRefZW(zw, _basepath){
      }
      _filetarget2 = zw["name"].replace("/config/", "/img_tmp/");
 //     _filetarget2 = _filetarget2.replace(".jpg", "_org.jpg");
-     FileCopyOnServer(_filetarget, _filetarget2, _basepath);
+     FileCopyOnServer(_filetarget, _filetarget2, _domainname);
 }
 

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -1,7 +1,3 @@
-function readconfig_Version(){
-     return "1.0.0 - 20200910";
- }
-
 var config_gesamt = "";
 var config_split = [];
 var param = [];
@@ -12,7 +8,7 @@ var REFERENCES = new Array(0);
 
 
 function getNUMBERSList() {
-	_basepath = getbasepath(); 
+	_domainname = getDomainname(); 
      var datalist = "";
 
 	var xhttp = new XMLHttpRequest();
@@ -25,7 +21,7 @@ function getNUMBERSList() {
 	 });
 
 	 try {
-		  url = _basepath + '/editflow?task=namenumbers';     
+		  url = _domainname + '/editflow?task=namenumbers';     
 		  xhttp.open("GET", url, false);
 		  xhttp.send();
 
@@ -43,7 +39,7 @@ function getNUMBERSList() {
 
 
 function getDATAList() {
-	_basepath = getbasepath(); 
+	_domainname = getDomainname(); 
      tflitelist = "";
 
 	var xhttp = new XMLHttpRequest();
@@ -56,7 +52,7 @@ function getDATAList() {
 	 });
 
 	 try {
-		  url = _basepath + '/editflow?task=data';     
+		  url = _domainname + '/editflow?task=data';     
 		  xhttp.open("GET", url, false);
 		  xhttp.send();
 
@@ -74,7 +70,7 @@ function getDATAList() {
 
 
 function getTFLITEList() {
-	_basepath = getbasepath(); 
+	_domainname = getDomainname(); 
      tflitelist = "";
 
 	var xhttp = new XMLHttpRequest();
@@ -87,7 +83,7 @@ function getTFLITEList() {
 	 });
 
 	 try {
-		  url = _basepath + '/editflow?task=tflite';     
+		  url = _domainname + '/editflow?task=tflite';     
 		  xhttp.open("GET", url, false);
 		  xhttp.send();
 
@@ -562,7 +558,7 @@ function isCommented(input)
           return [isComment, input];
      }    
 
-function SaveConfigToServer(_basepath){
+function SaveConfigToServer(_domainname){
      // leere Zeilen am Ende löschen
      var zw = config_split.length - 1;
      while (config_split[zw] == "") {
@@ -575,8 +571,8 @@ function SaveConfigToServer(_basepath){
           config_gesamt = config_gesamt + config_split[i] + "\n";
      } 
 
-     FileDeleteOnServer("/config/config.ini", _basepath);
-     FileSendContent(config_gesamt, "/config/config.ini", _basepath);          
+     FileDeleteOnServer("/config/config.ini", _domainname);
+     FileSendContent(config_gesamt, "/config/config.ini", _domainname);          
 }
 	 
 function getConfig() {
@@ -665,19 +661,19 @@ function getNUMBERS(_name, _type, _create = true)
 
  
 
-function CopyReferenceToImgTmp(_basepath)
+function CopyReferenceToImgTmp(_domainname)
 {
      for (index = 0; index < 2; ++index)
      {
           _filenamevon = REFERENCES[index]["name"];
           _filenamenach = _filenamevon.replace("/config/", "/img_tmp/");
-          FileDeleteOnServer(_filenamenach, _basepath);
-          FileCopyOnServer(_filenamevon, _filenamenach, _basepath);
+          FileDeleteOnServer(_filenamenach, _domainname);
+          FileCopyOnServer(_filenamevon, _filenamenach, _domainname);
      
           _filenamevon = _filenamevon.replace(".jpg", "_org.jpg");
           _filenamenach = _filenamenach.replace(".jpg", "_org.jpg");
-          FileDeleteOnServer(_filenamenach, _basepath);
-          FileCopyOnServer(_filenamevon, _filenamenach, _basepath);
+          FileDeleteOnServer(_filenamenach, _domainname);
+          FileCopyOnServer(_filenamevon, _filenamenach, _domainname);
      }
 }
 
@@ -686,18 +682,18 @@ function GetReferencesInfo(){
 }
 
 
-function UpdateConfigReference(_basepath){
+function UpdateConfigReference(_domainname){
      for (var index = 0; index < 2; ++index)
      {
           _filenamenach = REFERENCES[index]["name"];
           _filenamevon = _filenamenach.replace("/config/", "/img_tmp/");
-          FileDeleteOnServer(_filenamenach, _basepath);
-          FileCopyOnServer(_filenamevon, _filenamenach, _basepath);
+          FileDeleteOnServer(_filenamenach, _domainname);
+          FileCopyOnServer(_filenamevon, _filenamenach, _domainname);
      
           _filenamenach = _filenamenach.replace(".jpg", "_org.jpg");
           _filenamevon = _filenamevon.replace(".jpg", "_org.jpg");
-          FileDeleteOnServer(_filenamenach, _basepath);
-          FileCopyOnServer(_filenamevon, _filenamenach, _basepath);
+          FileDeleteOnServer(_filenamenach, _domainname);
+          FileCopyOnServer(_filenamevon, _filenamenach, _domainname);
 
      }
 }

--- a/sd-card/html/reboot_page.html
+++ b/sd-card/html/reboot_page.html
@@ -18,6 +18,7 @@ p {font-size: 1em;}
 }
 </style>
 
+<script type="text/javascript" src="common.js"></script> 
 </head>
 
 <body style="font-family: arial; padding: 0px 10px;">
@@ -35,7 +36,7 @@ p {font-size: 1em;}
 <script>
 function doReboot() {
 	// if (confirm("Are you sure you want to reboot the ESP32?")) {
-		var stringota = "/reboot";
+		var stringota = getDomainname() + "/reboot";
 		window.location = stringota;
 		window.location.href = stringota;
 		window.location.assign(stringota);

--- a/sd-card/html/setup.html
+++ b/sd-card/html/setup.html
@@ -58,9 +58,10 @@ p {font-size: 1em;}
 
  
 
+<script type="text/javascript" src="common.js"></script> 
 <script type="text/javascript">
 	var canvas = document.getElementById('canvas'),
-		basepath = "http://192.168.178.22"; 
+		domainname = getDomainname(); 
 		aktstatu = 0;
 
 function clickNext() {

--- a/sd-card/html/test.html
+++ b/sd-card/html/test.html
@@ -10,13 +10,13 @@
   <div id="value"></div>
 </html>
 
-<script type="text/javascript" src="./gethost.js"></script> 
+<script type="text/javascript" src="common.js"></script> 
 
 <script type="text/javascript">
-	var basepath = "http://192.168.178.22"; 
+	var domainname = getDomainname(); 
 	function testinit(){
-		basepath = getbasepath();
-		url = basepath + '/value?all=true';     
+		domainname = getDomainname();
+		url = domainname + '/value?all=true';     
 		var xhttp = new XMLHttpRequest();
 		xhttp.onreadystatechange = function() {
 			if (this.readyState == 4 && this.status == 200) {

--- a/sd-card/html/upload_script.html
+++ b/sd-card/html/upload_script.html
@@ -30,7 +30,7 @@
     </td></tr>
 </table>
 
-<script type="text/javascript" src="/fileserver/html/gethost.js"> 
+<script type="text/javascript" src="/fileserver/html/common.js"> 
 </script>            
 <script language="JavaScript">
 function setpath() {

--- a/sd-card/html/wlan_config.html
+++ b/sd-card/html/wlan_config.html
@@ -77,7 +77,7 @@ if (!file.name.includes("remote-setup")){if (!confirm("The zip file name should 
     
         var nameneu = document.getElementById("newfile").value;
         filePath = nameneu.split(/[\\\/]/).pop();
-        var _toDo = basepath + "/ota?task=update&file=" + filePath;
+        var _toDo = domainname + "/ota?task=update&file=" + filePath;
         xhttp.open("GET", _toDo, true);
         xhttp.send();
     }


### PR DESCRIPTION
- centralized Test-IP definition into `common.js`, now the IP has only to be adjusted in one place
- moved functions of `gethost.js` to `common.js` and deleted `gethost.js`
- renamed `basepath` => `domainname`
- added missing Access-Control-Allow-Origin
- cleanup

Notes:
For the following files remote testing does not fully work:
 - `reboot_page.html`
 - `info.html`