### PR TITLE
Cleanup defines.h

### DIFF
--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -21,7 +21,9 @@
 
 
     // use himem //https://github.com/jomjol/AI-on-the-edge-device/issues/1842
-    //#define USE_HIMEM_IF_AVAILABLE
+    #if (CONFIG_SPIRAM_BANKSWITCH_ENABLE)
+        #define USE_HIMEM_IF_AVAILABLE 1
+    #endif
 
     /* Uncomment this to generate task list with stack sizes using the /heap handler
         PLEASE BE AWARE: The following CONFIG parameters have to to be set in 

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -21,7 +21,7 @@
 
 
     // use himem //https://github.com/jomjol/AI-on-the-edge-device/issues/1842
-    #define USE_HIMEM_IF_AVAILABLE
+    //#define USE_HIMEM_IF_AVAILABLE
 
     /* Uncomment this to generate task list with stack sizes using the /heap handler
         PLEASE BE AWARE: The following CONFIG parameters have to to be set in 
@@ -116,7 +116,6 @@
 
     //ClassFlowControll: Serve alg_roi.jpg from memory as JPG
     #define ALGROI_LOAD_FROM_MEM_AS_JPG // Load ALG_ROI.JPG as rendered JPG from RAM
-    #define ALGROI_LOAD_FROM_MEM_AS_JPG__SHOW_TAKE_IMAGE_PROCESS // Show take image image processing on webinterface (overview.html)
 
     //ClassFlowMQTT
     #define LWT_TOPIC        "connection"


### PR DESCRIPTION
- Disable define USE_HIMEM_IF_AVAILABLE because function generally is disabled in sdkconfig.defaults
- Remove orphan define ALGROI_LOAD_FROM_MEM_AS_JPG__SHOW_TAKE_IMAGE_PROCESS (not used anymore)