### PR TITLE
GPIO handler: Deinit before delete handler

### DIFF
--- a/code/components/jomjol_controlGPIO/server_GPIO.cpp
+++ b/code/components/jomjol_controlGPIO/server_GPIO.cpp
@@ -692,6 +692,7 @@ void gpio_handler_deinit() {
 void gpio_handler_destroy()
 {
     if (gpioHandler != NULL) {
+        gpio_handler_deinit();
         delete gpioHandler;
         gpioHandler = NULL;
     }


### PR DESCRIPTION
GPIO handler: Deinit before delete handler to avoid a rarely occurring exception in reboot process