### PR TITLE
improve caching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,28 +25,28 @@ jobs:
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Update PIP cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: ~/.cache/pip
         key: pip-${{ github.run_id }}
         restore-keys: pip # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Update PlatformIO cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: ~/.platformio
         key: platformio-${{ github.run_id }}
         restore-keys: platformio # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
           
     - name: Update Build cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: ./code/.pio/
         key: build-${{ github.run_id }}
         restore-keys: build # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
           
     - name: Update generated-files cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -91,7 +91,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update generated-files cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -102,7 +102,7 @@ jobs:
         restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Update update cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: update
         key: update-${{ github.run_id }}
@@ -152,7 +152,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update generated-files cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -163,7 +163,7 @@ jobs:
         restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
           
     - name: Update remote_setup cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: remote_setup
         key: remote_setup-${{ github.run_id }}
@@ -207,7 +207,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update generated-files cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -218,7 +218,7 @@ jobs:
         restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Update manual_setup cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: manual_setup
         key: manual_setup-${{ github.run_id }}
@@ -261,21 +261,21 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Update update cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: update
         key: update-${{ github.run_id }}
         restore-keys: update # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
     
     - name: Update remote_setup cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: remote_setup
         key: remote_setup-${{ github.run_id }}
         restore-keys: remote_setup # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
     
     - name: Update manual_setup cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: manual_setup
         key: manual_setup-${{ github.run_id }}
@@ -369,7 +369,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Update update cache on every commit
-      uses: actions/cache:@v3.2.3
+      uses: actions/cache@v3.2.3
       with:
         path: update
         key: update-${{ github.run_id }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -329,6 +329,10 @@ jobs:
     # all artifacts in firmware folder pushed to the release
     - name: Release
       uses: softprops/action-gh-release@v1
+      # Note:
+      # If you get the error "Resource not accessible by integration",
+      # The access rights are not sufficient, see
+      # https://github.com/softprops/action-gh-release/issues/232#issuecomment-1131379440
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name:  ${{ steps.get_version.outputs.version-without-v }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,19 +24,41 @@ jobs:
       run: |
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-    - name: Cache PIP
+    - name: Update PIP cache on every commit
       uses: actions/cache@v3.2.3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: pip-${{ github.run_id }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          pip- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
 
-    - name: Cache PlatformIO
+    - name: Update PlatformIO cache on every commit
       uses: actions/cache@v3.2.3
       with:
         path: ~/.platformio
-        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+        key: platformio-${{ github.run_id }}
+        restore-keys: |
+          platformio- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          
+    - name: Update Build cache on every commit
+      uses: actions/cache@v3.2.3
+      with:
+        path: ./code/.pio/
+        key: build-${{ github.run_id }}
+        restore-keys: |
+          build- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          
+    - name: Update generated-files cache on every commit
+      uses: actions/cache@v3.2.3
+      with:
+        path: |
+          ./code/.pio/build/esp32cam/firmware.bin
+          ./code/.pio/build/esp32cam/partitions.bin
+          ./code/.pio/build/esp32cam/bootloader.bin
+          ./sd-card/html/*
+        key: generated-files-${{ github.run_id }}
+        restore-keys: |
+          generated-files- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache          
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -48,12 +70,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
 
-    - name: Use Build Cache
-      uses: actions/cache@v3.2.3
-      with:
-        path: ./code/.pio/
-        key: ${{ runner.os }}-pio-${{ github.ref_name }}
-
     - name: Build Firmware
       #run: echo "Testing... ${{ github.ref_name }}, ${{ steps.vars.outputs.sha_short }}" > ./sd-card/html/version.txt; mkdir -p ./code/.pio/build/esp32cam/; cd ./code/.pio/build/esp32cam/; echo "${{ steps.vars.outputs.sha_short }}" > firmware.bin; cp firmware.bin partitions.bin; cp firmware.bin bootloader.bin # Testing
       run: cd code; platformio run --environment esp32cam
@@ -61,16 +77,6 @@ jobs:
     - name: Set Hash in all Web UI files
       run: cd sd-card/html; find . -type f -exec sed -i 's/$COMMIT_HASH/${{ steps.vars.outputs.sha_short }}/g' {} \;
 
-
-    - name: Store generated files in cache
-      uses: actions/cache@v3.2.3
-      with:
-        path: |
-          ./code/.pio/build/esp32cam/firmware.bin
-          ./code/.pio/build/esp32cam/partitions.bin
-          ./code/.pio/build/esp32cam/bootloader.bin
-          ./sd-card/html/*
-        key: ${{ github.run_number }}
 
 
 #########################################################################################
@@ -88,7 +94,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Get generated files from cache
+    - name: Update generated-files cache on every commit
       uses: actions/cache@v3.2.3
       with:
         path: |
@@ -96,8 +102,18 @@ jobs:
           ./code/.pio/build/esp32cam/partitions.bin
           ./code/.pio/build/esp32cam/bootloader.bin
           ./sd-card/html/*
-        key: ${{ github.run_number }}
+        key: generated-files-${{ github.run_id }}
+        restore-keys: |
+          generated-files- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
 
+    - name: Update update cache on every commit
+      uses: actions/cache@v3.2.3
+      with:
+        path: update
+        key: update-${{ github.run_id }}
+        restore-keys: |
+          update- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+    
     - name: Set Variables
       id: vars
       run: |
@@ -124,11 +140,6 @@ jobs:
         name: "AI-on-the-edge-device__update__${{ steps.vars.outputs.branch }}_(${{ steps.vars.outputs.sha_short }})"
         path: ./update/*
 
-    - name: Store generated files in cache
-      uses: actions/cache@v3.2.3
-      with:
-        path: update
-        key: ${{ github.run_number }}-update
 
 
 #########################################################################################
@@ -146,7 +157,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Get generated files from cache
+    - name: Update generated-files cache on every commit
       uses: actions/cache@v3.2.3
       with:
         path: |
@@ -154,7 +165,17 @@ jobs:
           ./code/.pio/build/esp32cam/partitions.bin
           ./code/.pio/build/esp32cam/bootloader.bin
           ./sd-card/html/*
-        key: ${{ github.run_number }}
+        key: generated-files-${{ github.run_id }}
+        restore-keys: |
+          generated-files- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          
+    - name: Update remote_setup cache on every commit
+      uses: actions/cache@v3.2.3
+      with:
+        path: remote_setup
+        key: remote_setup-${{ github.run_id }}
+        restore-keys: |
+          remote_setup- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Set Variables
       id: vars
@@ -181,12 +202,6 @@ jobs:
         name: "AI-on-the-edge-device__remote-setup__${{ steps.vars.outputs.branch }}_(${{ steps.vars.outputs.sha_short }})"
         path: ./remote_setup/*
 
-    - name: Store generated files in cache
-      uses: actions/cache@v3.2.3
-      with:
-        path: remote_setup
-        key: ${{ github.run_number }}-remote_setup
-
 
 #########################################################################################
 ## Pack for a fresh install (USB flashing) (manual_setup)
@@ -199,7 +214,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Get generated files from cache
+    - name: Update generated-files cache on every commit
       uses: actions/cache@v3.2.3
       with:
         path: |
@@ -207,7 +222,17 @@ jobs:
           ./code/.pio/build/esp32cam/partitions.bin
           ./code/.pio/build/esp32cam/bootloader.bin
           ./sd-card/html/*
-        key: ${{ github.run_number }}
+        key: generated-files-${{ github.run_id }}
+        restore-keys: |
+          generated-files- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+
+    - name: Update manual_setup cache on every commit
+      uses: actions/cache@v3.2.3
+      with:
+        path: manual_setup
+        key: manual_setup-${{ github.run_id }}
+        restore-keys: |
+          manual_setup- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Set Variables
       id: vars
@@ -233,12 +258,6 @@ jobs:
         name: "AI-on-the-edge-device__manual-setup__${{ steps.vars.outputs.branch }}_(${{ steps.vars.outputs.sha_short }})"
         path: ./manual_setup
 
-    - name: Store generated files in cache
-      uses: actions/cache@v3.2.3
-      with:
-        path: manual_setup
-        key: ${{ github.run_number }}-manual_setup
-
 
 #########################################################################################
 ## Prepare and create release
@@ -250,27 +269,30 @@ jobs:
       
     steps:
     - uses: actions/checkout@v3
-
-    # import update
-    - name: Get generated update files from cache
+    
+    - name: Update update cache on every commit
       uses: actions/cache@v3.2.3
       with:
         path: update
-        key: ${{ github.run_number }}-update
-
-    # import remote_setup
-    - name: Get generated files from cache
+        key: update-${{ github.run_id }}
+        restore-keys: |
+          update- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+    
+    - name: Update remote_setup cache on every commit
       uses: actions/cache@v3.2.3
       with:
         path: remote_setup
-        key: ${{ github.run_number }}-remote_setup
-
-    # import manual_setup
-    - name: Get generated files from cache
+        key: remote_setup-${{ github.run_id }}
+        restore-keys: |
+          remote_setup- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+    
+    - name: Update manual_setup cache on every commit
       uses: actions/cache@v3.2.3
       with:
         path: manual_setup
-        key: ${{ github.run_number }}-manual_setup
+        key: manual_setup-${{ github.run_id }}
+        restore-keys: |
+          manual_setup- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Set Variables
       id: vars

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -256,7 +256,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pack-for-update, pack-for-manual_setup, pack-for-remote_setup]
     if: startsWith(github.ref, 'refs/tags/') 
-      
+
+    # Sets permissions of the GITHUB_TOKEN to allow updating the branches
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+
     steps:
     - uses: actions/checkout@v3
     

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,28 +25,28 @@ jobs:
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Update PIP cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: ~/.cache/pip
         key: pip-${{ github.run_id }}
         restore-keys: pip # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Update PlatformIO cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: ~/.platformio
         key: platformio-${{ github.run_id }}
         restore-keys: platformio # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
           
     - name: Update Build cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: ./code/.pio/
         key: build-${{ github.run_id }}
         restore-keys: build # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
           
     - name: Update generated-files cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -91,7 +91,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update generated-files cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -102,7 +102,7 @@ jobs:
         restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Update update cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: update
         key: update-${{ github.run_id }}
@@ -152,7 +152,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update generated-files cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -163,7 +163,7 @@ jobs:
         restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
           
     - name: Update remote_setup cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: remote_setup
         key: remote_setup-${{ github.run_id }}
@@ -207,7 +207,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update generated-files cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -218,7 +218,7 @@ jobs:
         restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Update manual_setup cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: manual_setup
         key: manual_setup-${{ github.run_id }}
@@ -261,21 +261,21 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Update update cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: update
         key: update-${{ github.run_id }}
         restore-keys: update # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
     
     - name: Update remote_setup cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: remote_setup
         key: remote_setup-${{ github.run_id }}
         restore-keys: remote_setup # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
     
     - name: Update manual_setup cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: manual_setup
         key: manual_setup-${{ github.run_id }}
@@ -369,7 +369,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Update update cache on every commit
-      uses: restore-keys:@v3.2.3
+      uses: actions/cache:@v3.2.3
       with:
         path: update
         key: update-${{ github.run_id }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,7 +124,7 @@ jobs:
 
     - name: Add CNN to update
       run: |
-        mkdir ./update/config/
+        mkdir -p ./update/config/
         cp ./sd-card/config/*.tfl ./update/config/ 2>/dev/null || true
         cp ./sd-card/config/*.tflite ./update/config/ 2>/dev/null || true
 
@@ -185,7 +185,7 @@ jobs:
 
     - name: Add whole config folder to remote_setup
       run: |
-        mkdir ./remote_setup/config/
+        mkdir -p ./remote_setup/config/
         cp ./sd-card/config/* ./remote_setup/config/ 2>/dev/null || true
 
     - name: Upload remote_setup as remote_setup.zip artifact (Firmware + Web UI + Config)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,31 +25,28 @@ jobs:
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Update PIP cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: ~/.cache/pip
         key: pip-${{ github.run_id }}
-        restore-keys: |
-          pip- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: pip # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Update PlatformIO cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: ~/.platformio
         key: platformio-${{ github.run_id }}
-        restore-keys: |
-          platformio- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: platformio # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
           
     - name: Update Build cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: ./code/.pio/
         key: build-${{ github.run_id }}
-        restore-keys: |
-          build- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: build # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
           
     - name: Update generated-files cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -57,8 +54,7 @@ jobs:
           ./code/.pio/build/esp32cam/bootloader.bin
           ./sd-card/html/*
         key: generated-files-${{ github.run_id }}
-        restore-keys: |
-          generated-files- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache          
+        restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache          
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -95,7 +91,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update generated-files cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -103,16 +99,14 @@ jobs:
           ./code/.pio/build/esp32cam/bootloader.bin
           ./sd-card/html/*
         key: generated-files-${{ github.run_id }}
-        restore-keys: |
-          generated-files- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Update update cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: update
         key: update-${{ github.run_id }}
-        restore-keys: |
-          update- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: update # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
     
     - name: Set Variables
       id: vars
@@ -158,7 +152,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update generated-files cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -166,16 +160,14 @@ jobs:
           ./code/.pio/build/esp32cam/bootloader.bin
           ./sd-card/html/*
         key: generated-files-${{ github.run_id }}
-        restore-keys: |
-          generated-files- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
           
     - name: Update remote_setup cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: remote_setup
         key: remote_setup-${{ github.run_id }}
-        restore-keys: |
-          remote_setup- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: remote_setup # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Set Variables
       id: vars
@@ -215,7 +207,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update generated-files cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: |
           ./code/.pio/build/esp32cam/firmware.bin
@@ -223,16 +215,14 @@ jobs:
           ./code/.pio/build/esp32cam/bootloader.bin
           ./sd-card/html/*
         key: generated-files-${{ github.run_id }}
-        restore-keys: |
-          generated-files- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: generated-files # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Update manual_setup cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: manual_setup
         key: manual_setup-${{ github.run_id }}
-        restore-keys: |
-          manual_setup- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: manual_setup # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Set Variables
       id: vars
@@ -271,28 +261,25 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Update update cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: update
         key: update-${{ github.run_id }}
-        restore-keys: |
-          update- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: update # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
     
     - name: Update remote_setup cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: remote_setup
         key: remote_setup-${{ github.run_id }}
-        restore-keys: |
-          remote_setup- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: remote_setup # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
     
     - name: Update manual_setup cache on every commit
-      uses: actions/cache@v3.2.3
+      uses: restore-keys:@v3.2.3
       with:
         path: manual_setup
         key: manual_setup-${{ github.run_id }}
-        restore-keys: |
-          manual_setup- # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        restore-keys: manual_setup # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Set Variables
       id: vars
@@ -381,12 +368,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    # import update
-    - name: Get generated update files from cache
-      uses: actions/cache@v3.2.3
+    - name: Update update cache on every commit
+      uses: restore-keys:@v3.2.3
       with:
         path: update
-        key: ${{ github.run_number }}-update
+        key: update-${{ github.run_id }}
+        restore-keys: update # This matches above key as it is only used as a prefix. it the restores the nearest cache, see https://github.com/restore-keys:/blob/main/tips-and-workarounds.md#update-a-cache
 
     - name: Set Variables
       id: vars

--- a/README.md
+++ b/README.md
@@ -99,3 +99,4 @@ See [Changelog](Changelog.md)
 There are some ideas and feature requests which are not followed currently - mainly due to capacity reasons on side of the developer. They are collected here: [FeatureRequest.md](FeatureRequest.md)
 
 ------
+

--- a/README.md
+++ b/README.md
@@ -99,4 +99,3 @@ See [Changelog](Changelog.md)
 There are some ideas and feature requests which are not followed currently - mainly due to capacity reasons on side of the developer. They are collected here: [FeatureRequest.md](FeatureRequest.md)
 
 ------
-


### PR DESCRIPTION
I reworked the build pipeline according the example in https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache

Hopefully this fixes it now.
It now picks the latest cache, uses it and creates a new (updated) cache. This way a cache newer is outdated. The older caches automatically get deleted after 7 days.
Even more, according to the docs, the branches use the caches from rolling. This means that the first build of a branch uses the cache from its parent and does not need to run a full build.