### PR TITLE
Use the preprocessed Web UI for the manual.zip

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -248,6 +248,7 @@ jobs:
         cp -f "./code/.pio/build/esp32cam/firmware.bin" "manual_setup/firmware.bin"
         cp -f "./code/.pio/build/esp32cam/bootloader.bin" "manual_setup/bootloader.bin"
         cp -f "./code/.pio/build/esp32cam/partitions.bin" "manual_setup/partitions.bin"
+        rm -f ./sd-card/html/*
         cp -r ./html ./sd-card/html # Overwrite the Web UI with the preprocessed files
         cd sd-card; zip -r ../manual_setup/sd-card.zip *; cd ..
         cd ./manual_setup

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -248,8 +248,8 @@ jobs:
         cp -f "./code/.pio/build/esp32cam/firmware.bin" "manual_setup/firmware.bin"
         cp -f "./code/.pio/build/esp32cam/bootloader.bin" "manual_setup/bootloader.bin"
         cp -f "./code/.pio/build/esp32cam/partitions.bin" "manual_setup/partitions.bin"
-        rm -f ./sd-card/html/*
-        cp -r ./html ./sd-card/html # Overwrite the Web UI with the preprocessed files
+        rm -rf ./sd-card/html
+        cp -r ./html ./sd-card/ # Overwrite the Web UI with the preprocessed files
         cd sd-card; zip -r ../manual_setup/sd-card.zip *; cd ..
         cd ./manual_setup
   

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -248,6 +248,7 @@ jobs:
         cp -f "./code/.pio/build/esp32cam/firmware.bin" "manual_setup/firmware.bin"
         cp -f "./code/.pio/build/esp32cam/bootloader.bin" "manual_setup/bootloader.bin"
         cp -f "./code/.pio/build/esp32cam/partitions.bin" "manual_setup/partitions.bin"
+        cp -r ./html ./sd-card/html # Overwrite the Web UI with the preprocessed files
         cd sd-card; zip -r ../manual_setup/sd-card.zip *; cd ..
         cd ./manual_setup
   


### PR DESCRIPTION
See https://github.com/jomjol/AI-on-the-edge-device/discussions/1975#discussioncomment-4874437

I already replaced the `manual.zip` of the `14.0.0` release.