### PR TITLE
Fix for "initial image size" issue (weird ROI image) + JPG buffer overflow protection

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -208,6 +208,10 @@ bool ClassFlowAlignment::doFlow(string time)
         int _zw = ImageBasis->height;
         ImageBasis->height = ImageBasis->width;
         ImageBasis->width = _zw;
+
+        _zw = ImageTMP->width;
+        ImageTMP->width = ImageTMP->height;
+        ImageTMP->height = _zw;
     }
 
     if (initialmirror)
@@ -246,13 +250,6 @@ bool ClassFlowAlignment::doFlow(string time)
     
     if (SaveAllFiles)
     {
-        if (initialflip)
-        {
-            int _zw = ImageTMP->width;
-            ImageTMP->width = ImageTMP->height;
-            ImageTMP->height = _zw;
-        }
-
         AlignAndCutImage->SaveToFile(FormatFileName("/sdcard/img_tmp/alg.jpg"));
         ImageTMP->SaveToFile(FormatFileName("/sdcard/img_tmp/alg_roi.jpg"));
     }

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -755,7 +755,8 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
                     fseek(file, 0, SEEK_SET); /* reset */
                     
                     if (flowalignment->AlgROI->size > MAX_JPG_SIZE) {
-                        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File /sdcard/html/Flowstate_take_image.jpg too large: " + std::to_string(flowalignment->AlgROI->size));
+                        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File /sdcard/html/Flowstate_take_image.jpg (" + std::to_string(flowalignment->AlgROI->size) +
+                                                                ") > allocated buffer (" + std::to_string(MAX_JPG_SIZE) + ")");
                         fclose(file);
                         return ESP_FAIL;
                     }

--- a/code/components/jomjol_image_proc/CImageBasis.cpp
+++ b/code/components/jomjol_image_proc/CImageBasis.cpp
@@ -67,7 +67,7 @@ void writejpghelp(void *context, void *data, int size)
     uint8_t *voidstart = _zw->data;
     uint8_t *datastart = (uint8_t*) data;
     
-    if ((_zw->size < MAX_JPG_SIZE)) {   // Abort copy -> no buffer anymore
+    if ((_zw->size < MAX_JPG_SIZE)) {   // Abort copy to prevent buffer overflow
         voidstart += _zw->size;
 
         for (int i = 0; i < size; ++i)
@@ -91,7 +91,7 @@ ImageData* CImageBasis::writeToMemoryAsJPG(const int quality)
 
     if (jpgFileTooLarge) {
         jpgFileTooLarge = false;
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "writeToMemoryAsJPG: JPG creation aborted! Preallocated buffer not sufficient: " + std::to_string(MAX_JPG_SIZE));
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "writeToMemoryAsJPG: Creation aborted! JPG size > preallocated buffer: " + std::to_string(MAX_JPG_SIZE));
     }
     return ii;
 }
@@ -107,7 +107,7 @@ void CImageBasis::writeToMemoryAsJPG(ImageData* i, const int quality)
 
     if (jpgFileTooLarge) {
         jpgFileTooLarge = false;
-        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "writeToMemoryAsJPG: JPG creation aborted! Preallocated buffer not sufficient: " + std::to_string(MAX_JPG_SIZE));
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "writeToMemoryAsJPG: Creation aborted! JPG size > preallocated buffer: " + std::to_string(MAX_JPG_SIZE));
     }
     memCopy((uint8_t*) ii, (uint8_t*) i, sizeof(ImageData));
     delete ii;

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -21,7 +21,7 @@
 
 
     // use himem //https://github.com/jomjol/AI-on-the-edge-device/issues/1842
-    #define USE_HIMEM_IF_AVAILABLE
+    //#define USE_HIMEM_IF_AVAILABLE
 
     /* Uncomment this to generate task list with stack sizes using the /heap handler
         PLEASE BE AWARE: The following CONFIG parameters have to to be set in 

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -130,7 +130,7 @@
     //CImageBasis
     #define HTTP_BUFFER_SENT 1024
     #define GET_MEMORY(X) heap_caps_malloc(X, MALLOC_CAP_SPIRAM)
-    #define MAX_JPG_SIZE 160000
+    #define MAX_JPG_SIZE 128000
 
 
     //CAlignAndCutImage + CImageBasis

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -130,7 +130,7 @@
     //CImageBasis
     #define HTTP_BUFFER_SENT 1024
     #define GET_MEMORY(X) heap_caps_malloc(X, MALLOC_CAP_SPIRAM)
-    #define MAX_JPG_SIZE 128000
+    #define MAX_JPG_SIZE 160000
 
 
     //CAlignAndCutImage + CImageBasis

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -21,7 +21,7 @@
 
 
     // use himem //https://github.com/jomjol/AI-on-the-edge-device/issues/1842
-    //#define USE_HIMEM_IF_AVAILABLE
+    #define USE_HIMEM_IF_AVAILABLE
 
     /* Uncomment this to generate task list with stack sizes using the /heap handler
         PLEASE BE AWARE: The following CONFIG parameters have to to be set in 


### PR DESCRIPTION
fixes #1961 

- Fix for "initial image size" issue (if alignment parameter activated --> weird ROI image on WebUI)
- Protect against buffer overflow of JPG files > MAX_JPG_SIZE incl. error message
