### PR TITLE
Esp32 sys info

### DIFF
--- a/code/components/jomjol_helper/esp_sys.cpp
+++ b/code/components/jomjol_helper/esp_sys.cpp
@@ -1,0 +1,168 @@
+#include "../../include/defines.h"
+
+#ifdef DEBUG_ENABLE_SYSINFO
+
+#include "esp_sys.h"
+
+#include <string>
+
+
+#include "esp_chip_info.h"
+
+// for esp_spiram_get_size
+extern "C" {
+    
+#include <esp32/spiram.h>
+#include <esp32/himem.h>
+}
+
+
+void Restart() {
+    esp_restart();
+}
+
+//source : https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/misc_system_api.html#_CPPv416esp_chip_model_t
+
+//https://github.com/espressif/esp-idf/blob/8464186e67e34b417621df6b6f1f289a6c60b859/components/esp_hw_support/include/esp_chip_info.h
+/*
+typedef enum {
+    CHIP_ESP32  = 1, //!< ESP32
+    CHIP_ESP32S2 = 2, //!< ESP32-S2
+    CHIP_ESP32S3 = 9, //!< ESP32-S3
+    CHIP_ESP32C3 = 5, //!< ESP32-C3
+    CHIP_ESP32H4 = 6, //!< ESP32-H4
+    CHIP_ESP32C2 = 12, //!< ESP32-C2
+    CHIP_ESP32C6 = 13, //!< ESP32-C6
+    CHIP_ESP32H2 = 16, //!< ESP32-H2
+    CHIP_POSIX_LINUX = 999, //!< The code is running on POSIX/Linux simulator
+} esp_chip_model_t;
+*/
+
+char* GetChipModel(){
+    esp_chip_info_t chipInfo;
+    esp_chip_info(&chipInfo);
+    switch((int)chipInfo.model) {
+        case 0 : return (char*)"ESP8266";
+        case (int)esp_chip_model_t::CHIP_ESP32 : return (char*)"ESP32";
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)        
+        case (int)esp_chip_model_t::CHIP_ESP32S2 : return (char*)"ESP32-S2";
+        case (int)esp_chip_model_t::CHIP_ESP32S3 : return (char*)"ESP32-S3";
+        case (int)esp_chip_model_t::CHIP_ESP32C3 : return (char*)"ESP32-C3";
+        case 6 : return (char*)"ESP32-H4";
+        case 12 : return (char*)"ESP32-C2";
+        case 13 : return (char*)"ESP32-C6";
+        //case (int)esp_chip_model_t::CHIP_ESP32H4 : return (char*)"ESP32-H4";
+        //case (int)esp_chip_model_t::CHIP_ESP32C2 : return (char*)"ESP32-C2";
+        //case (int)esp_chip_model_t::CHIP_ESP32C6 : return (char*)"ESP32-C6";
+        //case (int)esp_chip_model_t::CHIP_ESP32H2 : return (char*)"ESP32-H2";
+        case 16 : return (char*)"ESP32-H2";
+        //case (int)esp_chip_model_t::CHIP_POSIX_LINUX : return (char*)"CHIP_POSIX_LINUX";
+
+#endif
+    }
+    return (char*)"Chip Unknown";
+}
+
+uint8_t GetChipCoreCount() {
+    esp_chip_info_t chipInfo;
+    esp_chip_info(&chipInfo);
+    return chipInfo.cores;
+}
+
+uint16_t GetChipRevision() {
+    esp_chip_info_t chipInfo;
+    esp_chip_info(&chipInfo);
+    return chipInfo.revision;
+}
+
+uint32_t  GetChipfeatures() {
+    esp_chip_info_t chipInfo;
+    esp_chip_info(&chipInfo);
+    return chipInfo.features;
+}
+
+
+uint32_t GetFreeHeap() {
+    return esp_get_free_heap_size();
+}
+
+uint32_t GetLeastHeapFreeSinceBoot() {
+    return esp_get_minimum_free_heap_size();
+}
+
+
+std::string get_device_info()
+{
+    esp_chip_info_t chip_info;
+    esp_chip_info(&chip_info);
+    
+    std::string espInfoResultStr = "";
+    char aMsgBuf[40];
+
+    espInfoResultStr += "Device Info:";
+    espInfoResultStr += "---------------\n";
+    espInfoResultStr += "Chip Model: " + std::string(GetChipModel()) +"\n";
+    sprintf(aMsgBuf,"Chip Revision: %d\n", chip_info.revision);
+    espInfoResultStr += std::string(aMsgBuf);
+    sprintf(aMsgBuf,"CPU Cores: %d\n", chip_info.cores);
+    espInfoResultStr += std::string(aMsgBuf);
+    sprintf(aMsgBuf,"Flash Memory: %dMB\n", spi_flash_get_chip_size()/(1024*1024));
+    espInfoResultStr += std::string(aMsgBuf);
+    if(chip_info.features & CHIP_FEATURE_WIFI_BGN)
+        //espInfoResultStr += "Base MAC: " + std::string(getMac()) +"\n";
+        espInfoResultStr += "ESP-IDF version: " + std::string(esp_get_idf_version()) +"\n";
+    if((chip_info.features & CHIP_FEATURE_WIFI_BGN) || (chip_info.features & CHIP_FEATURE_BT) ||
+       (chip_info.features & CHIP_FEATURE_BLE) || (chip_info.features & CHIP_FEATURE_EMB_FLASH))
+    {
+        espInfoResultStr += "Characteristics:\n";
+        if(chip_info.features & CHIP_FEATURE_WIFI_BGN)
+            espInfoResultStr += "    WiFi 2.4GHz\n";
+        if(chip_info.features & CHIP_FEATURE_BT)
+            espInfoResultStr += "    Bluetooth Classic\n";
+        if(chip_info.features & CHIP_FEATURE_BLE)
+            espInfoResultStr += "    Bluetooth Low Energy\n";
+        if(chip_info.features & CHIP_FEATURE_EMB_FLASH)
+            espInfoResultStr += "    Embedded Flash memory\n";
+        else
+           espInfoResultStr += "    External Flash memory\n";
+    }
+        sprintf(aMsgBuf,"spiram size %u\n", esp_spiram_get_size());
+        espInfoResultStr += std::string(aMsgBuf);
+        sprintf(aMsgBuf,"himem free %u\n", esp_himem_get_free_size());
+        espInfoResultStr += std::string(aMsgBuf);
+        sprintf(aMsgBuf,"himem phys %u\n", esp_himem_get_phys_size());
+        espInfoResultStr += std::string(aMsgBuf);
+        sprintf(aMsgBuf,"himem reserved %u\n", esp_himem_reserved_area_size());
+    
+    return espInfoResultStr; 
+}
+
+
+size_t getFreeMemoryInternal(){ //Current Free Memory
+    return heap_caps_get_free_size(MALLOC_CAP_8BIT) - heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+}
+
+size_t getFreeMemorySPIRAM(){ //Current Free Memory
+    return heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+}
+
+
+size_t getLargestFreeBlockInternal(){ //Largest Free Block
+    return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+}
+
+size_t getLargestFreeBlockSPIRAM(){ //Largest Free Block
+    return heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM);
+}
+
+
+size_t getMinEverFreeMemInternal(){ //Min. Ever Free Size
+    return heap_caps_get_minimum_free_size(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+}
+
+size_t getMinEverFreeMemSPIRAM(){ //Min. Ever Free Size
+    return heap_caps_get_minimum_free_size(MALLOC_CAP_SPIRAM);
+}
+//#endif // ESP_IDF_VERSION
+
+#endif //DEBUG_ENABLE_SYSINFO

--- a/code/components/jomjol_helper/esp_sys.h
+++ b/code/components/jomjol_helper/esp_sys.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "../../include/defines.h"
+
+#ifdef DEBUG_ENABLE_SYSINFO
+
+#ifndef ESP_SYS_H
+#define ESP_SYS_H
+
+
+#include <string>
+
+
+// Device libraries (ESP-IDF)
+#include <esp_system.h>
+#include <esp_spi_flash.h>
+#include <esp_heap_caps.h>
+
+
+
+    void Restart();
+    char *GetChipModel();
+    uint8_t GetChipCoreCount();
+    uint16_t GetChipRevision();
+    uint32_t  GetChipfeatures();
+    uint32_t GetFreeHeap();
+    uint32_t GetLeastHeapFreeSinceBoot();
+
+/*
+    bool CHIP_FEATURE_EMB_FLASH; //Chip has embedded flash memory.
+    bool CHIP_FEATURE_WIFI_BGN; //Chip has 2.4GHz WiFi.
+    bool CHIP_FEATURE_BLE; //Chip has Bluetooth LE.
+    bool CHIP_FEATURE_BT; //Chip has Bluetooth Classic.
+    bool CHIP_FEATURE_IEEE802154; //Chip has IEEE 802.15.4 (Zigbee/Thread)
+    bool CHIP_FEATURE_EMB_PSRAM; //Chip has embedded psram.
+*/
+
+    std::string get_device_info();
+
+    size_t getFreeMemoryInternal();
+    size_t  getFreeMemorySPIRAM();
+    size_t  getLargestFreeBlockInternal();
+    size_t  getLargestFreeBlockSPIRAM();
+    size_t  getMinEverFreeMemInternal();
+    size_t  getMinEverFreeMemSPIRAM();
+
+#endif //ESP_SYS_H
+
+#endif // DEBUG_ENABLE_SYSINFO

--- a/code/components/jomjol_helper/perfmon.c
+++ b/code/components/jomjol_helper/perfmon.c
@@ -1,0 +1,70 @@
+//source : https://github.com/Carbon225/esp32-perfmon
+
+#include "../../include/defines.h"
+
+#ifdef DEBUG_ENABLE_PERFMON
+
+#include "perfmon.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_freertos_hooks.h"
+#include "sdkconfig.h"
+
+#include "esp_log.h"
+static const char *TAG = "perfmon";
+
+static uint64_t idle0Calls = 0;
+static uint64_t idle1Calls = 0;
+
+#if defined(CONFIG_ESP32_DEFAULT_CPU_FREQ_240)
+static const uint64_t MaxIdleCalls = 1855000;
+#elif defined(CONFIG_ESP32_DEFAULT_CPU_FREQ_160)
+static const uint64_t MaxIdleCalls = 1233100;
+#else
+#error "Unsupported CPU frequency"
+#endif
+
+static bool idle_task_0()
+{
+	idle0Calls += 1;
+	return false;
+}
+
+static bool idle_task_1()
+{
+	idle1Calls += 1;
+	return false;
+}
+
+static void perfmon_task(void *args)
+{
+	while (1)
+	{
+		float idle0 = idle0Calls;
+		float idle1 = idle1Calls;
+		idle0Calls = 0;
+		idle1Calls = 0;
+
+		int cpu0 = 100.f -  idle0 / MaxIdleCalls * 100.f;
+		int cpu1 = 100.f - idle1 / MaxIdleCalls * 100.f;
+
+		ESP_LOGI(TAG, "Core 0 at %d%%", cpu0);
+		ESP_LOGI(TAG, "Core 1 at %d%%", cpu1);
+		// TODO configurable delay
+		vTaskDelay(5000 / portTICK_PERIOD_MS);
+	}
+	vTaskDelete(NULL);
+}
+
+esp_err_t perfmon_start()
+{
+	ESP_ERROR_CHECK(esp_register_freertos_idle_hook_for_cpu(idle_task_0, 0));
+	ESP_ERROR_CHECK(esp_register_freertos_idle_hook_for_cpu(idle_task_1, 1));
+	// TODO calculate optimal stack size
+	xTaskCreate(perfmon_task, "perfmon", 2048, NULL, 1, NULL);
+	return ESP_OK;
+}
+
+
+#endif // DEBUG_ENABLE_PERFMON

--- a/code/components/jomjol_helper/perfmon.h
+++ b/code/components/jomjol_helper/perfmon.h
@@ -1,0 +1,24 @@
+
+#include "../../include/defines.h"
+
+#ifdef DEBUG_ENABLE_PERFMON
+
+#ifndef COMPONENTS_PERFMON_INCLUDE_PERFMON_H_
+#define COMPONENTS_PERFMON_INCLUDE_PERFMON_H_
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "esp_err.h"
+
+esp_err_t perfmon_start();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COMPONENTS_PERFMON_INCLUDE_PERFMON_H_ */
+
+#endif //DEBUG_ENABLE_PERFMON 

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -6,10 +6,20 @@
 ////          Global definitions         ////
 /////////////////////////////////////////////
 
+    //********* debug options :  *************
+
+    //can be set in platformio with -D OPTION_TO_ACTIVATE
+
+    //#define DEBUG_DETAIL_ON 
+    //#define DEBUG_DISABLE_BROWNOUT_DETECTOR
+    //#define DEBUG_ENABLE_SYSINFO
+    //#define DEBUG_ENABLE_PERFMON
+
+  
+
     /* Uncomment this to generate task list with stack sizes using the /heap handler
         PLEASE BE AWARE: The following CONFIG parameters have to to be set in 
         sdkconfig.defaults before use of this function is possible!!
-
         CONFIG_FREERTOS_USE_TRACE_FACILITY=1
         CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y
         CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID=y
@@ -17,13 +27,12 @@
     // server_tflite.cpp
     //#define TASK_ANALYSIS_ON
 
-    // ######## debug options : 
-    //#define DISABLE_BROWNOUT_DETECTOR
-
     /* Uncomment this to keep the logfile open for appending.
     * If commented out, the logfile gets opened/closed for each log measage (old behaviour) */
     // ClassLogFile
     //#define KEEP_LOGFILE_OPEN_FOR_APPENDING
+
+  //****************************************
 
     //compiler optimization for tflite-micro-esp-examples
     #define XTENSA

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -48,6 +48,12 @@
     #include "soc/rtc_cntl_reg.h" 
 #endif
 
+#ifdef DEBUG_ENABLE_SYSINFO
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL( 4, 0, 0 )
+    #include "esp_sys.h"
+#endif
+#endif //DEBUG_ENABLE_SYSINFO
+
 extern const char* GIT_TAG;
 extern const char* GIT_REV;
 extern const char* GIT_BRANCH;
@@ -153,6 +159,13 @@ extern "C" void app_main(void)
 #ifdef DISABLE_BROWNOUT_DETECTOR
     WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); //disable brownout detector
 #endif
+    
+#ifdef DEBUG_ENABLE_SYSINFO
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL( 4, 0, 0 )
+    LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Device Info" + get_device_info() );
+    ESP_LOGD(TAG, "Device infos %s", get_device_info().c_str());
+#endif
+#endif //DEBUG_ENABLE_SYSINFO
 
     ESP_LOGI(TAG, "\n\n\n\n\n"); // Add mark on log to see when it restarted
     


### PR DESCRIPTION
get esp32 system board info only if -D DEBUG_ENABLE_SYSINFO is set in platform.io (or in define.h). 
Can be used in future to have different build upon boards (espcam rev 0 to 3)

Add [perfmon library](https://github.com/Carbon225/esp32-perfmon) -D DEBUG_ENABLE_PERFMON)