### PR TITLE
ClassFlowAlignment - Allocate only one ImageTMP

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -162,7 +162,7 @@ string ClassFlowAlignment::getHTMLSingleStep(string host)
 bool ClassFlowAlignment::doFlow(string time) 
 {
     if (!ImageTMP) 
-        ImageTMP = new CImageBasis(ImageBasis, 5);
+        ImageTMP = new CImageBasis(ImageBasis);
 
     delete AlignAndCutImage;
     


### PR DESCRIPTION
Allocate only one ImageTMP instead 5x

@jomjol: Do I have something overseen here?