### PR TITLE
Rest handler: Use none chunked transfer

### DIFF
--- a/code/components/jomjol_controlcamera/server_camera.cpp
+++ b/code/components/jomjol_controlcamera/server_camera.cpp
@@ -48,7 +48,7 @@ esp_err_t handler_lightOn(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Light On API not yet initialized. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not initialized: REST API /lighton not available!");
         return ESP_ERR_NOT_FOUND;
     }
 
@@ -75,7 +75,7 @@ esp_err_t handler_lightOff(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Light Off API not yet initialized. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not initialized: REST API /lightoff not available!");
         return ESP_ERR_NOT_FOUND;
     }
 
@@ -117,7 +117,7 @@ esp_err_t handler_capture(httpd_req_t *req)
     }
         else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Capture API not yet initialized. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not initialized: REST API /capture not available!");
         return ESP_ERR_NOT_FOUND;
     }
 }
@@ -177,7 +177,7 @@ esp_err_t handler_capture_with_ligth(httpd_req_t *req)
     }
         else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Capture + flashlight API not yet initialized. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not initialized: REST API /capture_with_flashlight not available!");
         return ESP_ERR_NOT_FOUND;
     }
 }
@@ -248,7 +248,7 @@ esp_err_t handler_capture_save_to_file(httpd_req_t *req)
     }
     else 
     {
-        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera Capture + save API not yet initialized. Please retry later...");
+        httpd_resp_send_err(req, HTTPD_403_FORBIDDEN, "Camera not initialized: REST API /save not available!");
         return ESP_ERR_NOT_FOUND;
     }
 }

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -46,154 +46,138 @@ esp_err_t info_get_handler(httpd_req_t *req)
             ESP_LOGD(TAG, "type is found: %s", _valuechar);
             _task = std::string(_valuechar);
         }
-    };
+    }
 
     httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
 
     if (_task.compare("GitBranch") == 0)
     {
-        httpd_resp_sendstr_chunk(req, libfive_git_branch());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, libfive_git_branch());
         return ESP_OK;        
     }
     else if (_task.compare("GitTag") == 0)
     {
-        httpd_resp_sendstr_chunk(req, libfive_git_version());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, libfive_git_version());
         return ESP_OK;        
     }
     else if (_task.compare("GitRevision") == 0)
     {
-        httpd_resp_sendstr_chunk(req, libfive_git_revision());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, libfive_git_revision());
         return ESP_OK;        
     }
     else if (_task.compare("BuildTime") == 0)
     {
-        httpd_resp_sendstr_chunk(req, build_time());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, build_time());
         return ESP_OK;        
     }
     else if (_task.compare("FirmwareVersion") == 0)
     {
-        httpd_resp_sendstr_chunk(req, getFwVersion().c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, getFwVersion().c_str());
         return ESP_OK;        
     }
     else if (_task.compare("HTMLVersion") == 0)
     {
-        httpd_resp_sendstr_chunk(req, getHTMLversion().c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, getHTMLversion().c_str());
         return ESP_OK;        
     }
     else if (_task.compare("Hostname") == 0)
     {
         std::string zw;
         zw = std::string(hostname);
-        httpd_resp_sendstr_chunk(req, zw.c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
     else if (_task.compare("IP") == 0)
     {
         std::string *zw;
         zw = getIPAddress();
-        httpd_resp_sendstr_chunk(req, zw->c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw->c_str());
         return ESP_OK;        
     }
     else if (_task.compare("SSID") == 0)
     {
         std::string *zw;
         zw = getSSID();
-        httpd_resp_sendstr_chunk(req, zw->c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw->c_str());
         return ESP_OK;        
     }
     else if (_task.compare("FlowStatus") == 0)
     {
         std::string zw;
         zw = std::string("FlowStatus");
-        httpd_resp_sendstr_chunk(req, zw.c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
     else if (_task.compare("Round") == 0)
     {
         char formated[10] = "";    
         snprintf(formated, sizeof(formated), "%d", getCountFlowRounds());
-        httpd_resp_sendstr_chunk(req, formated);
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, formated);
         return ESP_OK;        
     }
     else if (_task.compare("SDCardPartitionSize") == 0)
     {
         std::string zw;
         zw = getSDCardPartitionSize();
-        httpd_resp_sendstr_chunk(req, zw.c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
     else if (_task.compare("SDCardFreePartitionSpace") == 0)
     {
         std::string zw;
         zw = getSDCardFreePartitionSpace();
-        httpd_resp_sendstr_chunk(req, zw.c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
     else if (_task.compare("SDCardPartitionAllocationSize") == 0)
     {
         std::string zw;
         zw = getSDCardPartitionAllocationSize();
-        httpd_resp_sendstr_chunk(req, zw.c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
     else if (_task.compare("SDCardManufacturer") == 0)
     {
         std::string zw;
         zw = getSDCardManufacturer(); 
-        httpd_resp_sendstr_chunk(req, zw.c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
     else if (_task.compare("SDCardName") == 0)
     {
         std::string zw;
         zw = getSDCardName(); 
-        httpd_resp_sendstr_chunk(req, zw.c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
     else if (_task.compare("SDCardCapacity") == 0)
     {
         std::string zw;
         zw = getSDCardCapacity();
-        httpd_resp_sendstr_chunk(req, zw.c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
     else if (_task.compare("SDCardSectorSize") == 0)
     {
         std::string zw;
         zw = getSDCardSectorSize();
-        httpd_resp_sendstr_chunk(req, zw.c_str());
-        httpd_resp_sendstr_chunk(req, NULL);  
+        httpd_resp_sendstr(req, zw.c_str());
         return ESP_OK;        
     }
 
     return ESP_OK;
 }
 
+
 esp_err_t starttime_get_handler(httpd_req_t *req)
 {
-    httpd_resp_send(req, starttime.c_str(), strlen(starttime.c_str())); 
-    /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_send_chunk(req, NULL, 0);  
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    
+    httpd_resp_send(req, starttime.c_str(), starttime.length()); 
 
     return ESP_OK;
 }
+
 
 esp_err_t hello_main_handler(httpd_req_t *req)
 {
@@ -286,6 +270,7 @@ esp_err_t hello_main_handler(httpd_req_t *req)
     return ESP_OK;
 }
 
+
 esp_err_t img_tmp_handler(httpd_req_t *req)
 {
     char filepath[50];
@@ -309,6 +294,7 @@ esp_err_t img_tmp_handler(httpd_req_t *req)
     httpd_resp_send_chunk(req, NULL, 0);
     return ESP_OK;
 }
+
 
 esp_err_t img_tmp_virtual_handler(httpd_req_t *req)
 {
@@ -390,12 +376,11 @@ esp_err_t sysinfo_handler(httpd_req_t *req)
     resp_str = zw.c_str();
 
     httpd_resp_set_type(req, "application/json");
-    httpd_resp_send(req, resp_str, strlen(resp_str));   
-    /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_send_chunk(req, NULL, 0);  
+    httpd_resp_sendstr(req, resp_str);
 
     return ESP_OK;
 }
+
 
 void register_server_main_uri(httpd_handle_t server, const char *base_path)
 {
@@ -423,8 +408,6 @@ void register_server_main_uri(httpd_handle_t server, const char *base_path)
     };
     httpd_register_uri_handler(server, &starttime_tmp_handle);
 
-
-
     httpd_uri_t img_tmp_handle = {
         .uri       = "/img_tmp/*",  // Match all URIs of type /path/to/file
         .method    = HTTP_GET,
@@ -432,7 +415,6 @@ void register_server_main_uri(httpd_handle_t server, const char *base_path)
         .user_ctx  = (void*) base_path    // Pass server data as context
     };
     httpd_register_uri_handler(server, &img_tmp_handle);
-
 
     httpd_uri_t main_rest_handle = {
         .uri       = "/*",  // Match all URIs of type /path/to/file
@@ -443,7 +425,6 @@ void register_server_main_uri(httpd_handle_t server, const char *base_path)
     httpd_register_uri_handler(server, &main_rest_handle);
 
 }
-
 
 
 httpd_handle_t start_webserver(void)
@@ -486,6 +467,7 @@ httpd_handle_t start_webserver(void)
     return NULL;
 }
 
+
 void stop_webserver(httpd_handle_t server)
 {
     httpd_stop(server);
@@ -502,6 +484,7 @@ void disconnect_handler(void* arg, esp_event_base_t event_base,
         *server = NULL;
     }
 }
+
 
 void connect_handler(void* arg, esp_event_base_t event_base, 
                             int32_t event_id, void* event_data)


### PR DESCRIPTION
1. Rest handler -> switch to none chunked transfer
- info
- sysinfo
- starttime
- value
- flow_start
- statusflow
- cpu_temperature
- rssi
- uptime
- setPreValue
- doInit
- json --> already done (#1379)

2. HTTP error messages renamed