### PR TITLE
Add testing environnements in platformio

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -79,6 +79,7 @@ board = esp32cam
 framework = espidf
 build_flags = 
 ;Add macro definition ENABLE_MQTT, ENABLE_INFLUXDB, DEBUG_DETAIL_ON
+;if ENABLE_SOFTAP = disabled, set CONFIG_ESP_WIFI_SOFTAP_SUPPORT=n in sdkconfig.defaults to save 28k of flash
 	-D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
 	${common:esp32-idf.build_flags}
 	${flags:runtime.build_flags}
@@ -93,6 +94,7 @@ board = node32s
 board_build.flash_mode = qio
 build_flags = 
 ;Add macro definition ENABLE_MQTT, ENABLE_INFLUXDB, DEBUG_DETAIL_ON
+;if ENABLE_SOFTAP = disabled, set CONFIG_ESP_WIFI_SOFTAP_SUPPORT=n in sdkconfig.defaults to save 28k of flash
 	-D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
 	${common:esp32-idf.build_flags}
 	${flags:clangtidy.build_flags}

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -8,29 +8,144 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-
 [platformio]
 src_dir = main
+default_envs = esp32cam
+
+[common:idf]
+build_flags = 
+	-DUSE_ESP_IDF
+lib_deps =
+
+[common:arduino]
+extends = common
+lib_deps =
+build_flags =
+    ${common.build_flags}
+    -DUSE_ARDUINO
+
+[common:esp32-idf]
+extends = common:idf
+platform = platformio/espressif32 @ 5.2.0
+platform_packages = 
+	;platformio/framework-espidf @ ~3.40402.0
+framework = espidf
+lib_deps = 
+	${common:idf.lib_deps}
+build_flags = 
+	${common:idf.build_flags}
+	-Wno-nonnull-compare
+	-DUSE_ESP32
+	-DUSE_ESP32_FRAMEWORK_ESP_IDF
+
+
+; These are common settings for the RP2040 using Arduino.
+[common:rp2040-arduino]
+extends = common:arduino
+board_build.core = earlephilhower
+board_build.filesystem_size = 0.5m
+
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+platform_packages =
+    earlephilhower/framework-arduinopico @ https://github.com/earlephilhower/arduino-pico/releases/download/2.6.2/rp2040-2.6.2.zip
+
+framework = arduino
+lib_deps =
+    ${common:arduino.lib_deps}
+build_flags =
+    ${common:arduino.build_flags}
+    -DUSE_RP2040
+    -DUSE_RP2040_FRAMEWORK_ARDUINO
+
+[flags:runtime]
+build_flags = 
+	-Wno-nonnull-compare
+	-Wno-sign-compare
+	-Wno-unused-but-set-variable
+	-Wno-unused-variable
+	-fno-exceptions
+
+[flags:clangtidy]
+build_flags = 
+	-Wall
+	-Wextra
+	-Wunreachable-code
+	-Wfor-loop-analysis
+	-Wshadow-field
+	-Wshadow-field-in-constructor
+	-Wshadow-uncaptured-local
+	-fno-exceptions
 
 [env:esp32cam]
-platform = espressif32@5.2.0
-;platform = espressif32@5.3.0
+extends = common:esp32-idf
 board = esp32cam
-;board = m5stack-core-esp32
 framework = espidf
-
-;Add macro definition ENABLE_MQTT, ENABLE_INFLUXDB, DEBUG_DETAIL_ON
-build_flags = -D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
-
-;board_build.partitions = partitions_singleapp.csv
+build_flags = 
+	-D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
+	${common:esp32-idf.build_flags}
+	${flags:runtime.build_flags}
 board_build.partitions = partitions.csv
-
 monitor_speed = 115200
 monitor_rts = 0
 monitor_dtr = 0
+;debug_tool = esp-prog
+;platform = espressif32
 
-debug_tool = esp-prog
 
-; Enable and adapt for logging over USB
-;upload_port = /dev/ttyUSB0
-;upload_port =com3
+[env:esp32cam-testing]
+extends = common:esp32-idf
+board = node32s
+board_build.flash_mode = qio
+build_flags = 
+	-D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
+	${common:esp32-idf.build_flags}
+	${flags:clangtidy.build_flags}
+framework = espidf
+lib_ldf_mode = deep+
+platform = platformio/espressif32 @ 5.2.0
+platform_packages = 
+    ;platformio/framework-espidf @ 3.40402.0 (4.4.2)
+    platformio/framework-espidf@^3.50000.0
+    ;platformio/tool-cmake @ 3.16.4
+    platformio/tool-cmake@^3.21.3
+    ;platformio/tool-esptoolpy @ 1.40201.0 (4.2.1)
+    platformio/tool-esptoolpy@^1.40400.0
+    ;platformio/tool-idf @ 1.0.1
+    ;platformio/tool-mconf @ 1.4060000.20190628 (406.0.0)
+    ;platformio/tool-ninja @ 1.9.0
+    platformio/tool-ninja @ 1.10.2
+    ;platformio/toolchain-esp32ulp @ 1.22851.191205 (2.28.51)
+    espressif/toolchain-esp32ulp @ 2.35.0-20220830
+    ;platformio/toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch3
+    ;platformio/toolchain-xtensa-esp32 @ 11.2.0+2022r1
+    
+board_build.partitions = partitions.csv
+monitor_speed = 115200
+monitor_rts = 0
+monitor_dtr = 0
+;debug_tool = esp-prog
+
+[env:esp32c3-idf-testing]
+extends = common:esp32-idf
+board = esp32-c3-devkitm-1
+board_build.esp-idf.sdkconfig_path = sdkconfig-esp32c3-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:clangtidy.build_flags}
+
+
+[env:esp32s2-idf-testing]
+extends = common:esp32-idf
+board = esp32-s2-kaluga-1
+board_build.esp-idf.sdkconfig_path = sdkconfig-esp32s2-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:clangtidy.build_flags}
+
+
+[env:rp2040-pico-arduino-testing]
+extends = common:rp2040-arduino
+board = rpipico
+build_flags =
+    ${common:rp2040-arduino.build_flags}
+    ${flags:clangtidy.build_flags}

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -141,6 +141,26 @@ build_flags =
     ${common:esp32-idf.build_flags}
     ${flags:clangtidy.build_flags}
 
+[env:esp-s3-eye-idf-testing]
+extends = common:esp32-idf
+board = esp32s3camlcd ;ESP-S3-EYE
+board_build.mcu = esp32s3
+board_build.f_cpu = 240000000L
+board_build.esp-idf.sdkconfig_path = sdkconfig-esp-s3-eye-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:clangtidy.build_flags}
+
+
+[env:m5stack-cam]
+extends = common:esp32-idf
+board = m5stack-timer-cam
+board_build.mcu = esp32
+board_build.f_cpu = 240000000L
+board_build.esp-idf.sdkconfig_path = sdkconfig-m5stack-cam-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:clangtidy.build_flags}
 
 [env:rp2040-pico-arduino-testing]
 extends = common:rp2040-arduino

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -78,6 +78,7 @@ extends = common:esp32-idf
 board = esp32cam
 framework = espidf
 build_flags = 
+;Add macro definition ENABLE_MQTT, ENABLE_INFLUXDB, DEBUG_DETAIL_ON
 	-D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
 	${common:esp32-idf.build_flags}
 	${flags:runtime.build_flags}
@@ -85,15 +86,13 @@ board_build.partitions = partitions.csv
 monitor_speed = 115200
 monitor_rts = 0
 monitor_dtr = 0
-;debug_tool = esp-prog
-;platform = espressif32
-
 
 [env:esp32cam-testing]
 extends = common:esp32-idf
 board = node32s
 board_build.flash_mode = qio
 build_flags = 
+;Add macro definition ENABLE_MQTT, ENABLE_INFLUXDB, DEBUG_DETAIL_ON
 	-D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
 	${common:esp32-idf.build_flags}
 	${flags:clangtidy.build_flags}
@@ -124,7 +123,6 @@ board_build.partitions = partitions.csv
 monitor_speed = 115200
 monitor_rts = 0
 monitor_dtr = 0
-;debug_tool = esp-prog
 
 [env:esp32c3-idf-testing]
 extends = common:esp32-idf

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -70,10 +70,7 @@ build_flags =
 	-Wall
 	-Wextra
 	-Wunreachable-code
-	-Wfor-loop-analysis
-	-Wshadow-field
-	-Wshadow-field-in-constructor
-	-Wshadow-uncaptured-local
+	-Wshadow-compatible-local
 	-fno-exceptions
 
 [env:esp32cam]
@@ -100,20 +97,24 @@ build_flags =
 	-D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
 	${common:esp32-idf.build_flags}
 	${flags:clangtidy.build_flags}
+    -D CONFIG_ESP_TASK_WDT
+    ;-D CONFIG_COMPILER_OPTIMIZATION_ASSERTION_LEVEL
+    -D CONFIG_SPIRAM
+    -D CONFIG_ESP_TASK_WDT_TIMEOUT_S ; fix for CONFIG_ESP_INT_WDT_TIMEOUT_MS
 framework = espidf
 lib_ldf_mode = deep+
 platform = platformio/espressif32 @ 5.2.0
 platform_packages = 
     ;platformio/framework-espidf @ 3.40402.0 (4.4.2)
-    platformio/framework-espidf@^3.50000.0
+    ;platformio/framework-espidf@^3.50000.0
     ;platformio/tool-cmake @ 3.16.4
-    platformio/tool-cmake@^3.21.3
+    ;platformio/tool-cmake@^3.21.3
     ;platformio/tool-esptoolpy @ 1.40201.0 (4.2.1)
     platformio/tool-esptoolpy@^1.40400.0
     ;platformio/tool-idf @ 1.0.1
     ;platformio/tool-mconf @ 1.4060000.20190628 (406.0.0)
     ;platformio/tool-ninja @ 1.9.0
-    platformio/tool-ninja @ 1.10.2
+    ;platformio/tool-ninja @ 1.10.2
     ;platformio/toolchain-esp32ulp @ 1.22851.191205 (2.28.51)
     espressif/toolchain-esp32ulp @ 2.35.0-20220830
     ;platformio/toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch3


### PR DESCRIPTION
1)Add fine tune for testing : 
```
[env:esp32cam-testing]
build_flags = 
	-D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
    -D CONFIG_ESP_TASK_WDT
    -D CONFIG_SPIRAM
    -D CONFIG_ESP_TASK_WDT_TIMEOUT_S ; fix for CONFIG_ESP_INT_WDT_TIMEOUT_MS
lib_ldf_mode = deep+
platform = platformio/espressif32 @ 5.2.0
platform_packages = 
    platformio/tool-esptoolpy@^1.40400.0
    espressif/toolchain-esp32ulp @ 2.35.0-20220830
  
```



2) More boards to test :
Add testing support for several boards as esp32c3, esp32s2, rp2040

3) Usage : 
You can invoke differents environnements :
```
platformio run --environment esp32cam-testing
platformio run --environment esp32c3-idf-testing
platformio run --environment esp32s2-idf-testing
platformio run --environment rp2040-pico-arduino-testing
```

4) Notes : 
Only compile actually with esp32cam-testing, but do not infer with classic "esp32cam"
(You may need to delete your .platformio\packages and clean all cache, before compiling other envs)

5) Finally : 
AI-Thinker-esp32cam board is end of life https://github.com/jomjol/AI-on-the-edge-device/discussions/1732, we need to prepare for future ...
