### PR TITLE
*** OLD *** Migrate configuration -> Superseeded by PR2017

### DIFF
--- a/FeatureRequest.md
+++ b/FeatureRequest.md
@@ -180,9 +180,9 @@ haveing this state in the mqtt broker can trigger functions like closing the ate
 
 * Implementation of an authentication mechanism.
 
-#### #8 MQTT configurable readout intervall
+#### #8 MQTT configurable readout interval
 
-Make the readout intervall configurable via MQTT.
+Make the readout interval configurable via MQTT.
 
 * Change the mqtt part to receive and process input and not only sending
 

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -996,8 +996,13 @@ std::string unzip_new(std::string _in_zip_file, std::string _target_zip, std::st
 
                 ESP_LOGI(TAG, "Filename to extract: %s, Zwischenfilename: %s", zw.c_str(), filename_zw.c_str());
 
+                std::string folder = path.substr(0, filename_zw.find_last_of('/'));
+                MakeDir(folder);
+
                 // extrahieren in zwischendatei
                 DeleteFile(filename_zw);
+
+
                 FILE* fpTargetFile = fopen(filename_zw.c_str(), "wb");
                 uint writtenbytes = fwrite(p, 1, (uint)uncomp_size, fpTargetFile);
                 fclose(fpTargetFile);

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -739,10 +739,6 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
     /* Redirect onto root to see the updated file list */
     httpd_resp_set_status(req, "303 See Other");
     httpd_resp_set_hdr(req, "Location", directory.c_str());
-
-    /* Redirect onto root to see the updated file list */
-    httpd_resp_set_status(req, "303 See Other");
-    httpd_resp_set_hdr(req, "Location", directory.c_str());
     httpd_resp_sendstr(req, "File uploaded successfully");
 
 /*
@@ -996,7 +992,7 @@ std::string unzip_new(std::string _in_zip_file, std::string _target_zip, std::st
 
                 ESP_LOGI(TAG, "Filename to extract: %s, Zwischenfilename: %s", zw.c_str(), filename_zw.c_str());
 
-                std::string folder = path.substr(0, filename_zw.find_last_of('/'));
+                std::string folder = filename_zw.substr(0, filename_zw.find_last_of('/'));
                 MakeDir(folder);
 
                 // extrahieren in zwischendatei

--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -74,7 +74,7 @@ bool ClassFlowAlignment::ReadParameter(FILE* pfile, string& aktparamgraph)
         if (!this->GetNextParagraph(pfile, aktparamgraph))
             return false;
 
-    if (aktparamgraph.compare("[Alignment]") != 0)       //Paragraph does not fit MakeImage
+    if (aktparamgraph.compare("[Alignment]") != 0)       //Paragraph does not fit Alignment
         return false;
 
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph))

--- a/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowAlignment.cpp
@@ -1,5 +1,5 @@
 #include "ClassFlowAlignment.h"
-#include "ClassFlowMakeImage.h"
+#include "ClassFlowTakeImage.h"
 #include "ClassFlow.h"
 #include "server_tflite.h"
 
@@ -46,9 +46,9 @@ ClassFlowAlignment::ClassFlowAlignment(std::vector<ClassFlow*>* lfc)
 
     for (int i = 0; i < ListFlowControll->size(); ++i)
     {
-        if (((*ListFlowControll)[i])->name().compare("ClassFlowMakeImage") == 0)
+        if (((*ListFlowControll)[i])->name().compare("ClassFlowTakeImage") == 0)
         {
-            ImageBasis = ((ClassFlowMakeImage*) (*ListFlowControll)[i])->rawImage;
+            ImageBasis = ((ClassFlowTakeImage*) (*ListFlowControll)[i])->rawImage;
         }
     }
 

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -206,7 +206,7 @@ ClassFlow* ClassFlowControll::CreateClassFlow(std::string _type)
 
     _type = trim(_type);
 
-    if (toUpper(_type).compare("[MAKEIMAGE]") == 0)
+    if (toUpper(_type).compare("[TAKEIMAGE]") == 0)
     {
         cfc = new ClassFlowTakeImage(&FlowControll);
         flowtakeimage = (ClassFlowTakeImage*) cfc;

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -527,7 +527,7 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, string& aktparamgraph)
 
 
     if ((toUpper(aktparamgraph).compare("[AUTOTIMER]") != 0) && (toUpper(aktparamgraph).compare("[DEBUG]") != 0) &&
-        (toUpper(aktparamgraph).compare("[SYSTEM]") != 0 && (toUpper(aktparamgraph).compare("[DATALOGGING]") != 0)))      // Paragraph passt nicht zu MakeImage
+        (toUpper(aktparamgraph).compare("[SYSTEM]") != 0 && (toUpper(aktparamgraph).compare("[DATALOGGING]") != 0)))      // Paragraph passt nicht zu Debug oder DataLogging
         return false;
 
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph))

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -38,8 +38,8 @@ std::string ClassFlowControll::doSingleStep(std::string _stepname, std::string _
 
     ESP_LOGD(TAG, "Step %s start", _stepname.c_str());
 
-    if ((_stepname.compare("[MakeImage]") == 0) || (_stepname.compare(";[MakeImage]") == 0)){
-        _classname = "ClassFlowMakeImage";
+    if ((_stepname.compare("[TakeImage]") == 0) || (_stepname.compare(";[TakeImage]") == 0)){
+        _classname = "ClassFlowTakeImage";
     }
     if ((_stepname.compare("[Alignment]") == 0) || (_stepname.compare(";[Alignment]") == 0)){
         _classname = "ClassFlowAlignment";
@@ -64,7 +64,7 @@ std::string ClassFlowControll::doSingleStep(std::string _stepname, std::string _
 
     for (int i = 0; i < FlowControll.size(); ++i)
         if (FlowControll[i]->name().compare(_classname) == 0){
-            if (!(FlowControll[i]->name().compare("ClassFlowMakeImage") == 0))      // if it is a MakeImage, the image does not need to be included, this happens automatically with the html query.
+            if (!(FlowControll[i]->name().compare("ClassFlowTakeImage") == 0))      // if it is a TakeImage, the image does not need to be included, this happens automatically with the html query.
                 FlowControll[i]->doFlow("");
             result = FlowControll[i]->getHTMLSingleStep(_host);
         }
@@ -77,7 +77,7 @@ std::string ClassFlowControll::doSingleStep(std::string _stepname, std::string _
 
 std::string ClassFlowControll::TranslateAktstatus(std::string _input)
 {
-    if (_input.compare("ClassFlowMakeImage") == 0)
+    if (_input.compare("ClassFlowTakeImage") == 0)
         return ("Take Image");
     if (_input.compare("ClassFlowAlignment") == 0)
         return ("Aligning");
@@ -171,7 +171,7 @@ bool ClassFlowControll::StartMQTTService() {
     /* Start the MQTT service */
         for (int i = 0; i < FlowControll.size(); ++i) {
             if (FlowControll[i]->name().compare("ClassFlowMQTT") == 0) {
-                return ((ClassFlowMQTT*) (FlowControll[i]))->Start(AutoIntervall);
+                return ((ClassFlowMQTT*) (FlowControll[i]))->Start(AutoInterval);
             }  
         } 
     return false;
@@ -183,7 +183,7 @@ void ClassFlowControll::SetInitialParameter(void)
 {
     AutoStart = false;
     SetupModeActive = false;
-    AutoIntervall = 10; // Minutes
+    AutoInterval = 10; // Minutes
     flowdigit = NULL;
     flowanalog = NULL;
     flowpostprocessing = NULL;
@@ -193,9 +193,9 @@ void ClassFlowControll::SetInitialParameter(void)
 }
 
 
-bool ClassFlowControll::isAutoStart(long &_intervall)
+bool ClassFlowControll::isAutoStart(long &_interval)
 {
-    _intervall = AutoIntervall * 60 * 1000; // AutoInterval: minutes -> ms
+    _interval = AutoInterval * 60 * 1000; // AutoInterval: minutes -> ms
     return AutoStart;
 }
 
@@ -208,8 +208,8 @@ ClassFlow* ClassFlowControll::CreateClassFlow(std::string _type)
 
     if (toUpper(_type).compare("[MAKEIMAGE]") == 0)
     {
-        cfc = new ClassFlowMakeImage(&FlowControll);
-        flowmakeimage = (ClassFlowMakeImage*) cfc;
+        cfc = new ClassFlowTakeImage(&FlowControll);
+        flowtakeimage = (ClassFlowTakeImage*) cfc;
     }
     if (toUpper(_type).compare("[ALIGNMENT]") == 0)
     {
@@ -322,13 +322,13 @@ void ClassFlowControll::setActStatus(std::string _aktstatus)
 }
 
 
-void ClassFlowControll::doFlowMakeImageOnly(string time)
+void ClassFlowControll::doFlowTakeImageOnly(string time)
 {
     std::string zw_time;
 
     for (int i = 0; i < FlowControll.size(); ++i)
     {
-        if (FlowControll[i]->name() == "ClassFlowMakeImage") {
+        if (FlowControll[i]->name() == "ClassFlowTakeImage") {
             zw_time = getCurrentTimeString("%H:%M:%S");
             std::string flowStatus = TranslateAktstatus(FlowControll[i]->name());
             aktstatus = flowStatus + " (" + zw_time + ")";
@@ -541,9 +541,9 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, string& aktparamgraph)
             }
         }
 
-        if ((toUpper(splitted[0]) == "INTERVALL") && (splitted.size() > 1))
+        if ((toUpper(splitted[0]) == "INTERVAL") && (splitted.size() > 1))
         {
-            AutoIntervall = std::stof(splitted[1]);
+            AutoInterval = std::stof(splitted[1]);
         }
 
         if ((toUpper(splitted[0]) == "DATALOGACTIVE") && (splitted.size() > 1))
@@ -589,13 +589,13 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, string& aktparamgraph)
 
         /* TimeServer and TimeZone got already read from the config, see setupTime () */
 
-        if ((toUpper(splitted[0]) == "RSSITHREASHOLD") && (splitted.size() > 1))
+        if ((toUpper(splitted[0]) == "RSSITHRESHOLD") && (splitted.size() > 1))
         {
-            if (ChangeRSSIThreashold(WLAN_CONFIG_FILE, atoi(splitted[1].c_str())))
+            if (ChangeRSSIThreshold(WLAN_CONFIG_FILE, atoi(splitted[1].c_str())))
             {
                 // reboot necessary so that the new wlan.ini is also used !!!
                 fclose(pfile);
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Rebooting to activate new RSSITHREASHOLD ...");
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Rebooting to activate new RSSITHRESHOLD ...");
                 esp_restart();
                 hard_restart();                   
                 doReboot();
@@ -660,7 +660,7 @@ int ClassFlowControll::CleanTempFolder() {
 
 esp_err_t ClassFlowControll::SendRawJPG(httpd_req_t *req)
 {
-    return flowmakeimage != NULL ? flowmakeimage->SendRawJPG(req) : ESP_FAIL;
+    return flowtakeimage != NULL ? flowtakeimage->SendRawJPG(req) : ESP_FAIL;
 }
 
 

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.h
@@ -6,7 +6,7 @@
 #include <string>
 
 #include "ClassFlow.h"
-#include "ClassFlowMakeImage.h"
+#include "ClassFlowTakeImage.h"
 #include "ClassFlowAlignment.h"
 #include "ClassFlowCNNGeneral.h"
 #include "ClassFlowPostProcessing.h"
@@ -29,11 +29,11 @@ protected:
 	ClassFlowCNNGeneral* flowanalog;
 	ClassFlowCNNGeneral* flowdigit;
 //	ClassFlowDigit* flowdigit;
-	ClassFlowMakeImage* flowmakeimage;
+	ClassFlowTakeImage* flowtakeimage;
 	ClassFlow* CreateClassFlow(std::string _type);
 
 	bool AutoStart;
-	float AutoIntervall;
+	float AutoInterval;
 	bool SetupModeActive;
 	void SetInitialParameter(void);	
 	std::string aktstatus;
@@ -42,7 +42,7 @@ protected:
 public:
 	void InitFlow(std::string config);
 	bool doFlow(string time);
-	void doFlowMakeImageOnly(string time);
+	void doFlowTakeImageOnly(string time);
 	bool getStatusSetupModus(){return SetupModeActive;};
 	string getReadout(bool _rawvalue, bool _noerror);
 	string getReadoutAll(int _type);	
@@ -68,7 +68,7 @@ public:
 
 	std::string doSingleStep(std::string _stepname, std::string _host);
 
-	bool isAutoStart(long &_intervall);
+	bool isAutoStart(long &_interval);
 
 	std::string* getActStatus();
 	void setActStatus(std::string _aktstatus);

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -184,9 +184,9 @@ string ClassFlowMQTT::GetMQTTMainTopic()
 }
 
 
-bool ClassFlowMQTT::Start(float AutoIntervall) 
+bool ClassFlowMQTT::Start(float AutoInterval) 
 {
-    roundInterval = AutoIntervall; // Minutes
+    roundInterval = AutoInterval; // Minutes
     keepAlive = roundInterval * 60 * 2.5; // Seconds, make sure it is greater thatn 2 rounds!
 
     std::stringstream stream;

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -95,7 +95,7 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, string& aktparamgraph)
         if (!this->GetNextParagraph(pfile, aktparamgraph))
             return false;
 
-    if (toUpper(aktparamgraph).compare("[MQTT]") != 0)       // Paragraph does not fit MakeImage
+    if (toUpper(aktparamgraph).compare("[MQTT]") != 0)       // Paragraph does not fit MQTT
         return false;
 
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph))

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.h
@@ -32,7 +32,7 @@ public:
     ClassFlowMQTT(std::vector<ClassFlow*>* lfc, ClassFlow *_prev);
 
     string GetMQTTMainTopic();
-    bool Start(float AutoIntervall);
+    bool Start(float AutoInterval);
 
     bool ReadParameter(FILE* pfile, string& aktparamgraph);
     bool doFlow(string time);

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -1,6 +1,6 @@
 #include "ClassFlowPostProcessing.h"
 #include "Helper.h"
-#include "ClassFlowMakeImage.h"
+#include "ClassFlowTakeImage.h"
 #include "ClassLogFile.h"
 
 #include <iomanip>
@@ -285,7 +285,7 @@ ClassFlowPostProcessing::ClassFlowPostProcessing(std::vector<ClassFlow*>* lfc, C
     ListFlowControll = NULL;
     FilePreValue = FormatFileName("/sdcard/config/prevalue.ini");
     ListFlowControll = lfc;
-    flowMakeImage = NULL;
+    flowTakeImage = NULL;
     UpdatePreValueINI = false;
     IgnoreLeadingNaN = false;
     flowAnalog = _analog;
@@ -293,9 +293,9 @@ ClassFlowPostProcessing::ClassFlowPostProcessing(std::vector<ClassFlow*>* lfc, C
 
     for (int i = 0; i < ListFlowControll->size(); ++i)
     {
-        if (((*ListFlowControll)[i])->name().compare("ClassFlowMakeImage") == 0)
+        if (((*ListFlowControll)[i])->name().compare("ClassFlowTakeImage") == 0)
         {
-            flowMakeImage = (ClassFlowMakeImage*) (*ListFlowControll)[i];
+            flowTakeImage = (ClassFlowTakeImage*) (*ListFlowControll)[i];
         }
     }
 }
@@ -715,7 +715,7 @@ bool ClassFlowPostProcessing::doFlow(string zwtime)
 
     // Update decimal point, as the decimal places can also change when changing from CNNType Auto --> xyz:
 
-    imagetime = flowMakeImage->getTimeImageTaken();
+    imagetime = flowTakeImage->getTimeImageTaken();
     if (imagetime == 0)
         time(&imagetime);
 

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -503,7 +503,7 @@ bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, string& aktparamgraph)
             return false;
 
 
-    if (aktparamgraph.compare("[PostProcessing]") != 0)       // Paragraph does not fit MakeImage
+    if (aktparamgraph.compare("[PostProcessing]") != 0)       // Paragraph does not fit PostProcessing
         return false;
 
     InitNUMBERS();

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
@@ -4,7 +4,7 @@
 #define CLASSFFLOWPOSTPROCESSING_H
 
 #include "ClassFlow.h"
-#include "ClassFlowMakeImage.h"
+#include "ClassFlowTakeImage.h"
 #include "ClassFlowCNNGeneral.h"
 #include "ClassFlowDefineTypes.h"
 
@@ -29,7 +29,7 @@ protected:
 
     string FilePreValue;
 
-    ClassFlowMakeImage *flowMakeImage;
+    ClassFlowTakeImage *flowTakeImage;
 
     bool LoadPreValue(void);
     string ShiftDecimal(string in, int _decShift);

--- a/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
@@ -1,4 +1,4 @@
-#include "ClassFlowMakeImage.h"
+#include "ClassFlowTakeImage.h"
 #include "Helper.h"
 #include "ClassLogFile.h"
 
@@ -17,7 +17,7 @@
 
 static const char* TAG = "flow_make_image";
 
-esp_err_t ClassFlowMakeImage::camera_capture(){
+esp_err_t ClassFlowTakeImage::camera_capture(){
     string nm =  namerawimage;
     Camera.CaptureToFile(nm);
     time(&TimeImageTaken);
@@ -26,7 +26,7 @@ esp_err_t ClassFlowMakeImage::camera_capture(){
     return ESP_OK;
 }
 
-void ClassFlowMakeImage::takePictureWithFlash(int flash_duration)
+void ClassFlowTakeImage::takePictureWithFlash(int flash_duration)
 {
     // in case the image is flipped, it must be reset here //
     rawImage->width = image_width;          
@@ -40,7 +40,7 @@ void ClassFlowMakeImage::takePictureWithFlash(int flash_duration)
     if (SaveAllFiles) rawImage->SaveToFile(namerawimage);
 }
 
-void ClassFlowMakeImage::SetInitialParameter(void)
+void ClassFlowTakeImage::SetInitialParameter(void)
 {
     waitbeforepicture = 5;
     isImageSize = false;
@@ -56,7 +56,7 @@ void ClassFlowMakeImage::SetInitialParameter(void)
 }     
 
 
-ClassFlowMakeImage::ClassFlowMakeImage(std::vector<ClassFlow*>* lfc) : ClassFlowImage(lfc, TAG)
+ClassFlowTakeImage::ClassFlowTakeImage(std::vector<ClassFlow*>* lfc) : ClassFlowImage(lfc, TAG)
 {
     LogImageLocation = "/log/source";
     logfileRetentionInDays = 5;
@@ -64,7 +64,7 @@ ClassFlowMakeImage::ClassFlowMakeImage(std::vector<ClassFlow*>* lfc) : ClassFlow
 }
 
 
-bool ClassFlowMakeImage::ReadParameter(FILE* pfile, string& aktparamgraph)
+bool ClassFlowTakeImage::ReadParameter(FILE* pfile, string& aktparamgraph)
 {
     std::vector<string> splitted;
 
@@ -77,7 +77,7 @@ bool ClassFlowMakeImage::ReadParameter(FILE* pfile, string& aktparamgraph)
         if (!this->GetNextParagraph(pfile, aktparamgraph))
             return false;
 
-    if (aktparamgraph.compare("[MakeImage]") != 0)       // Paragraph does not fit MakeImage
+    if (aktparamgraph.compare("[TakeImage]") != 0)       // Paragraph does not fit TakeImage
         return false;
 
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph))
@@ -173,7 +173,7 @@ bool ClassFlowMakeImage::ReadParameter(FILE* pfile, string& aktparamgraph)
 }
 
 
-string ClassFlowMakeImage::getHTMLSingleStep(string host)
+string ClassFlowTakeImage::getHTMLSingleStep(string host)
 {
     string result;
     result = "Raw Image: <br>\n<img src=\"" + host + "/img_tmp/raw.jpg\">\n";
@@ -181,14 +181,14 @@ string ClassFlowMakeImage::getHTMLSingleStep(string host)
 }
 
 
-bool ClassFlowMakeImage::doFlow(string zwtime)
+bool ClassFlowTakeImage::doFlow(string zwtime)
 {
     string logPath = CreateLogFolder(zwtime);
 
     int flash_duration = (int) (waitbeforepicture * 1000);
  
     #ifdef DEBUG_DETAIL_ON  
-        LogFile.WriteHeapInfo("ClassFlowMakeImage::doFlow - Before takePictureWithFlash");
+        LogFile.WriteHeapInfo("ClassFlowTakeImage::doFlow - Before takePictureWithFlash");
     #endif
 
 
@@ -204,7 +204,7 @@ bool ClassFlowMakeImage::doFlow(string zwtime)
 
 
     #ifdef DEBUG_DETAIL_ON  
-        LogFile.WriteHeapInfo("ClassFlowMakeImage::doFlow - After takePictureWithFlash");
+        LogFile.WriteHeapInfo("ClassFlowTakeImage::doFlow - After takePictureWithFlash");
     #endif
 
     LogImage(logPath, "raw", NULL, NULL, zwtime, rawImage);
@@ -212,14 +212,14 @@ bool ClassFlowMakeImage::doFlow(string zwtime)
     RemoveOldLogs();
 
     #ifdef DEBUG_DETAIL_ON  
-        LogFile.WriteHeapInfo("ClassFlowMakeImage::doFlow - After RemoveOldLogs");
+        LogFile.WriteHeapInfo("ClassFlowTakeImage::doFlow - After RemoveOldLogs");
     #endif
 
     return true;
 }
 
 
-esp_err_t ClassFlowMakeImage::SendRawJPG(httpd_req_t *req)
+esp_err_t ClassFlowTakeImage::SendRawJPG(httpd_req_t *req)
 {
     int flash_duration = (int) (waitbeforepicture * 1000);
     time(&TimeImageTaken);
@@ -229,7 +229,7 @@ esp_err_t ClassFlowMakeImage::SendRawJPG(httpd_req_t *req)
 }
 
 
-ImageData* ClassFlowMakeImage::SendRawImage()
+ImageData* ClassFlowTakeImage::SendRawImage()
 {
     CImageBasis *zw = new CImageBasis(rawImage);
     ImageData *id;
@@ -243,12 +243,12 @@ ImageData* ClassFlowMakeImage::SendRawImage()
     return id;  
 }
 
-time_t ClassFlowMakeImage::getTimeImageTaken()
+time_t ClassFlowTakeImage::getTimeImageTaken()
 {
     return TimeImageTaken;
 }
 
-ClassFlowMakeImage::~ClassFlowMakeImage(void)
+ClassFlowTakeImage::~ClassFlowTakeImage(void)
 {
     delete rawImage;
 }

--- a/code/components/jomjol_flowcontroll/ClassFlowTakeImage.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowTakeImage.h
@@ -9,7 +9,7 @@
 
 #include <string>
 
-class ClassFlowMakeImage :
+class ClassFlowTakeImage :
     public ClassFlowImage
 {
 protected:
@@ -37,18 +37,18 @@ protected:
 public:
     CImageBasis *rawImage;
 
-    ClassFlowMakeImage(std::vector<ClassFlow*>* lfc);
+    ClassFlowTakeImage(std::vector<ClassFlow*>* lfc);
 
     bool ReadParameter(FILE* pfile, string& aktparamgraph);
     bool doFlow(string time);
     string getHTMLSingleStep(string host);
     time_t getTimeImageTaken();
-    string name(){return "ClassFlowMakeImage";};
+    string name(){return "ClassFlowTakeImage";};
 
     ImageData* SendRawImage();
     esp_err_t SendRawJPG(httpd_req_t *req);
 
-    ~ClassFlowMakeImage(void);
+    ~ClassFlowTakeImage(void);
 };
 
 

--- a/code/components/jomjol_flowcontroll/ClassFlowTakeImage.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowTakeImage.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#ifndef CLASSFFLOWMAKEIMAGE_H
-#define CLASSFFLOWMAKEIMAGE_H
+#ifndef CLASSFFLOWTAKEIMAGE_H
+#define CLASSFFLOWTAKEIMAGE_H
 
 #include "ClassFlowImage.h"
 #include "ClassControllCamera.h"
@@ -52,4 +52,4 @@ public:
 };
 
 
-#endif //CLASSFFLOWMAKEIMAGE_H
+#endif //CLASSFFLOWTAKEIMAGE_H

--- a/code/components/jomjol_helper/Helper.cpp
+++ b/code/components/jomjol_helper/Helper.cpp
@@ -224,15 +224,50 @@ void FindReplace(std::string& line, std::string& oldString, std::string& newStri
 }
 
 
-bool MakeDir(std::string _what)
+/**
+ * Create a folder and its parent folders as needed
+ */
+bool MakeDir(std::string path)
 {
-	int mk_ret = mkdir(_what.c_str(), 0775);
-	if (mk_ret)
-	{
-		ESP_LOGD(TAG, "error with mkdir %s ret %d", _what.c_str(), mk_ret);
-		return false;
+	std::string parent;
+
+	LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Creating folder " + path + "...");
+
+	bool bSuccess = false;
+    int nRC = ::mkdir( path.c_str(), 0775 );
+    if( nRC == -1 )
+    {
+        switch( errno ) {
+            case ENOENT:
+                //parent didn't exist, try to create it
+				parent = path.substr(0, path.find_last_of('/'));
+        		LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Need to create parent folder first: " + parent);
+                if(MakeDir(parent)) {
+                    //Now, try to create again.
+                    bSuccess = 0 == ::mkdir( path.c_str(), 0775 );
+				}
+                else {
+        			LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to create parent folder: " + parent);
+                    bSuccess = false;
+				}
+                break;
+
+            case EEXIST:
+                //Done!
+                bSuccess = true;
+                break;
+				
+            default:
+				LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to create folder: " + path);
+                bSuccess = false;
+                break;
+        }
+    }
+    else {
+        bSuccess = true;
 	}
-	return true;
+
+    return bSuccess;
 }
 
 

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -30,7 +30,7 @@ TaskHandle_t xHandletask_autodoFlow = NULL;
 bool bTaskAutoFlowCreated = false;
 bool flowisrunning = false;
 
-long auto_intervall = 0;
+long auto_interval = 0;
 bool auto_isrunning = false;
 
 int countRounds = 0;
@@ -620,8 +620,8 @@ esp_err_t handler_editflow(httpd_req_t *req)
 //        string zwzw = "Do " + _task + " start\n"; ESP_LOGD(TAG, zwzw.c_str());
         Camera.SetBrightnessContrastSaturation(bri, con, sat);
         Camera.SetLEDIntensity(intens);
-        ESP_LOGD(TAG, "test_take - vor MakeImage");
-        std::string zw = tfliteflow.doSingleStep("[MakeImage]", _host);
+        ESP_LOGD(TAG, "test_take - vor TakeImage");
+        std::string zw = tfliteflow.doSingleStep("[TakeImage]", _host);
         httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
         httpd_resp_send(req, zw.c_str(), zw.length()); 
     } 
@@ -825,13 +825,13 @@ void task_autodoFlow(void *pvParameter)
     ESP_LOGD(TAG, "task_autodoFlow: start");
     doInit();
 
-    auto_isrunning = tfliteflow.isAutoStart(auto_intervall);
+    auto_isrunning = tfliteflow.isAutoStart(auto_interval);
 
     if (isSetupModusActive()) 
     {
         auto_isrunning = false;
         std::string zw_time = getCurrentTimeString(LOGFILE_TIME_FORMAT);
-        tfliteflow.doFlowMakeImageOnly(zw_time);
+        tfliteflow.doFlowTakeImageOnly(zw_time);
     }
     
     while (auto_isrunning)
@@ -873,9 +873,9 @@ void task_autodoFlow(void *pvParameter)
                 " completed (" + std::to_string(getUpTime() - roundStartTime) + " seconds)");
 
         fr_delta_ms = (esp_timer_get_time() - fr_start) / 1000;
-        if (auto_intervall > fr_delta_ms)
+        if (auto_interval > fr_delta_ms)
         {
-            const TickType_t xDelay = (auto_intervall - fr_delta_ms)  / portTICK_PERIOD_MS;
+            const TickType_t xDelay = (auto_interval - fr_delta_ms)  / portTICK_PERIOD_MS;
             ESP_LOGD(TAG, "Autoflow: sleep for: %ldms", (long) xDelay);
             vTaskDelay( xDelay );        
         }

--- a/code/components/jomjol_wlan/connect_wlan.cpp
+++ b/code/components/jomjol_wlan/connect_wlan.cpp
@@ -63,7 +63,7 @@ std::string hostname = "";
 std::string std_hostname = "watermeter";
 std::string ipadress = "";
 std::string ssid = "";
-int RSSIThreashold;
+int RSSIThreshold;
 
 /////////////////////////////////
 /////////////////////////////////
@@ -403,9 +403,9 @@ void strinttoip4(const char *ip, int &a, int &b, int &c, int &d) {
 }
 
 
-void wifi_init_sta(const char *_ssid, const char *_password, const char *_hostname, const char *_ipadr, const char *_gw,  const char *_netmask, const char *_dns, int _rssithreashold)
+void wifi_init_sta(const char *_ssid, const char *_password, const char *_hostname, const char *_ipadr, const char *_gw,  const char *_netmask, const char *_dns, int _rssithreshold)
 {
-	RSSI_Threshold = _rssithreashold;
+	RSSI_Threshold = _rssithreshold;
     s_wifi_event_group = xEventGroupCreate();
 
     ESP_ERROR_CHECK(esp_netif_init());

--- a/code/components/jomjol_wlan/connect_wlan.h
+++ b/code/components/jomjol_wlan/connect_wlan.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-void wifi_init_sta(const char *_ssid, const char *_password, const char *_hostname, const char *_ipadr, const char *_gw,  const char *_netmask, const char *_dns, int _rssithreashold);
+void wifi_init_sta(const char *_ssid, const char *_password, const char *_hostname, const char *_ipadr, const char *_gw,  const char *_netmask, const char *_dns, int _rssithreshold);
 void wifi_init_sta(const char *_ssid, const char *_password, const char *_hostname);
 void wifi_init_sta(const char *_ssid, const char *_password);
 
@@ -17,6 +17,6 @@ void WIFIDestroy();
 
 extern std::string hostname;
 extern std::string std_hostname;
-extern int RSSIThreashold;
+extern int RSSIThreshold;
 
 #endif //CONNECT_WLAN_H

--- a/code/components/jomjol_wlan/read_wlanini.cpp
+++ b/code/components/jomjol_wlan/read_wlanini.cpp
@@ -41,7 +41,7 @@ std::vector<string> ZerlegeZeileWLAN(std::string input, std::string _delimiter =
 
 
 
-bool LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_hostname, char *&_ipadr, char *&_gw,  char *&_netmask, char *&_dns, int &_rssithreashold)
+bool LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_hostname, char *&_ipadr, char *&_gw,  char *&_netmask, char *&_dns, int &_rssithreshold)
 {
     std::string ssid = "";
     std::string passphrase = "";
@@ -91,7 +91,7 @@ bool LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_ho
             }
         }
 
-        if ((splitted.size() > 1) && (toUpper(splitted[0]) == "RSSITHREASHOLD")){
+        if ((splitted.size() > 1) && (toUpper(splitted[0]) == "RSSITHRESHOLD")){
             string _s = trim(splitted[1]);
             if ((_s[0] == '"') && (_s[_s.length()-1] == '"')){
                 _s = _s.substr(1, ssid.length()-2);
@@ -194,8 +194,8 @@ bool LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_ho
     else
         _dns = NULL;
 
-    _rssithreashold = rssithreshold;
-    RSSIThreashold = rssithreshold;
+    _rssithreshold = rssithreshold;
+    RSSIThreshold = rssithreshold;
     return true;
 }
 
@@ -274,9 +274,9 @@ bool ChangeHostName(std::string fn, std::string _newhostname)
 }
 
 
-bool ChangeRSSIThreashold(std::string fn, int _newrssithreashold)
+bool ChangeRSSIThreshold(std::string fn, int _newrssithreshold)
 {
-    if (RSSIThreashold == _newrssithreashold)
+    if (RSSIThreshold == _newrssithreshold)
         return false;
 
     string line = "";
@@ -305,8 +305,8 @@ bool ChangeRSSIThreashold(std::string fn, int _newrssithreashold)
         splitted = ZerlegeZeileWLAN(line, "=");
         splitted[0] = trim(splitted[0], " ");
 
-        if ((splitted.size() > 1) && (toUpper(splitted[0]) == "RSSITHREASHOLD")){
-            line = "RSSIThreashold = " + to_string(_newrssithreashold) + "\n";
+        if ((splitted.size() > 1) && (toUpper(splitted[0]) == "RSSITHRESHOLD")){
+            line = "RSSIThreshold = " + to_string(_newrssithreshold) + "\n";
             found = true;
         }
 
@@ -324,7 +324,7 @@ bool ChangeRSSIThreashold(std::string fn, int _newrssithreashold)
 
     if (!found)
     {
-        line = "RSSIThreashold = " + to_string(_newrssithreashold) + "\n";
+        line = "RSSIThreshold = " + to_string(_newrssithreshold) + "\n";
         neuesfile.push_back(line);        
     }
 
@@ -340,7 +340,7 @@ bool ChangeRSSIThreashold(std::string fn, int _newrssithreashold)
 
     fclose(pFile);
 
-    ESP_LOGD(TAG, "*** RSSIThreashold update done ***");
+    ESP_LOGD(TAG, "*** RSSIThreshold update done ***");
 
     return true;
 }

--- a/code/components/jomjol_wlan/read_wlanini.h
+++ b/code/components/jomjol_wlan/read_wlanini.h
@@ -5,10 +5,10 @@
 
 #include <string>
 
-bool LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_hostname, char *&_ipadr, char *&_gw,  char *&_netmask, char *&_dns, int &_rssithreashold);
+bool LoadWlanFromFile(std::string fn, char *&_ssid, char *&_password, char *&_hostname, char *&_ipadr, char *&_gw,  char *&_netmask, char *&_dns, int &_rssithreshold);
 
 bool ChangeHostName(std::string fn, std::string _newhostname);
-bool ChangeRSSIThreashold(std::string fn, int _newrssithreashold);
+bool ChangeRSSIThreshold(std::string fn, int _newrssithreshold);
 
 
 #endif //READ_WLANINI_H

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -58,7 +58,7 @@
     //#define CONFIG_IDF_TARGET_ARCH_XTENSA //not needed with platformio/espressif32 @ 5.2.0
 
 
-    //ClassControllCamera + ClassFlowMakeImage + connect_wlan + main
+    //ClassControllCamera + ClassFlowTakeImage + connect_wlan + main
     #define FLASH_GPIO GPIO_NUM_4
     #define BLINK_GPIO GPIO_NUM_33
 
@@ -71,7 +71,7 @@
     //server_GPIO
     #define __LEDGLOBAL
 
-    //ClassControllCamera + ClassFlowMakeImage
+    //ClassControllCamera + ClassFlowTakeImage
     #define CAMERA_MODEL_AI_THINKER
     #define BOARD_ESP32CAM_AITHINKER
 

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -77,6 +77,7 @@
 
     //server_GPIO + server_file + SoftAP
     #define CONFIG_FILE "/sdcard/config/config.ini"
+    #define CONFIG_FILE_BACKUP "/sdcard/config/config.bak"
 
     //ClassFlowControll + Main + SoftAP
     #define WLAN_CONFIG_FILE "/sdcard/wlan.ini"

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -421,9 +421,41 @@ void migrateConfiguration(void) {
 	std::ifstream ifs(CONFIG_FILE);
   	std::string content((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
 	
+    /* Typos */
     found = found | replace_all(content, "[MakeImage]", "[TakeImage]");
     found = found | replace_all(content, "Intervall", "Interval");
     found = found | replace_all(content, "RSSIThreashold", "RSSIThreshold");
+    found = found | replace_all(content, "RSSIThreashold", "RSSIThreshold");
+
+    /* Boolean parameters which where set to false but commented out -> remove semicolon */
+    found = found | replace_all(content, ";Demo = false", "Demo = false");
+    found = found | replace_all(content, ";FixedExposure = false", "FixedExposure = false");
+    found = found | replace_all(content, ";InitialMirror = false", "InitialMirror = false");
+    found = found | replace_all(content, ";FlipImageSize = false", "FlipImageSize = false");
+    found = found | replace_all(content, ";ExtendedResolution = false", "ExtendedResolution = false");
+    found = found | replace_all(content, ";PreValueUse = false", "PreValueUse = false");
+    found = found | replace_all(content, ";ErrorMessage = false", "ErrorMessage = false");
+    found = found | replace_all(content, ";CheckDigitIncreaseConsistency = false", "CheckDigitIncreaseConsistency = false");
+    found = found | replace_all(content, ";SetRetainFlag = false", "SetRetainFlag = false");
+    found = found | replace_all(content, ";HomeassistantDiscovery = false", "HomeassistantDiscovery = false");
+    found = found | replace_all(content, ";AutoStart = false", "AutoStart = false");
+    found = found | replace_all(content, ";DataLogActive = false", "DataLogActive = false");
+    found = found | replace_all(content, ";SetupMode = false", "SetupMode = false");
+
+    /* Boolean parameters which where set to true but commented out -> remove semicolon and set to its default value */
+    found = found | replace_all(content, ";Demo = true", "Demo = false");
+    found = found | replace_all(content, ";FixedExposure = true", "FixedExposure = false");
+    found = found | replace_all(content, ";InitialMirror = true", "InitialMirror = false");
+    found = found | replace_all(content, ";FlipImageSize = true", "FlipImageSize = false");
+    found = found | replace_all(content, ";ExtendedResolution = true", "ExtendedResolution = false");
+    found = found | replace_all(content, ";PreValueUse = true", "PreValueUse = false");
+    found = found | replace_all(content, ";ErrorMessage = true", "ErrorMessage = false");
+    found = found | replace_all(content, ";CheckDigitIncreaseConsistency = true", "CheckDigitIncreaseConsistency = false");
+    found = found | replace_all(content, ";SetRetainFlag = true", "SetRetainFlag = false");
+    found = found | replace_all(content, ";HomeassistantDiscovery = true", "HomeassistantDiscovery = false");
+    found = found | replace_all(content, ";AutoStart = true", "AutoStart = false");
+    found = found | replace_all(content, ";DataLogActive = true", "DataLogActive = true"); // Enabled by default!
+    found = found | replace_all(content, ";SetupMode = true", "SetupMode = false");
 
     if (found) { // At least one replacement happened
         if (! RenameFile(CONFIG_FILE, CONFIG_FILE_BACKUP)) {

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -249,10 +249,10 @@ extern "C" void app_main(void)
     ESP_ERROR_CHECK( heap_trace_start(HEAP_TRACE_LEAKS) );
 #endif
     
-    char *ssid = NULL, *passwd = NULL, *hostname = NULL, *ip = NULL, *gateway = NULL, *netmask = NULL, *dns = NULL; int rssithreashold = 0;
-    LoadWlanFromFile(WLAN_CONFIG_FILE, ssid, passwd, hostname, ip, gateway, netmask, dns, rssithreashold);
+    char *ssid = NULL, *passwd = NULL, *hostname = NULL, *ip = NULL, *gateway = NULL, *netmask = NULL, *dns = NULL; int rssithreshold = 0;
+    LoadWlanFromFile(WLAN_CONFIG_FILE, ssid, passwd, hostname, ip, gateway, netmask, dns, rssithreshold);
 
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "WLAN-Settings - RSSI-Threashold: " + to_string(rssithreashold));
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "WLAN-Settings - RSSI-Threshold: " + to_string(rssithreshold));
 
     if (ssid != NULL && passwd != NULL)
 #ifdef __HIDE_PASSWORD
@@ -275,7 +275,7 @@ extern "C" void app_main(void)
        ESP_LOGD(TAG, "DNS IP: %s", dns);
 
 
-    wifi_init_sta(ssid, passwd, hostname, ip, gateway, netmask, dns, rssithreashold);   
+    wifi_init_sta(ssid, passwd, hostname, ip, gateway, netmask, dns, rssithreshold);   
 
 
     xDelay = 2000 / portTICK_PERIOD_MS;

--- a/code/main/softAP.cpp
+++ b/code/main/softAP.cpp
@@ -95,7 +95,7 @@ void wifi_init_softAP(void)
 void SendHTTPResponse(httpd_req_t *req)
 {
     std::string message = "<h1>AI-on-the-edge - BASIC SETUP</h1><p>This is an access point with a minimal server to setup the minimum required files and information on the device and the SD-card. ";
-    message += "This mode is always startet if one of the following files is missing: /wlan.ini or the /config/config.ini.<p>";
+    message += "This mode is always startet if one of the following files on the SD-Card is missing: /wlan.ini or the /config/config.ini.<p>";
     message += "The setup is done in 3 steps: 1. upload full inital configuration (sd-card content), 2. store WLAN acces information, 3. reboot (and connect to WLANs)<p><p>";
     message += "Please follow the below instructions.<p>";
     httpd_resp_send_chunk(req, message.c_str(), strlen(message.c_str()));
@@ -105,7 +105,7 @@ void SendHTTPResponse(httpd_req_t *req)
     if (!isConfigINI)
     {
         message = "<h3>1. Upload initial configuration to sd-card</h3><p>";
-        message += "The configuration file config.ini is missing and most propably the full configuration and html folder on the sd-card. ";
+        message += "The configuration file config.ini is missing and most probably the full configuration and html folder on the sd-card. ";
         message += "This is normal after the first flashing of the firmware and an empty sd-card. Please upload \"remote_setup.zip\", which contains an full inital configuration.<p>";
         message += "<input id=\"newfile\" type=\"file\"><br>";
         message += "<button class=\"button\" style=\"width:300px\" id=\"doUpdate\" type=\"button\" onclick=\"upload()\">Upload File</button><p>";
@@ -140,14 +140,14 @@ void SendHTTPResponse(httpd_req_t *req)
 //        message += "<tr><td>gateway</td><td><input type=\"text\" name=\"gateway\" id=\"gateway\"></td><td>Leave emtpy if set by router</td></tr>";
 //        message += "<tr><td>netmask</td><td><input type=\"text\" name=\"netmask\" id=\"netmask\"></td><td>Leave emtpy if set by router</td>";
 //        message += "</tr><tr><td>DNS</td><td><input type=\"text\" name=\"dns\" id=\"dns\"></td><td>Leave emtpy if set by router</td></tr>";
-//        message += "<tr><td>RSSI Threashold</td><td><input type=\"number\" name=\"name\" id=\"threashold\" min=\"-100\"  max=\"0\" step=\"1\" value = \"0\"></td><td>WLAN Mesh Parameter: Threashold for RSSI value to check for start switching access point in a mesh system.Possible values: -100 to 0, 0 = disabled - Value will be transfered to wlan.ini at next startup)</td></tr>";
+//        message += "<tr><td>RSSI Threshold</td><td><input type=\"number\" name=\"name\" id=\"threshold\" min=\"-100\"  max=\"0\" step=\"1\" value = \"0\"></td><td>WLAN Mesh Parameter: Threshold for RSSI value to check for start switching access point in a mesh system.Possible values: -100 to 0, 0 = disabled - Value will be transfered to wlan.ini at next startup)</td></tr>";
 //        httpd_resp_send_chunk(req, message.c_str(), strlen(message.c_str()));
 
 
         message = "<button class=\"button\" type=\"button\" onclick=\"wr()\">Write wlan.ini</button>";
         message += "<script language=\"JavaScript\">async function wr(){";
         message += "api = \"/config?\"+\"ssid=\"+document.getElementById(\"ssid\").value+\"&pwd=\"+document.getElementById(\"password\").value;";
-//        message += "api = \"/config?\"+\"ssid=\"+document.getElementById(\"ssid\").value+\"&pwd=\"+document.getElementById(\"password\").value+\"&hn=\"+document.getElementById(\"hostname\").value+\"&ip=\"+document.getElementById(\"ip\").value+\"&gw=\"+document.getElementById(\"gateway\").value+\"&nm=\"+document.getElementById(\"netmask\").value+\"&dns=\"+document.getElementById(\"dns\").value+\"&rssi=\"+document.getElementById(\"threashold\").value;";
+//        message += "api = \"/config?\"+\"ssid=\"+document.getElementById(\"ssid\").value+\"&pwd=\"+document.getElementById(\"password\").value+\"&hn=\"+document.getElementById(\"hostname\").value+\"&ip=\"+document.getElementById(\"ip\").value+\"&gw=\"+document.getElementById(\"gateway\").value+\"&nm=\"+document.getElementById(\"netmask\").value+\"&dns=\"+document.getElementById(\"dns\").value+\"&rssi=\"+document.getElementById(\"threshold\").value;";
         message += "fetch(api);await new Promise(resolve => setTimeout(resolve, 1000));location.reload();}</script>";
         httpd_resp_send_chunk(req, message.c_str(), strlen(message.c_str()));
         return;
@@ -311,7 +311,7 @@ esp_err_t config_ini_handler(httpd_req_t *req)
     fputs(dns.c_str(), configfilehandle);
 
     if (rssi.length())
-        rssi = "RSSIThreashold = \"" + rssi + "\"\n";
+        rssi = "RSSIThreshold = \"" + rssi + "\"\n";
     else
         rssi = ";rssi = \"\"\n";
     fputs(rssi.c_str(), configfilehandle);

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
@@ -9,11 +9,11 @@ UnderTestPost* setUpClassFlowPostprocessing(t_CNNType digType, t_CNNType anaType
     ClassFlowCNNGeneral* _analog;
     ClassFlowCNNGeneral* _digit;
     std::vector<ClassFlow*> FlowControll;
-    ClassFlowMakeImage* flowmakeimage;
+    ClassFlowTakeImage* flowtakeimage;
 
     // wird im doFlow verwendet
-    flowmakeimage = new ClassFlowMakeImage(&FlowControll);
-    FlowControll.push_back(flowmakeimage);
+    flowtakeimage = new ClassFlowTakeImage(&FlowControll);
+    FlowControll.push_back(flowtakeimage);
 
     // Die Modeltypen werden gesetzt, da keine Modelle verwendet werden.
     _analog = new ClassFlowCNNGeneral(nullptr, anaType);

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
@@ -4,7 +4,7 @@
 #include <unity.h>
 #include <ClassFlowPostProcessing.h>
 #include <ClassFlowCNNGeneral.h>
-#include <ClassFlowMakeImage.h>
+#include <ClassFlowTakeImage.h>
 #include <Helper.h>
 
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -3,4 +3,4 @@ The firmware got moved to the [Release page](https://github.com/jomjol/AI-on-the
 
 # Installation Guide
 
-You find the complete installation guide at <https://github.com/jomjol/AI-on-the-edge-device/wiki/Installation>
+You find the complete installation guide at https://jomjol.github.io/AI-on-the-edge-device-docs/Installation/

--- a/sd-card/config/config.ini
+++ b/sd-card/config/config.ini
@@ -1,4 +1,4 @@
-[MakeImage]
+[TakeImage]
 ;LogImageLocation = /log/source
 WaitBeforeTakingPicture = 5
 ;LogfileRetentionInDays = 15
@@ -85,7 +85,7 @@ LEDColor = 150 150 150
 
 [AutoTimer]
 AutoStart = true
-Intervall = 5
+Interval = 5
 
 [DataLogging]
 DataLogActive = true
@@ -100,5 +100,5 @@ TimeZone = CET-1CEST,M3.5.0,M10.5.0/3
 ;TimeServer = pool.ntp.org
 ;AutoAdjustSummertime = false
 ;Hostname = undefined
-;RSSIThreashold = 0
+;RSSIThreshold = 0
 SetupMode = true

--- a/sd-card/config/config.ini
+++ b/sd-card/config/config.ini
@@ -35,7 +35,7 @@ Model = /config/ana-cont_11.3.1_s2.tflite
 CNNGoodThreshold = 0.5
 ;LogImageLocation = /log/analog
 ;LogfileRetentionInDays = 3
-ExtendedResolution = true
+ExtendedResolution = false
 main.ana1 432 230 92 92 false
 main.ana2 379 332 92 92 false
 main.ana3 283 374 92 92 false
@@ -60,8 +60,8 @@ CheckDigitIncreaseConsistency = false
 ;ClientID = watermeter
 ;user = USERNAME
 ;password = PASSWORD
-;SetRetainFlag = true
-;HomeassistantDiscovery = true
+SetRetainFlag = false
+HomeassistantDiscovery = false
 ;MeterType = other
 
 ;[InfluxDB]
@@ -98,7 +98,7 @@ LogfileRetentionInDays = 3
 [System]
 TimeZone = CET-1CEST,M3.5.0,M10.5.0/3
 ;TimeServer = pool.ntp.org
-;AutoAdjustSummertime = false
+AutoAdjustSummertime = false
 ;Hostname = undefined
 ;RSSIThreshold = 0
 SetupMode = true

--- a/sd-card/html/common.js
+++ b/sd-card/html/common.js
@@ -1,7 +1,7 @@
  
 /* The UI can also be run locally, but you have to set the IP of your devide accordingly.
  * And you also might have to disable CORS in your webbrowser! */
-var domainname_for_testing = "192.168.178.62";
+var domainname_for_testing = "192.168.178.44";
 
 
 

--- a/sd-card/html/common.js
+++ b/sd-card/html/common.js
@@ -1,7 +1,7 @@
  
 /* The UI can also be run locally, but you have to set the IP of your devide accordingly.
  * And you also might have to disable CORS in your webbrowser! */
-var domainname_for_testing = "192.168.178.44";
+var domainname_for_testing = "192.168.178.62";
 
 
 

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -1940,7 +1940,7 @@ function ReadParameterAll()
 	ReadParameter(param, "PostProcessing", "PreValueUse", false);		
 	ReadParameter(param, "PostProcessing", "PreValueAgeStartup", true);		
 //	ReadParameter(param, "PostProcessing", "AllowNegativeRates", true);
-	ReadParameter(param, "PostProcessing", "ErrorMessage", true);
+	ReadParameter(param, "PostProcessing", "ErrorMessage", false);
 	ReadParameter(param, "PostProcessing", "CheckDigitIncreaseConsistency", false);
 
 	ReadParameter(param, "MQTT", "Uri", true);	

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -126,7 +126,6 @@ textarea {
 		</tr>		
 		<tr class="expert" id="ex1">
 			<td class="indent1">
-				<input type="checkbox" id="TakeImage_Demo_enabled" value="1"  onclick = 'InvertEnableItem("TakeImage", "Demo")' unchecked >
 				<label for=TakeImage_Demo_enabled><class id="TakeImage_Demo_text" style="color:black;">Demo Mode</class></label>
 			</td>
 			<td>
@@ -388,7 +387,6 @@ textarea {
 		</tr> 		
 		<tr>
 			<td class="indent1">
-				<input type="checkbox" id="PostProcessing_PreValueUse_enabled" value="1"  onclick = 'InvertEnableItem("PostProcessing", "PreValueUse")' unchecked >
 				<label for=PostProcessing_PreValueUse_enabled><class id="PostProcessing_PreValueUse_text" style="color:black;">PreValueUse</class></label>
 			</td>
 			<td>
@@ -415,7 +413,6 @@ textarea {
 		</tr>
 		<tr class="expert"  id="ex12">
 			<td class="indent1">
-				<input type="checkbox" id="PostProcessing_ErrorMessage_enabled" value="1"  onclick = 'InvertEnableItem("PostProcessing", "ErrorMessage")' unchecked >
 				<label for=PostProcessing_ErrorMessage_enabled><class id="PostProcessing_ErrorMessage_text" style="color:black;">ErrorMessage</class></label>
 			</td>
 			<td>
@@ -430,7 +427,6 @@ textarea {
 		</tr>
 		<tr class="expert" id="ex1dddd">
 			<td class="indent1">
-				<input type="checkbox" id="PostProcessing_CheckDigitIncreaseConsistency_enabled" value="1"  onclick = 'InvertEnableItem("PostProcessing", "CheckDigitIncreaseConsistency")' unchecked >
 				<label for=PostProcessing_CheckDigitIncreaseConsistency_enabled><class id="PostProcessing_CheckDigitIncreaseConsistency_text" style="color:black;">CheckDigitIncreaseConsistency</class></label>
 			</td>
 			<td>
@@ -457,7 +453,6 @@ textarea {
 		</tr>
 		<tr>
 			<td class="indent1">
-				<input type="checkbox" id="PostProcessing_AllowNegativeRates_enabled" value="1"  onclick = 'InvertEnableItem("PostProcessing", "AllowNegativeRates")' unchecked >
 				<label for=PostProcessing_AllowNegativeRates_enabled><class id="PostProcessing_AllowNegativeRates_text" style="color:black;">AllowNegativeRates</class></label>
 			</td>
 			<td>
@@ -526,8 +521,7 @@ textarea {
 		</tr>
 		<tr>
 			<td class="indent1">
-				<input type="checkbox" id="PostProcessing_ExtendedResolution_enabled" value="1"  onclick = 'InvertEnableItem("PostProcessing", "ExtendedResolution")' unchecked >
-			<label for=PostProcessing_ExtendedResolution_enabled><class id="PostProcessing_ExtendedResolution_text" style="color:black;">ExtendedResolution</class></label>
+				<label for=PostProcessing_ExtendedResolution_enabled><class id="PostProcessing_ExtendedResolution_text" style="color:black;">ExtendedResolution</class></label>
 			</td>
 			<td>
 				<select id="PostProcessing_ExtendedResolution_value1">
@@ -542,8 +536,7 @@ textarea {
 		
 		<tr>
 			<td id="ex121" class="indent1">
-				<input type="checkbox" id="PostProcessing_IgnoreLeadingNaN_enabled" value="1"  onclick = 'InvertEnableItem("PostProcessing", "IgnoreLeadingNaN")' unchecked >
-			<label for=PostProcessing_IgnoreLeadingNaN_enabled><class id="PostProcessing_IgnoreLeadingNaN_text" style="color:black;">IgnoreLeadingNaN</class></label>
+				<label for=PostProcessing_IgnoreLeadingNaN_enabled><class id="PostProcessing_IgnoreLeadingNaN_text" style="color:black;">IgnoreLeadingNaN</class></label>
 			</td>
 			<td>
 				<select id="PostProcessing_IgnoreLeadingNaN_value1">
@@ -634,7 +627,6 @@ textarea {
 		</tr>
 		<tr>
 			<td class="indent1">
-				<input type="checkbox" id="MQTT_SetRetainFlag_enabled" value="1"  onclick = 'InvertEnableItem("MQTT", "SetRetainFlag")' unchecked >
 				<label for=MQTT_SetRetainFlag_enabled><class id="MQTT_SetRetainFlag_text" style="color:black;">Enable MQTT Retain Flag</class></label>
 			</td>
 			<td>
@@ -656,7 +648,6 @@ textarea {
 		</tr> 
 		<tr>
 			<td class="indent1">
-				<input type="checkbox" id="MQTT_HomeassistantDiscovery_enabled" value="1"  onclick = 'InvertEnableItem("MQTT", "HomeassistantDiscovery")' unchecked >
 				<label for=MQTT_HomeassistantDiscovery_enabled><class id="MQTT_HomeassistantDiscovery_text" style="color:black;">Homeassistant Discovery</class></label>
 			</td>
 			<td>
@@ -1776,9 +1767,9 @@ function UpdateInputIndividual()
 		ReadParameter(param, "PostProcessing", "AnalogDigitalTransitionStart", true, NUNBERSAkt)		
 		ReadParameter(param, "PostProcessing", "MaxRateValue", true, NUNBERSAkt)		
 		ReadParameter(param, "PostProcessing", "MaxRateType", true, NUNBERSAkt)		
-		ReadParameter(param, "PostProcessing", "ExtendedResolution", true, NUNBERSAkt)		
-		ReadParameter(param, "PostProcessing", "IgnoreLeadingNaN", true, NUNBERSAkt)		
-		ReadParameter(param, "PostProcessing", "AllowNegativeRates", true, NUNBERSAkt)		
+		ReadParameter(param, "PostProcessing", "ExtendedResolution", false, NUNBERSAkt)		
+		ReadParameter(param, "PostProcessing", "IgnoreLeadingNaN", false, NUNBERSAkt)		
+		ReadParameter(param, "PostProcessing", "AllowNegativeRates", false, NUNBERSAkt)		
 	}
 
 	var sel = document.getElementById("Numbers_value1");
@@ -1787,9 +1778,9 @@ function UpdateInputIndividual()
 	WriteParameter(param, category, "PostProcessing", "AnalogDigitalTransitionStart", true, NUNBERSAkt);
 	WriteParameter(param, category, "PostProcessing", "MaxRateValue", true, NUNBERSAkt);
 	WriteParameter(param, category, "PostProcessing", "MaxRateType", true, NUNBERSAkt);
-	WriteParameter(param, category, "PostProcessing", "ExtendedResolution", true, NUNBERSAkt);
-	WriteParameter(param, category, "PostProcessing", "IgnoreLeadingNaN", true, NUNBERSAkt);
-	WriteParameter(param, category, "PostProcessing", "AllowNegativeRates", true, NUNBERSAkt);
+	WriteParameter(param, category, "PostProcessing", "ExtendedResolution", false, NUNBERSAkt);
+	WriteParameter(param, category, "PostProcessing", "IgnoreLeadingNaN", false, NUNBERSAkt);
+	WriteParameter(param, category, "PostProcessing", "AllowNegativeRates", false, NUNBERSAkt);
 }
 
 function UpdateInput() {
@@ -1802,7 +1793,7 @@ function UpdateInput() {
 
 	WriteParameter(param, category, "TakeImage", "LogImageLocation", true);
 	WriteParameter(param, category, "TakeImage", "LogfileRetentionInDays", true);
-	WriteParameter(param, category, "TakeImage", "Demo", true);
+	WriteParameter(param, category, "TakeImage", "Demo", false);
 	WriteParameter(param, category, "TakeImage", "WaitBeforeTakingPicture", false);
 	WriteParameter(param, category, "TakeImage", "ImageQuality", false);
 	WriteParameter(param, category, "TakeImage", "Brightness", false);
@@ -1823,19 +1814,19 @@ function UpdateInput() {
 	WriteParameter(param, category, "Analog", "LogImageLocation", true);		
 	WriteParameter(param, category, "Analog", "LogfileRetentionInDays", true);		
 	
-	WriteParameter(param, category, "PostProcessing", "PreValueUse", true);		
+	WriteParameter(param, category, "PostProcessing", "PreValueUse", false);		
 	WriteParameter(param, category, "PostProcessing", "PreValueAgeStartup", true);		
 //	WriteParameter(param, category, "PostProcessing", "AllowNegativeRates", true);
-	WriteParameter(param, category, "PostProcessing", "ErrorMessage", true);
-	WriteParameter(param, category, "PostProcessing", "CheckDigitIncreaseConsistency", true);
+	WriteParameter(param, category, "PostProcessing", "ErrorMessage", false);
+	WriteParameter(param, category, "PostProcessing", "CheckDigitIncreaseConsistency", false);
 
 	WriteParameter(param, category, "MQTT", "Uri", true);	
 	WriteParameter(param, category, "MQTT", "MainTopic", true);	
 	WriteParameter(param, category, "MQTT", "ClientID", true);	
 	WriteParameter(param, category, "MQTT", "user", true);	
 	WriteParameter(param, category, "MQTT", "password", true);
-	WriteParameter(param, category, "MQTT", "SetRetainFlag", true);
-	WriteParameter(param, category, "MQTT", "HomeassistantDiscovery", true);
+	WriteParameter(param, category, "MQTT", "SetRetainFlag", false);
+	WriteParameter(param, category, "MQTT", "HomeassistantDiscovery", false);
 	WriteParameter(param, category, "MQTT", "MeterType", true);
 	
 	WriteParameter(param, category, "InfluxDB", "Uri", true);	
@@ -1923,7 +1914,7 @@ function ReadParameterAll()
 	
 	ReadParameter(param, "TakeImage", "LogImageLocation", true);
 	ReadParameter(param, "TakeImage", "LogfileRetentionInDays", true);
-	ReadParameter(param, "TakeImage", "Demo", true);
+	ReadParameter(param, "TakeImage", "Demo", false);
 	ReadParameter(param, "TakeImage", "WaitBeforeTakingPicture", false);
 	ReadParameter(param, "TakeImage", "ImageQuality", false);
 	ReadParameter(param, "TakeImage", "Brightness", false);
@@ -1946,19 +1937,19 @@ function ReadParameterAll()
 	ReadParameter(param, "Analog", "LogImageLocation", true);		
 	ReadParameter(param, "Analog", "LogfileRetentionInDays", true);		
 
-	ReadParameter(param, "PostProcessing", "PreValueUse", true);		
+	ReadParameter(param, "PostProcessing", "PreValueUse", false);		
 	ReadParameter(param, "PostProcessing", "PreValueAgeStartup", true);		
 //	ReadParameter(param, "PostProcessing", "AllowNegativeRates", true);
 	ReadParameter(param, "PostProcessing", "ErrorMessage", true);
-	ReadParameter(param, "PostProcessing", "CheckDigitIncreaseConsistency", true);
+	ReadParameter(param, "PostProcessing", "CheckDigitIncreaseConsistency", false);
 
 	ReadParameter(param, "MQTT", "Uri", true);	
 	ReadParameter(param, "MQTT", "MainTopic", true);	
 	ReadParameter(param, "MQTT", "ClientID", true);	
 	ReadParameter(param, "MQTT", "user", true);	
 	ReadParameter(param, "MQTT", "password", true);	
-	ReadParameter(param, "MQTT", "SetRetainFlag", true);	
-	ReadParameter(param, "MQTT", "HomeassistantDiscovery", true);
+	ReadParameter(param, "MQTT", "SetRetainFlag", false);	
+	ReadParameter(param, "MQTT", "HomeassistantDiscovery", false);
 	ReadParameter(param, "MQTT", "MeterType", true);
 
 	ReadParameter(param, "InfluxDB", "Uri", true);	

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -102,11 +102,11 @@ textarea {
 		</tr> 
 		<tr>
 			<td class="indent1">
-				<input type="checkbox" id="MakeImage_LogImageLocation_enabled" value="1"  onclick = 'InvertEnableItem("MakeImage", "LogImageLocation")' unchecked >
-				<label for=MakeImage_LogImageLocation_enabled><class id="MakeImage_LogImageLocation_text" style="color:black;">LogImageLocation</class></label>
+				<input type="checkbox" id="TakeImage_LogImageLocation_enabled" value="1"  onclick = 'InvertEnableItem("TakeImage", "LogImageLocation")' unchecked >
+				<label for=TakeImage_LogImageLocation_enabled><class id="TakeImage_LogImageLocation_text" style="color:black;">LogImageLocation</class></label>
 			</td>
 			<td>
-				<input type="text" name="name" id="MakeImage_LogImageLocation_value1">
+				<input type="text" name="name" id="TakeImage_LogImageLocation_value1">
 			</td>
 			<td class="description">
 				Location to store raw images for logging
@@ -114,11 +114,11 @@ textarea {
 		</tr>
 		<tr>
 			<td class="indent1">
-				<input type="checkbox" id="MakeImage_LogfileRetentionInDays_enabled" value="1"  onclick = 'InvertEnableItem("MakeImage", "LogfileRetentionInDays")' unchecked >
-				<label for=MakeImage_LogfileRetentionInDays_enabled><class id="MakeImage_LogfileRetentionInDays_text" style="color:black;">LogfileRetentionInDays</class></label>
+				<input type="checkbox" id="TakeImage_LogfileRetentionInDays_enabled" value="1"  onclick = 'InvertEnableItem("TakeImage", "LogfileRetentionInDays")' unchecked >
+				<label for=TakeImage_LogfileRetentionInDays_enabled><class id="TakeImage_LogfileRetentionInDays_text" style="color:black;">LogfileRetentionInDays</class></label>
 			</td>
 			<td>
-				<input type="number" id="MakeImage_LogfileRetentionInDays_value1" size="13" min="0" step="1">
+				<input type="number" id="TakeImage_LogfileRetentionInDays_value1" size="13" min="0" step="1">
 			</td>
 			<td class="description">
 				Time to keep the raw image (in days, resp. "0" = forever)
@@ -126,11 +126,11 @@ textarea {
 		</tr>		
 		<tr class="expert" id="ex1">
 			<td class="indent1">
-				<input type="checkbox" id="MakeImage_Demo_enabled" value="1"  onclick = 'InvertEnableItem("MakeImage", "Demo")' unchecked >
-				<label for=MakeImage_Demo_enabled><class id="MakeImage_Demo_text" style="color:black;">Demo Mode</class></label>
+				<input type="checkbox" id="TakeImage_Demo_enabled" value="1"  onclick = 'InvertEnableItem("TakeImage", "Demo")' unchecked >
+				<label for=TakeImage_Demo_enabled><class id="TakeImage_Demo_text" style="color:black;">Demo Mode</class></label>
 			</td>
 			<td>
-				<select id="MakeImage_Demo_value1">
+				<select id="TakeImage_Demo_value1">
 					<option value="true">true</option>
 					<option value="false" selected>false</option>
 				</select>
@@ -144,10 +144,10 @@ textarea {
 		<tr class="expert" id="ex1">
 			
 			<td class="indent1">
-				<class id="MakeImage_WaitBeforeTakingPicture_text" style="color:black;">WaitBeforeTakingPicture</class>
+				<class id="TakeImage_WaitBeforeTakingPicture_text" style="color:black;">WaitBeforeTakingPicture</class>
 			</td>
 			<td>
-				<input type="number" id="MakeImage_WaitBeforeTakingPicture_value1" size="13" min="0" step="any">
+				<input type="number" id="TakeImage_WaitBeforeTakingPicture_value1" size="13" min="0" step="any">
 			</td>
 			<td class="description">
 				Wait time between switching illumination on and taking the picture (in seconds)
@@ -155,10 +155,10 @@ textarea {
 		</tr>
 		<tr class="expert" id="ex2">
 			<td class="indent1">
-				<class id="MakeImage_ImageQuality_text" style="color:black;">ImageQuality</class>
+				<class id="TakeImage_ImageQuality_text" style="color:black;">ImageQuality</class>
 			</td>
 			<td>
-				<input type="number" id="MakeImage_ImageQuality_value1" size="13" min="0" max="63">
+				<input type="number" id="TakeImage_ImageQuality_value1" size="13" min="0" max="63">
 			</td>
 			<td class="description">
 				Quality index for picture (default = "12" - "0" high ... "63" low) <br>
@@ -167,10 +167,10 @@ textarea {
 		</tr>
 		<tr class="expert"  id="ex3">
 			<td class="indent1">
-				<class id="MakeImage_ImageSize_text" style="color:black;">ImageSize</class>
+				<class id="TakeImage_ImageSize_text" style="color:black;">ImageSize</class>
 			</td>
 			<td>
-				<select id="MakeImage_ImageSize_value1">
+				<select id="TakeImage_ImageSize_value1">
 					<option value="VGA" selected>VGA</option>
 					<option value="QVGA" >QVGA</option>
 				</select>
@@ -182,10 +182,10 @@ textarea {
 
 		<tr class="expert"  id="LEDIntensity_ex3">
 			<td class="indent1">
-				<class id="MakeImage_LEDIntensity_text" style="color:black;">LEDIntensity</class>
+				<class id="TakeImage_LEDIntensity_text" style="color:black;">LEDIntensity</class>
 			</td>
 			<td>
-				<input type="number" id="MakeImage_LEDIntensity_value1" size="13" min="0" max="100">
+				<input type="number" id="TakeImage_LEDIntensity_value1" size="13" min="0" max="100">
 			</td>
 			<td style="font-size: 80%;">
 				Internal LED Flash Intensity (PWM from 0% - 100%). <br>
@@ -195,10 +195,10 @@ textarea {
 
 		<tr class="expert"  id="Brightness_ex3">
 			<td class="indent1">
-				<class id="MakeImage_Brightness_text" style="color:black;">Brightness</class>
+				<class id="TakeImage_Brightness_text" style="color:black;">Brightness</class>
 			</td>
 			<td>
-				<input type="number" id="MakeImage_Brightness_value1" size="13" min="-2" max="2">
+				<input type="number" id="TakeImage_Brightness_value1" size="13" min="-2" max="2">
 			</td>
 			<td style="font-size: 80%;">
 				Image Brightness (-2 .. 2 - default = "0")
@@ -207,10 +207,10 @@ textarea {
 
 		<tr class="expert"  id="Contrast_ex3">
 			<td class="indent1">
-				<class id="MakeImage_Contrast_text" style="color:black;">Contrast</class>
+				<class id="TakeImage_Contrast_text" style="color:black;">Contrast</class>
 			</td>
 			<td>
-				<input type="number" id="MakeImage_Contrast_value1" size="13" min="-2" max="2">
+				<input type="number" id="TakeImage_Contrast_value1" size="13" min="-2" max="2">
 			</td>
 			<td style="font-size: 80%;">
 				Image Contrast (-2 .. 2 - default = "0") <br>
@@ -220,10 +220,10 @@ textarea {
 
 		<tr class="expert"  id="Saturation_ex3">
 			<td class="indent1">
-				<class id="MakeImage_Saturation_text" style="color:black;">Saturation</class>
+				<class id="TakeImage_Saturation_text" style="color:black;">Saturation</class>
 			</td>
 			<td>
-				<input type="number" id="MakeImage_Saturation_value1" size="13" min="-2" max="2">
+				<input type="number" id="TakeImage_Saturation_value1" size="13" min="-2" max="2">
 			</td>
 			<td style="font-size: 80%;">
 				Image Saturation (-2 .. 2 - default = "0") <br>
@@ -231,12 +231,12 @@ textarea {
 			</td>
 		</tr>
 		
-		<tr class="expert"  id="MakeImage_FixedExposure_ex10">
+		<tr class="expert"  id="TakeImage_FixedExposure_ex10">
 			<td class="indent1">
-				<class id="MakeImage_FixedExposure_text" style="color:black;">FixedExposure</class>
+				<class id="TakeImage_FixedExposure_text" style="color:black;">FixedExposure</class>
 			</td>
 			<td>
-				<select id="MakeImage_FixedExposure_value1">
+				<select id="TakeImage_FixedExposure_value1">
 					<option value="true" selected>true</option>
 					<option value="false" >false</option>
 				</select>
@@ -1287,10 +1287,10 @@ textarea {
 		</tr>
 		<tr>
 			<td class="indent1">
-			    <class id="AutoTimer_Intervall_text" style="color:black;">Interval</class>
+			    <class id="AutoTimer_Interval_text" style="color:black;">Interval</class>
 			</td>
 			<td>
-				<input type="number" id="AutoTimer_Intervall_value1" size="13" min="3" step="any">
+				<input type="number" id="AutoTimer_Interval_value1" size="13" min="3" step="any">
 			</td>
 			<td style="font-size: 80%;">
 				Interval in which the number(s) are read (in minutes). If a digitalization round takes longer than this interval, the next run gets postponed until the current run completes.
@@ -1401,15 +1401,15 @@ textarea {
 				Hostname for server - will be transfered to wlan.ini at next startup)
 			</td>
 		</tr>
-		<tr class="expert"  id="System_RSSIThreashold">
+		<tr class="expert"  id="System_RSSIThreshold">
 			<td class="indent1">
-				<input type="checkbox" id="System_RSSIThreashold_enabled" value="1"  onclick = 'InvertEnableItem("System", "RSSIThreashold")' unchecked >
-				<label for=System_RSSIThreashold_enabled><class id="System_RSSIThreashold_text" style="color:black;">RSSIThreashold</class></label>
+				<input type="checkbox" id="System_RSSIThreshold_enabled" value="1"  onclick = 'InvertEnableItem("System", "RSSIThreshold")' unchecked >
+				<label for=System_RSSIThreshold_enabled><class id="System_RSSIThreshold_text" style="color:black;">RSSIThreshold</class></label>
 			</td>
 			<td>
-				<input type="number" name="name" id="System_RSSIThreashold_value1" min="-100"  max="0" step="1">
+				<input type="number" name="name" id="System_RSSIThreshold_value1" min="-100"  max="0" step="1">
 			<td class="description">
-				WLAN Mesh Parameter: Threashold for RSSI value to check for start switching access point in a mesh system.
+				WLAN Mesh Parameter: Threshold for RSSI value to check for start switching access point in a mesh system.
 				Possible values: -100 to 0, 0 = disabled - Value will be transfered to wlan.ini at next startup)
 			</td>
 		</tr>
@@ -1800,17 +1800,17 @@ function UpdateInput() {
 	document.getElementById("Category_InfluxDB_enabled").checked = category["InfluxDB"]["enabled"];
 	setVisible("GPIO_item", category["GPIO"]["enabled"]);
 
-	WriteParameter(param, category, "MakeImage", "LogImageLocation", true);
-	WriteParameter(param, category, "MakeImage", "LogfileRetentionInDays", true);
-	WriteParameter(param, category, "MakeImage", "Demo", true);
-	WriteParameter(param, category, "MakeImage", "WaitBeforeTakingPicture", false);		
-	WriteParameter(param, category, "MakeImage", "ImageQuality", false);		
-	WriteParameter(param, category, "MakeImage", "Brightness", false);		
-	WriteParameter(param, category, "MakeImage", "Contrast", false);		
-	WriteParameter(param, category, "MakeImage", "Saturation", false);		
-	WriteParameter(param, category, "MakeImage", "LEDIntensity", false);		
-	WriteParameter(param, category, "MakeImage", "ImageSize", false);		
-	WriteParameter(param, category, "MakeImage", "FixedExposure", false);		
+	WriteParameter(param, category, "TakeImage", "LogImageLocation", true);
+	WriteParameter(param, category, "TakeImage", "LogfileRetentionInDays", true);
+	WriteParameter(param, category, "TakeImage", "Demo", true);
+	WriteParameter(param, category, "TakeImage", "WaitBeforeTakingPicture", false);
+	WriteParameter(param, category, "TakeImage", "ImageQuality", false);
+	WriteParameter(param, category, "TakeImage", "Brightness", false);
+	WriteParameter(param, category, "TakeImage", "Contrast", false);
+	WriteParameter(param, category, "TakeImage", "Saturation", false);
+	WriteParameter(param, category, "TakeImage", "LEDIntensity", false);
+	WriteParameter(param, category, "TakeImage", "ImageSize", false);
+	WriteParameter(param, category, "TakeImage", "FixedExposure", false);
 
 	WriteParameter(param, category, "Alignment", "SearchFieldX", false);		
 	WriteParameter(param, category, "Alignment", "SearchFieldY", false);		
@@ -1855,7 +1855,7 @@ function UpdateInput() {
 	WriteParameter(param, category, "GPIO", "LEDColor", false);
 
 	WriteParameter(param, category, "AutoTimer", "AutoStart", false);	
-	WriteParameter(param, category, "AutoTimer", "Intervall", false);	
+	WriteParameter(param, category, "AutoTimer", "Interval", false);
 
 	WriteParameter(param, category, "DataLogging", "DataLogActive", false);	
 	WriteParameter(param, category, "DataLogging", "DataLogRetentionInDays", false);	
@@ -1866,7 +1866,7 @@ function UpdateInput() {
 	WriteParameter(param, category, "System", "TimeZone", true);	
 	WriteParameter(param, category, "System", "Hostname", true);	
 	WriteParameter(param, category, "System", "TimeServer", true);
-	WriteParameter(param, category, "System", "RSSIThreashold", true);
+	WriteParameter(param, category, "System", "RSSIThreshold", true);
 
 	WriteModelFiles();
 }
@@ -1921,17 +1921,17 @@ function ReadParameterAll()
 	category["InfluxDB"]["enabled"] = document.getElementById("Category_InfluxDB_enabled").checked;
 	category["GPIO"]["enabled"] = document.getElementById("Category_GPIO_enabled").checked;
 	
-	ReadParameter(param, "MakeImage", "LogImageLocation", true);
-	ReadParameter(param, "MakeImage", "LogfileRetentionInDays", true);	
-	ReadParameter(param, "MakeImage", "Demo", true);
-	ReadParameter(param, "MakeImage", "WaitBeforeTakingPicture", false);		
-	ReadParameter(param, "MakeImage", "ImageQuality", false);		
-	ReadParameter(param, "MakeImage", "Brightness", false);		
-	ReadParameter(param, "MakeImage", "Contrast", false);		
-	ReadParameter(param, "MakeImage", "Saturation", false);		
-	ReadParameter(param, "MakeImage", "LEDIntensity", false);		
-	ReadParameter(param, "MakeImage", "ImageSize", false);	
-	ReadParameter(param, "MakeImage", "FixedExposure", false);	
+	ReadParameter(param, "TakeImage", "LogImageLocation", true);
+	ReadParameter(param, "TakeImage", "LogfileRetentionInDays", true);
+	ReadParameter(param, "TakeImage", "Demo", true);
+	ReadParameter(param, "TakeImage", "WaitBeforeTakingPicture", false);
+	ReadParameter(param, "TakeImage", "ImageQuality", false);
+	ReadParameter(param, "TakeImage", "Brightness", false);
+	ReadParameter(param, "TakeImage", "Contrast", false);
+	ReadParameter(param, "TakeImage", "Saturation", false);
+	ReadParameter(param, "TakeImage", "LEDIntensity", false);
+	ReadParameter(param, "TakeImage", "ImageSize", false);
+	ReadParameter(param, "TakeImage", "FixedExposure", false);
 
 	ReadParameter(param, "Alignment", "SearchFieldX", false);		
 	ReadParameter(param, "Alignment", "SearchFieldY", false);
@@ -1985,7 +1985,7 @@ function ReadParameterAll()
 	param["GPIO"]["LEDColor"]["found"] = true;
 
 	ReadParameter(param, "AutoTimer", "AutoStart", false);	
-	ReadParameter(param, "AutoTimer", "Intervall", false);	
+	ReadParameter(param, "AutoTimer", "Interval", false);
 	
 	ReadParameter(param, "DataLogging", "DataLogActive", false);	
 	ReadParameter(param, "DataLogging", "DataLogRetentionInDays", false);	
@@ -1996,7 +1996,7 @@ function ReadParameterAll()
 	ReadParameter(param, "System", "TimeZone", true);	
 	ReadParameter(param, "System", "Hostname", true);	
 	ReadParameter(param, "System", "TimeServer", true);	
-	ReadParameter(param, "System", "RSSIThreashold", true);	
+	ReadParameter(param, "System", "RSSIThreshold", true);
 
 	UpdateInputIndividual();
 	

--- a/sd-card/html/edit_reference.html
+++ b/sd-card/html/edit_reference.html
@@ -49,8 +49,8 @@ table {
 		<td style="padding-top: 10px"><label for="mirror" id="labelmirror">Mirror Image:</label></td>
         <td style="padding-top: 10px"><input type="checkbox" id="mirror" name="mirror" value="1" onchange="drawRotated()"></td>
         <td>
-            <class id="MakeImage_LEDIntensity_text" style="color:black;">LEDIntensity: </class>
-            <input type="number" id="MakeImage_LEDIntensity_value1" size="13" value=0  min="0" max="100" style="float: right; clear: both;">
+            <class id="TakeImage_LEDIntensity_text" style="color:black;">LEDIntensity: </class>
+            <input type="number" id="TakeImage_LEDIntensity_value1" size="13" value=0  min="0" max="100" style="float: right; clear: both;">
         </td>
       </tr>
       <tr>
@@ -58,8 +58,8 @@ table {
 		<td><label for="flip" id="labelflip">Flip Image Size:</label></td>
         <td><input type="checkbox" id="flip" name="flip" value="1" onchange="drawRotated()"></td>
         <td>
-            <class id="MakeImage_Brightness_text" style="color:black;">Brightness: </class>
-            <input type="number" id="MakeImage_Brightness_value1" size="13" value=0  min="-2" max="2" style="float: right; clear: both;">
+            <class id="TakeImage_Brightness_text" style="color:black;">Brightness: </class>
+            <input type="number" id="TakeImage_Brightness_value1" size="13" value=0  min="-2" max="2" style="float: right; clear: both;">
         </td>
         
 	  </tr>
@@ -67,16 +67,16 @@ table {
         <td><label for="mirror">Pre-rotate Angle:</label></td>	  
 		<td><input type="number" id="prerotateangle" name="prerotateangle" value="0" min="-360" max="360" onchange="drawRotated()">Degrees</td>
         <td>
-            <class id="MakeImage_Contrast_text" style="color:black;">Contrast</class>
-            <input type="number" id="MakeImage_Contrast_value1" size="13" value=0  min="-2" max="2" style="float: right; clear: both;">
+            <class id="TakeImage_Contrast_text" style="color:black;">Contrast</class>
+            <input type="number" id="TakeImage_Contrast_value1" size="13" value=0  min="-2" max="2" style="float: right; clear: both;">
         </td>
 	  </tr>
 	  <tr>
 		<td><label for="mirror">Fine Alignment:</label></td>	
 		<td><input type="number" id="finerotate" name="finerotate" value=0.0 min="-1" max="1" step="0.2" onchange="drawRotated()">Degrees</td>
         <td>
-            <class id="MakeImage_Saturation_text" style="color:black;">Saturation</class>
-            <input type="number" id="MakeImage_Saturation_value1" size="13" value=0   min="-2" max="2" style="float: right; clear: both;">
+            <class id="TakeImage_Saturation_text" style="color:black;">Saturation</class>
+            <input type="number" id="TakeImage_Saturation_value1" size="13" value=0   min="-2" max="2" style="float: right; clear: both;">
         </td>
 
     </tr>
@@ -121,13 +121,13 @@ table {
 
         function doTake(){ 
             var xhttp = new XMLHttpRequest();
-            if (param["MakeImage"]["Brightness"].found && param["MakeImage"]["Brightness"].enabled)
+            if (param["TakeImage"]["Brightness"].found && param["TakeImage"]["Brightness"].enabled)
             {
-                _intensity = document.getElementById("MakeImage_LEDIntensity_value1").value;
+                _intensity = document.getElementById("TakeImage_LEDIntensity_value1").value;
                 if (_intensity == "") _intensity = "50";
-                _brightness = document.getElementById("MakeImage_Brightness_value1").value;
-                _contrast = document.getElementById("MakeImage_Contrast_value1").value;
-                _saturation = document.getElementById("MakeImage_Saturation_value1").value;
+                _brightness = document.getElementById("TakeImage_Brightness_value1").value;
+                _contrast = document.getElementById("TakeImage_Contrast_value1").value;
+                _saturation = document.getElementById("TakeImage_Saturation_value1").value;
                 url = getDomainname() + "/editflow?task=test_take&bri=" + _brightness;
                 url = url + "&con=" + _saturation + "&sat=" + _saturation + "&int=" + _intensity;
             }
@@ -166,24 +166,24 @@ table {
                 document.getElementById("labelflip").style = "color:lightgrey;";
             }
 
-            if (param["MakeImage"]["Brightness"].found && param["MakeImage"]["Brightness"].enabled)
+            if (param["TakeImage"]["Brightness"].found && param["TakeImage"]["Brightness"].enabled)
             {
-                document.getElementById("MakeImage_Brightness_value1").disabled = false;
-                document.getElementById("MakeImage_Contrast_value1").disabled = false;
-                document.getElementById("MakeImage_Saturation_value1").disabled = false;
-                document.getElementById("MakeImage_LEDIntensity_value1").disabled = false;
+                document.getElementById("TakeImage_Brightness_value1").disabled = false;
+                document.getElementById("TakeImage_Contrast_value1").disabled = false;
+                document.getElementById("TakeImage_Saturation_value1").disabled = false;
+                document.getElementById("TakeImage_LEDIntensity_value1").disabled = false;
             }
             else
             {
-                document.getElementById("MakeImage_Brightness_value1").type = "hidden";
-                document.getElementById("MakeImage_Brightness_text").style.visibility = "hidden";
+                document.getElementById("TakeImage_Brightness_value1").type = "hidden";
+                document.getElementById("TakeImage_Brightness_text").style.visibility = "hidden";
                 
             }
 
-//            if (param["MakeImage"]["Saturation"].found)
-//                document.getElementById("MakeImage_Saturation_value1").disabled = false;
-//            if (param["MakeImage"]["Contrast"].found)
-//                document.getElementById("MakeImage_Contrast_value1").disabled = false;
+//            if (param["TakeImage"]["Saturation"].found)
+//                document.getElementById("TakeImage_Saturation_value1").disabled = false;
+//            if (param["TakeImage"]["Contrast"].found)
+//                document.getElementById("TakeImage_Contrast_value1").disabled = false;
 
             isActReference = false;
             loadCanvas(url);  
@@ -205,16 +205,16 @@ table {
             document.getElementById("prerotateangle").disabled = true; 
             document.getElementById("updatereferenceimage").disabled = true;
             document.getElementById("take").disabled = true;
-            document.getElementById("MakeImage_Brightness_value1").disabled = true;
-            document.getElementById("MakeImage_Saturation_value1").disabled = true;
-            document.getElementById("MakeImage_Contrast_value1").disabled = true;
-            document.getElementById("MakeImage_LEDIntensity_value1").disabled = true;
+            document.getElementById("TakeImage_Brightness_value1").disabled = true;
+            document.getElementById("TakeImage_Saturation_value1").disabled = true;
+            document.getElementById("TakeImage_Contrast_value1").disabled = true;
+            document.getElementById("TakeImage_LEDIntensity_value1").disabled = true;
             document.getElementById("mirror").disabled = false;
             document.getElementById("flip").disabled = false;
-            if (!(param["MakeImage"]["Brightness"].found))
+            if (!(param["TakeImage"]["Brightness"].found))
             {
-                document.getElementById("MakeImage_Brightness_value1").type = "hidden";
-                document.getElementById("MakeImage_Brightness_text").style.visibility = "hidden";
+                document.getElementById("TakeImage_Brightness_value1").type = "hidden";
+                document.getElementById("TakeImage_Brightness_text").style.visibility = "hidden";
             }
 
 
@@ -253,12 +253,12 @@ table {
                 else
                     param["Alignment"]["FlipImageSize"].value1 = "false";
 
-                if (param["MakeImage"]["Brightness"].found && param["MakeImage"]["Brightness"].enabled)
+                if (param["TakeImage"]["Brightness"].found && param["TakeImage"]["Brightness"].enabled)
                 {
-                    ReadParameter(param, "MakeImage", "Brightness", false);		
-                	ReadParameter(param, "MakeImage", "Contrast", false);
-                    ReadParameter(param, "MakeImage", "Saturation", false);
-                    ReadParameter(param, "MakeImage", "LEDIntensity", false);
+                    ReadParameter(param, "TakeImage", "Brightness", false);
+                	ReadParameter(param, "TakeImage", "Contrast", false);
+                    ReadParameter(param, "TakeImage", "Saturation", false);
+                    ReadParameter(param, "TakeImage", "LEDIntensity", false);
                 }
 
                 var canvas = document.getElementById("canvas");
@@ -307,30 +307,30 @@ table {
             ParseConfig();
             param = getConfigParameters();
 
-            param["MakeImage"]["LEDIntensity"]["enabled"] = true;
-            param["MakeImage"]["Brightness"]["enabled"] = true;
-            param["MakeImage"]["Contrast"]["enabled"] = true;
-            param["MakeImage"]["Saturation"]["enabled"] = true;
+            param["TakeImage"]["LEDIntensity"]["enabled"] = true;
+            param["TakeImage"]["Brightness"]["enabled"] = true;
+            param["TakeImage"]["Contrast"]["enabled"] = true;
+            param["TakeImage"]["Saturation"]["enabled"] = true;
 
-            if (!param["MakeImage"]["LEDIntensity"]["found"])
+            if (!param["TakeImage"]["LEDIntensity"]["found"])
             {
-                param["MakeImage"]["LEDIntensity"]["found"] = true;
-                param["MakeImage"]["LEDIntensity"]["value1"] = "50";
+                param["TakeImage"]["LEDIntensity"]["found"] = true;
+                param["TakeImage"]["LEDIntensity"]["value1"] = "50";
             }
-            if (!param["MakeImage"]["Brightness"]["found"])
+            if (!param["TakeImage"]["Brightness"]["found"])
             {
-                param["MakeImage"]["Brightness"]["found"] = true;
-                param["MakeImage"]["Brightness"]["value1"] = "0";
+                param["TakeImage"]["Brightness"]["found"] = true;
+                param["TakeImage"]["Brightness"]["value1"] = "0";
             }
-            if (!param["MakeImage"]["Contrast"]["found"])
+            if (!param["TakeImage"]["Contrast"]["found"])
             {
-                param["MakeImage"]["Contrast"]["found"] = true;
-                param["MakeImage"]["Contrast"]["value1"] = "0";
+                param["TakeImage"]["Contrast"]["found"] = true;
+                param["TakeImage"]["Contrast"]["value1"] = "0";
             }
-            if (!param["MakeImage"]["Saturation"]["found"])
+            if (!param["TakeImage"]["Saturation"]["found"])
             {
-                param["MakeImage"]["Saturation"]["found"] = true;
-                param["MakeImage"]["Saturation"]["value1"] = "0";
+                param["TakeImage"]["Saturation"]["found"] = true;
+                param["TakeImage"]["Saturation"]["value1"] = "0";
             }
 
             UpdateInput();
@@ -338,10 +338,10 @@ table {
         }
 
         function UpdateInput() {
-            WriteParameter(param, category, "MakeImage", "Brightness", false);		
-            WriteParameter(param, category, "MakeImage", "Contrast", false);		
-            WriteParameter(param, category, "MakeImage", "Saturation", false);		
-            WriteParameter(param, category, "MakeImage", "LEDIntensity", false);		
+            WriteParameter(param, category, "TakeImage", "Brightness", false);
+            WriteParameter(param, category, "TakeImage", "Contrast", false);
+            WriteParameter(param, category, "TakeImage", "Saturation", false);
+            WriteParameter(param, category, "TakeImage", "LEDIntensity", false);
         }
 
 

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -105,7 +105,7 @@ function ParseConfig() {
      param = new Object();
      category = new Object(); 
 
-     var catname = "MakeImage";
+     var catname = "TakeImage";
      category[catname] = new Object(); 
      category[catname]["enabled"] = false;
      category[catname]["found"] = false;
@@ -224,7 +224,7 @@ function ParseConfig() {
      category[catname]["found"] = false;
      param[catname] = new Object();
      ParamAddValue(param, catname, "AutoStart");
-     ParamAddValue(param, catname, "Intervall");     
+     ParamAddValue(param, catname, "Interval");
 
      var catname = "DataLogging";
      category[catname] = new Object(); 
@@ -251,7 +251,7 @@ function ParseConfig() {
      ParamAddValue(param, catname, "TimeServer");         
      ParamAddValue(param, catname, "AutoAdjustSummertime");
      ParamAddValue(param, catname, "Hostname");   
-     ParamAddValue(param, catname, "RSSIThreashold");   
+     ParamAddValue(param, catname, "RSSIThreshold");
      ParamAddValue(param, catname, "SetupMode"); 
      
      

--- a/sd-card/html/wlan_config.html
+++ b/sd-card/html/wlan_config.html
@@ -13,7 +13,7 @@
 <tr><td>gateway</td><td><input type="text" name="gateway" id="gateway"></td><td>Leave emtpy if set by router</td></tr>
 <tr><td>netmask</td><td><input type="text" name="netmask" id="netmask"></td><td>Leave emtpy if set by router</td>
 </tr><tr><td>DNS</td><td><input type="text" name="dns" id="dns"></td><td>Leave emtpy if set by router</td></tr>
-<tr><td>RSSI Threashold</td><td><input type="number" name="name" id="threashold" min="-100"  max="0" step="1" value = "0"></td><td>WLAN Mesh Parameter: Threashold for RSSI value to check for start switching access point in a mesh system.Possible values: -100 to 0, 0 = disabled - Value will be transfered to wlan.ini at next startup)</td></tr>
+<tr><td>RSSI Threshold</td><td><input type="number" name="name" id="threshold" min="-100"  max="0" step="1" value = "0"></td><td>WLAN Mesh Parameter: Threshold for RSSI value to check for start switching access point in a mesh system.Possible values: -100 to 0, 0 = disabled - Value will be transfered to wlan.ini at next startup)</td></tr>
 </table>
 <button class="button" type="button" onclick="wr()">Write wlan.ini</button>
 <input id="newfile" type="file">
@@ -21,7 +21,7 @@
 
 
 <script language="JavaScript">function wr(){
-        api = "/config?"+"ssid"+document.getElementById("ssid").value+"&pwd="+document.getElementById("password").value;+"&hn="+document.getElementById("hostname").value;+"&ip="+document.getElementById("ip").value;+"&gw="+document.getElementById("gateway").value;+"&nm="+document.getElementById("netmask").value;+"&dns="+document.getElementById("dns").value;+"&rssi="+document.getElementById("threashold").value;
+        api = "/config?"+"ssid"+document.getElementById("ssid").value+"&pwd="+document.getElementById("password").value;+"&hn="+document.getElementById("hostname").value;+"&ip="+document.getElementById("ip").value;+"&gw="+document.getElementById("gateway").value;+"&nm="+document.getElementById("netmask").value;+"&dns="+document.getElementById("dns").value;+"&rssi="+document.getElementById("threshold").value;
         fetch(api);}
 
 


### PR DESCRIPTION
Replaced by https://github.com/jomjol/AI-on-the-edge-device/pull/2017

---

This PR adds a migration function of some parameters:
- Rename section `MakeImage` to `TakeImage`, rename all variables and files accordingly
- Rename `Intervall` to `Interval`, rename all variables
- Rename `RSSIThreashold` to `RSSIThreshold`, rename all variables
- For all boolean parameters: If they where commented out -> remove the semicolon and set them to their default value (according to their C++ initialization).

The migration function gets called at startup and modifies the config file as needed. If one or mor eparameter needs a migration, store the `config.ini` as `config.bak` before any change to it.

# Yet to do
- [x] Remove the checkboxes for all boolean parameters in the UI -> @jomjol can you do this? I tried it but failed to understand how it exactly works.
- [ ] @jomjol @haverland @Slider0007: Are there other parameters where you think we should rename them? This PR might be a good time to do so.
- [ ] Testing