### PR TITLE
disable the automatic reboots in case the camera is no longer working or an empty image got loaded.

### DIFF
--- a/code/components/jomjol_controlcamera/ClassControllCamera.cpp
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.cpp
@@ -266,10 +266,10 @@ esp_err_t CCamera::CaptureToBasisImage(CImageBasis *_Image, int delay)
         LEDOnOff(false);
         LightOnOff(false);
 
-        ESP_LOGE(TAG, "CaptureToBasisImage: Capture Failed");
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "is not working anymore (CCamera::CaptureToBasisImage) - most probably caused by a hardware problem (instablility, ...). "
-                "System will reboot.");
-        doReboot();
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Camera is not working anymore (Capture Failed)! Most probably caused by a hardware problem (instablility, ...)!"
+                //" System will reboot."
+                );
+        //doReboot();
 
         return ESP_FAIL;
     }

--- a/code/components/jomjol_image_proc/CImageBasis.cpp
+++ b/code/components/jomjol_image_proc/CImageBasis.cpp
@@ -428,11 +428,11 @@ void CImageBasis::LoadFromMemory(stbi_uc *_buffer, int len)
     
     if ((width * height * channels) == 0)
     {
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Image with size 0 loaded --> reboot to be done! "
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Image with size 0 loaded! "
                 "Check that your camera module is working and connected properly.");
         LogFile.WriteHeapInfo("CImageBasis::LoadFromMemory");
 
-        doReboot();
+        //doReboot();
     }
     RGBImageRelease();
 }


### PR DESCRIPTION
Hopefully it works again in the next round. If not, we need to add the reboot again.

Removed automatic restarts for:
 - CaptureToBasisImage: Capture Failed
 - Image with size 0 loaded