### PR TITLE
REST handler CPU temp: escape special character

### DIFF
--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -692,7 +692,7 @@ esp_err_t handler_cputemp(httpd_req_t *req)
     const char* resp_str;
     char cputemp[20];
     
-    sprintf(cputemp, "%4.1f°C", temperatureRead());
+    sprintf(cputemp, "%4.1f&degC", temperatureRead());
 
     resp_str = cputemp;
 


### PR DESCRIPTION
REST handler CPU temp: Escape special character

![image](https://user-images.githubusercontent.com/115730895/214121487-419d6cf3-c94f-4a21-8353-11daddb1d3bc.png)

Issue reported here https://github.com/jomjol/AI-on-the-edge-device/issues/1887#issuecomment-1399232082