### PR TITLE
plaformio [env:esp32cam-dev] : Add task analysis & test for 8m spiram…

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -68,35 +68,58 @@
     monitor_rts = 0
     monitor_dtr = 0
 
-[env:esp32cam-testing]
-    extends = common:esp32-idf
-    board = node32s
-    board_build.flash_mode = qio
-    build_flags = 
-    ;Add macro definition ENABLE_MQTT, ENABLE_INFLUXDB, DEBUG_DETAIL_ON
-    ;if ENABLE_SOFTAP = disabled, set CONFIG_ESP_WIFI_SOFTAP_SUPPORT=n in sdkconfig.defaults to save 28k of flash
-        -D ENABLE_MQTT -D ENABLE_INFLUXDB -D ENABLE_SOFTAP
-        ${common:esp32-idf.build_flags}
-        ${flags:clangtidy.build_flags}
-        -D CONFIG_ESP_TASK_WDT
-        ;-D CONFIG_COMPILER_OPTIMIZATION_ASSERTION_LEVEL
-        -D CONFIG_SPIRAM
-        -D CONFIG_ESP_TASK_WDT_TIMEOUT_S ; fix for CONFIG_ESP_INT_WDT_TIMEOUT_MS
-    framework = espidf
-    lib_ldf_mode = deep+
-    platform = platformio/espressif32 @ 5.2.0
-    platform_packages = 
-        ;platformio/framework-espidf @ 3.40402.0 (4.4.2)
-        ;platformio/framework-espidf@^3.50000.0
-        ;platformio/tool-cmake @ 3.16.4
-        ;platformio/tool-cmake@^3.21.3
-        ;platformio/tool-esptoolpy @ 1.40201.0 (4.2.1)
-        platformio/tool-esptoolpy@^1.40400.0
-        ;platformio/tool-idf @ 1.0.1
-        ;platformio/tool-mconf @ 1.4060000.20190628 (406.0.0)
-        ;platformio/tool-ninja @ 1.9.0
-        ;platformio/tool-ninja @ 1.10.2
-        ;platformio/toolchain-esp32ulp @ 1.22851.191205 (2.28.51)
-        espressif/toolchain-esp32ulp @ 2.35.0-20220830
-        ;platformio/toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch3
-        ;platformio/toolchain-xtensa-esp32 @ 11.2.0+2022r1
+[env:esp32cam-dev]
+extends = common:esp32-idf
+board = node32s
+board_build.flash_mode = qio
+build_flags = 
+    ; ### common imported : 
+    ${common:esp32-idf.build_flags}
+	${flags:clangtidy.build_flags}
+    ; ### Sofware options :
+	-D ENABLE_MQTT 
+    -D ENABLE_INFLUXDB 
+    ;-D ENABLE_SOFTAP 
+    ;### test options 
+    -D CONFIG_ESP_TASK_WDT
+    ;-D CONFIG_COMPILER_OPTIMIZATION_ASSERTION_LEVEL
+    -D CONFIG_SPIRAM
+    -D CONFIG_ESP_TASK_WDT_TIMEOUT_S ; fix for CONFIG_ESP_INT_WDT_TIMEOUT_MS
+    ; ### Debug options :
+    -D DEBUG_DETAIL_ON
+    ;Task analysis
+    -D TASK_ANALYSIS_ON
+    -D CONFIG_FREERTOS_USE_TRACE_FACILITY
+    -D CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+    -D CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
+    ;#### enable support for 8Mb SPIRAM_ ; testing : https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/himem.html
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -D CONFIG_SPIRAM_TYPE_AUTO
+    -D CONFIG_SPIRAM_USE_CAPS_ALLOC
+    -D CONFIG_SPIRAM_USE_MALLOC
+    ;-D CONFIG_SPIRAM_BANKSWITCH_ENABLE=y
+    ;-D CONFIG_SPIRAM_BANKSWITCH_RESERVE=4
+framework = espidf
+lib_ldf_mode = deep+
+platform = platformio/espressif32 @ 5.2.0
+platform_packages = 
+    ;platformio/framework-espidf @ 3.40402.0 (4.4.2)
+    ;platformio/framework-espidf@^3.50000.0
+    ;platformio/tool-cmake @ 3.16.4
+    ;platformio/tool-cmake@^3.21.3
+    ;platformio/tool-esptoolpy @ 1.40201.0 (4.2.1)
+    platformio/tool-esptoolpy@^1.40400.0
+    ;platformio/tool-idf @ 1.0.1
+    ;platformio/tool-mconf @ 1.4060000.20190628 (406.0.0)
+    ;platformio/tool-ninja @ 1.9.0
+    ;platformio/tool-ninja @ 1.10.2
+    ;platformio/toolchain-esp32ulp @ 1.22851.191205 (2.28.51)
+    espressif/toolchain-esp32ulp @ 2.35.0-20220830
+    ;platformio/toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch3
+    ;platformio/toolchain-xtensa-esp32 @ 11.2.0+2022r1
+    
+board_build.partitions = partitions.csv
+monitor_speed = 115200
+monitor_rts = 0
+monitor_dtr = 0


### PR DESCRIPTION
- add support of   TASK_ANALYSIS_ON 
-  test full support of 8mb spiram board  (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/himem.html)