### PR TITLE
Add option to disable brownout detector

### DIFF
--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -16,7 +16,9 @@
     */
     // server_tflite.cpp
     //#define TASK_ANALYSIS_ON
-    
+
+    // ######## debug options : 
+    //#define DISABLE_BROWNOUT_DETECTOR
 
     /* Uncomment this to keep the logfile open for appending.
     * If commented out, the logfile gets opened/closed for each log measage (old behaviour) */
@@ -25,7 +27,7 @@
 
     //compiler optimization for tflite-micro-esp-examples
     #define XTENSA
-    #define CONFIG_IDF_TARGET_ARCH_XTENSA
+    //#define CONFIG_IDF_TARGET_ARCH_XTENSA //not needed with platformio/espressif32 @ 5.2.0
 
 
     //ClassControllCamera + ClassFlowMakeImage + connect_wlan + main

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -40,8 +40,13 @@
 //#include "server_GPIO.h"
 
 #ifdef ENABLE_SOFTAP
-#include "softAP.h"
+    #include "softAP.h"
 #endif //ENABLE_SOFTAP
+
+#ifdef DISABLE_BROWNOUT_DETECTOR
+    #include "soc/soc.h" 
+    #include "soc/rtc_cntl_reg.h" 
+#endif
 
 extern const char* GIT_TAG;
 extern const char* GIT_REV;
@@ -144,6 +149,10 @@ void task_MainInitError_blink(void *pvParameter)
 extern "C" void app_main(void)
 {
     TickType_t xDelay;
+    
+#ifdef DISABLE_BROWNOUT_DETECTOR
+    WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); //disable brownout detector
+#endif
 
     ESP_LOGI(TAG, "\n\n\n\n\n"); // Add mark on log to see when it restarted
     


### PR DESCRIPTION
It's sometime usefull to disable brownout detector (low voltage)
Add debug option in defines.h : #define DISABLE_BROWNOUT_DETECTOR