### PR TITLE
REST handler sysinfo + MQTT topic: Free heap memory not reporting

### DIFF
--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -185,7 +185,7 @@ void publishSystemData() {
     sprintf(tmp_char, "%ld", (long)getUpTime());
     MQTTPublish(maintopic + "/" + "uptime", std::string(tmp_char), retainFlag);
     
-    sprintf(tmp_char, "%zu", esp_get_free_heap_size());
+    sprintf(tmp_char, "%lu", (long) getESPHeapSize());
     MQTTPublish(maintopic + "/" + "freeMem", std::string(tmp_char), retainFlag);
 
     sprintf(tmp_char, "%d", get_WIFI_RSSI());

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -349,7 +349,7 @@ esp_err_t sysinfo_handler(httpd_req_t *req)
     std::string gitrevision = libfive_git_revision();
     std::string htmlversion = getHTMLversion();
     char freeheapmem[11];
-    sprintf(freeheapmem, "%zu", esp_get_free_heap_size());
+    sprintf(freeheapmem, "%lu", (long) getESPHeapSize());
     
     tcpip_adapter_ip_info_t ip_info;
     ESP_ERROR_CHECK(tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip_info));


### PR DESCRIPTION
REST handler sysinfo + MQTT topic: Free heap memory not reporting anymore (since PR #1706)
--> fixes #1814