### PR TITLE
add AlignmentAlgo=off option

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -65,7 +65,7 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, string& aktparamgraph)
     std::vector<string> splitted;
     int suchex = 40;
     int suchey = 40;
-    int alg_algo = 0;
+    int alg_algo = 0; //default=0; 1 =HIGHACCURACY; 2= FAST; 3= OFF
 
 
     aktparamgraph = trim(aktparamgraph);
@@ -130,6 +130,8 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, string& aktparamgraph)
                 alg_algo = 1;
             if (toUpper(splitted[1]) == "FAST")
                 alg_algo = 2;
+            if (toUpper(splitted[1]) == "OFF")
+                alg_algo = 3;
         }
     }
 
@@ -195,8 +197,11 @@ bool ClassFlowAlignment::doFlow(string time)
         }
     }
 
+//no align algo if set to 3 = off
+if(References[0].alignment_algo != 3){
     delete AlignAndCutImage;
     AlignAndCutImage = new CAlignAndCutImage(ImageBasis, ImageTMP);
+}
     if (!AlignAndCutImage) 
     {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Can't allocate AlignAndCutImage -> Exec this round aborted!");

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -282,6 +282,7 @@ textarea {
 					<option value="default" selected>Default</option>
 					<option value="highAccuracy" >HighAccuracy</option>
 					<option value="fast" >Fast</option>
+					<option value="off" >Fast</option>
 				</select>
 			</td>
 			<td style="font-size: 80%;">


### PR DESCRIPTION
I feel the alignment algo should be disabled if needed. 
It takes CPU time in the process and is not much needed in case of strong fixed camera.

Discussion https://github.com/jomjol/AI-on-the-edge-device/discussions/1338