### PR TITLE
Improve data logging on errors

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -734,8 +734,13 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
         NUMBERS[j]->ReturnValue = "";
         NUMBERS[j]->ErrorMessageText = "";
         NUMBERS[j]->Value = -1;
-        /* TODO to be discussed, see https://github.com/jomjol/AI-on-the-edge-device/issues/1617 */
-//        NUMBERS[j]->lastvalue = imagetime;    // must only be set in case of good value !!! --> move to the end
+
+        /* calculate time difference BEFORE we overwrite the 'lastvalue' */
+        double difference = difftime(imagetime, NUMBERS[j]->lastvalue);      // in seconds
+
+        /* TODO:
+         * We could call `NUMBERS[j]->lastvalue = imagetime;` here and remove all other such calls further down.
+         * But we should check nothing breaks! */
 
         UpdateNachkommaDecimalShift();
 
@@ -866,7 +871,6 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
             ESP_LOGD(TAG, "After AllowNegativeRates: Value %f", NUMBERS[j]->Value);
         #endif
 
-        double difference = difftime(imagetime, NUMBERS[j]->lastvalue);      // in seconds
         difference /= 60;  
         NUMBERS[j]->FlowRateAct = (NUMBERS[j]->Value - NUMBERS[j]->PreValue) / difference;
         NUMBERS[j]->ReturnRateValue =  to_string(NUMBERS[j]->FlowRateAct);

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -879,8 +879,6 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
 
             if (abs(_ratedifference) > abs(NUMBERS[j]->MaxRateValue))
             {
-                WriteDataLog(j);
-
                 NUMBERS[j]->ErrorMessageText = NUMBERS[j]->ErrorMessageText + "Rate too high - Read: " + RundeOutput(NUMBERS[j]->Value, NUMBERS[j]->Nachkomma) + " - Pre: " + RundeOutput(NUMBERS[j]->PreValue, NUMBERS[j]->Nachkomma) + " - Rate: " + RundeOutput(_ratedifference, NUMBERS[j]->Nachkomma);
                 NUMBERS[j]->Value = NUMBERS[j]->PreValue;
                 NUMBERS[j]->ReturnValue = "";
@@ -899,8 +897,6 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
         NUMBERS[j]->PreValue = NUMBERS[j]->Value;
         NUMBERS[j]->PreValueOkay = true;
         NUMBERS[j]->lastvalue = imagetime;
-
-
 
         NUMBERS[j]->ReturnValue = RundeOutput(NUMBERS[j]->Value, NUMBERS[j]->Nachkomma);
         NUMBERS[j]->ReturnPreValue = RundeOutput(NUMBERS[j]->PreValue, NUMBERS[j]->Nachkomma);

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -851,6 +851,7 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
                     NUMBERS[j]->ErrorMessageText = NUMBERS[j]->ErrorMessageText + "Neg. Rate - Read: " + zwvalue + " - Raw: " + NUMBERS[j]->ReturnRawValue + " - Pre: " + RundeOutput(NUMBERS[j]->PreValue, NUMBERS[j]->Nachkomma) + " "; 
                     NUMBERS[j]->Value = NUMBERS[j]->PreValue;
                     NUMBERS[j]->ReturnValue = "";
+                    NUMBERS[j]->lastvalue = imagetime;
 
                     string _zw = NUMBERS[j]->name + ": Raw: " + NUMBERS[j]->ReturnRawValue + ", Value: " + NUMBERS[j]->ReturnValue + ", Status: " + NUMBERS[j]->ErrorMessageText;
                     LogFile.WriteToFile(ESP_LOG_ERROR, TAG, _zw);
@@ -884,6 +885,7 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
                 NUMBERS[j]->Value = NUMBERS[j]->PreValue;
                 NUMBERS[j]->ReturnValue = "";
                 NUMBERS[j]->ReturnRateValue = "";
+                NUMBERS[j]->lastvalue = imagetime;
 
                 string _zw = NUMBERS[j]->name + ": Raw: " + NUMBERS[j]->ReturnRawValue + ", Value: " + NUMBERS[j]->ReturnValue + ", Status: " + NUMBERS[j]->ErrorMessageText;
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, _zw);

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -908,7 +908,6 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
         UpdatePreValueINI = true;
 
         string _zw = NUMBERS[j]->name + ": Raw: " + NUMBERS[j]->ReturnRawValue + ", Value: " + NUMBERS[j]->ReturnValue + ", Status: " + NUMBERS[j]->ErrorMessageText;
-        ESP_LOGD(TAG, "%s", zw.c_str());
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, _zw);
         WriteDataLog(j);
     }

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -833,7 +833,6 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
         #ifdef SERIAL_DEBUG
             ESP_LOGD(TAG, "After checkDigitIncreaseConsistency: Value %f", NUMBERS[j]->Value);
         #endif
-               
 
         if (!NUMBERS[j]->AllowNegativeRates)
         {
@@ -861,9 +860,11 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
                 
             }
         }
+
         #ifdef SERIAL_DEBUG
             ESP_LOGD(TAG, "After AllowNegativeRates: Value %f", NUMBERS[j]->Value);
         #endif
+
         double difference = difftime(imagetime, NUMBERS[j]->lastvalue);      // in seconds
         difference /= 60;  
         NUMBERS[j]->FlowRateAct = (NUMBERS[j]->Value - NUMBERS[j]->PreValue) / difference;
@@ -890,9 +891,11 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
                 continue;
             }
         }
+
         #ifdef SERIAL_DEBUG
            ESP_LOGD(TAG, "After MaxRateCheck: Value %f", NUMBERS[j]->Value);
         #endif
+        
         NUMBERS[j]->ReturnChangeAbsolute = RundeOutput(NUMBERS[j]->Value - NUMBERS[j]->PreValue, NUMBERS[j]->Nachkomma);
         NUMBERS[j]->PreValue = NUMBERS[j]->Value;
         NUMBERS[j]->PreValueOkay = true;

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -854,7 +854,7 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
                     NUMBERS[j]->ReturnValue = "";
 
                     string _zw = NUMBERS[j]->name + ": Raw: " + NUMBERS[j]->ReturnRawValue + ", Value: " + NUMBERS[j]->ReturnValue + ", Status: " + NUMBERS[j]->ErrorMessageText;
-                    LogFile.WriteToFile(ESP_LOG_INFO, TAG, _zw);
+                    LogFile.WriteToFile(ESP_LOG_ERROR, TAG, _zw);
                     WriteDataLog(j);
                     continue;
                 }
@@ -887,7 +887,7 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
                 NUMBERS[j]->ReturnRateValue = "";
 
                 string _zw = NUMBERS[j]->name + ": Raw: " + NUMBERS[j]->ReturnRawValue + ", Value: " + NUMBERS[j]->ReturnValue + ", Status: " + NUMBERS[j]->ErrorMessageText;
-                LogFile.WriteToFile(ESP_LOG_INFO, TAG, _zw);
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, _zw);
                 WriteDataLog(j);
                 continue;
             }


### PR DESCRIPTION
- There was a redundant call to `WriteToData()` in case of "Rate to high".
  This lead to the `value` to show the too-high value instead of using the `prevalue`

- Also in case of an error, the time did not get updated
  @jomjol Was there a reason for not updating the time, see my changes in https://github.com/jomjol/AI-on-the-edge-device/pull/1839/commits/c918254405fc6699429369771227a003db2836fe

Before:
```
2023-01-14T23:20:18+0100,main,530.0710,530.0710,530.0710,0.062842,0.0597,no error,5.0,2.9,0.0,0.7,7.0,0.8,0.6
### Next line: rate to high but time is not updated
2023-01-14T23:20:18+0100,main,531.8223,,530.0710,,0.0597,Rate too high - Read: 531.8223 - Pre: 530.0710 - Rate: 1.7513,5.0,3.0,1.7,8.2,2.2,2.1,3.2
2023-01-14T23:22:19+0100,main,530.0742,530.0742,530.0742,0.001587,0.0032,no error,5.0,2.9,0.0,0.7,7.3,4.5,2.8
2023-01-14T23:23:19+0100,main,530.1225,530.1225,530.1225,0.048300,0.0483,no error,5.0,2.9,0.0,1.2,2.3,2.3,5.1
```

New:
```
2023-01-14T23:28:21+0100,main,530.0113,,530.21360,,,Neg. Rate - Read:  - Raw: 530.0113 - Pre: 530.2136 ,5.0,2.9,9.9,0.2,1.1,1.2,3.6
2023-01-14T23:29:19+0100,main,530.0710,,530.21360,,,Neg. Rate - Read:  - Raw: 530.0710 - Pre: 530.2136 ,5.0,2.9,0.0,0.7,7.0,0.8,0.6
2023-01-14T23:30:19+0100,main,531.8223,,530.21360,,,Rate too high - Read: 531.8223 - Pre: 530.2136 - Rate: 1.6087,5.0,3.0,1.7,8.2,2.2,2.1,3.2
2023-01-14T23:31:19+0100,main,530.0742,,530.21360,,,Neg. Rate - Read:  - Raw: 530.0742 - Pre: 530.2136 ,5.0,2.9,0.0,0.7,7.3,4.5,2.8
2023-01-14T23:32:19+0100,main,530.1225,,530.21360,,,Neg. Rate - Read:  - Raw: 530.1225 - Pre: 530.2136 ,5.0,2.9,0.0,1.2,2.3,2.3,5.1
```