### PR TITLE
do not show value on recognition page

### DIFF
--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -379,13 +379,21 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
         }
 
 
+        std::string *status = tfliteflow.getActStatus();
         string query = std::string(_query);
     //    ESP_LOGD(TAG, "Query: %s, query.c_str());
         if (query.find("full") != std::string::npos)
         {
             string txt;
             txt = "<body style=\"font-family: arial\">";
-            txt += "<h3>Value</h3>";
+
+            if ((countRounds <= 1) && (*status != std::string("Flow finished"))) { // First round not completed yet
+                txt = "<h3>Please wait for the first round to complete!</h3><h3>Current state: " + *status + "</h3>\n";
+            }
+            else {
+                txt += "<h3>Value</h3>";
+            }
+
             httpd_resp_sendstr_chunk(req, txt.c_str());
         }
 
@@ -399,11 +407,8 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
         {
             string txt, zw;
 
-            std::string *status = tfliteflow.getActStatus();
-
             if ((countRounds <= 1) && (*status != std::string("Flow finished"))) { // First round not completed yet
-                txt = "<h3>Please wait for the first round to complete!</h3><h3>Current state: " + *status + "</h3>\n";
-                httpd_resp_sendstr_chunk(req, txt.c_str());
+                // Nothing to do
             }
             else {
                 /* Digital ROIs */

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -378,9 +378,12 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
             return ESP_OK;
         }
 
-        zw = tfliteflow.getReadout(_rawValue, _noerror);
-        if (zw.length() > 0)
-            httpd_resp_sendstr_chunk(req, zw.c_str()); 
+        if (_rawValue || _noerror) {
+            zw = tfliteflow.getReadout(_rawValue, _noerror);
+            if (zw.length() > 0)
+                httpd_resp_sendstr_chunk(req, zw.c_str()); 
+            return ESP_OK;
+        }
 
         string query = std::string(_query);
     //    ESP_LOGD(TAG, "Query: %s, query.c_str());

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -388,7 +388,7 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
             txt = "<body style=\"font-family: arial\">";
 
             if ((countRounds <= 1) && (*status != std::string("Flow finished"))) { // First round not completed yet
-                txt = "<h3>Please wait for the first round to complete!</h3><h3>Current state: " + *status + "</h3>\n";
+                txt += "<h3>Please wait for the first round to complete!</h3><h3>Current state: " + *status + "</h3>\n";
             }
             else {
                 txt += "<h3>Value</h3>";

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -380,20 +380,29 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
 
 
         string query = std::string(_query);
-        if (query.find("full") == std::string::npos) {
-            zw = tfliteflow.getReadout(_rawValue, _noerror);
-            if (zw.length() > 0)
-                httpd_resp_sendstr_chunk(req, zw.c_str()); 
-            return ESP_OK;
+    //    ESP_LOGD(TAG, "Query: %s, query.c_str());
+        if (query.find("full") != std::string::npos)
+        {
+            string txt;
+            txt = "<body style=\"font-family: arial\">";
+            txt += "<h3>Value</h3>";
+            httpd_resp_sendstr_chunk(req, txt.c_str());
         }
-        else {
+
+
+        zw = tfliteflow.getReadout(_rawValue, _noerror);
+        if (zw.length() > 0)
+            httpd_resp_sendstr_chunk(req, zw.c_str()); 
+
+
+        if (query.find("full") != std::string::npos)
+        {
             string txt, zw;
 
             std::string *status = tfliteflow.getActStatus();
 
             if ((countRounds <= 1) && (*status != std::string("Flow finished"))) { // First round not completed yet
-                txt = "<body style=\"font-family: arial\">";
-                txt += "<h3>Please wait for the first round to complete!</h3><h3>Current state: " + *status + "</h3>\n";
+                txt = "<h3>Please wait for the first round to complete!</h3><h3>Current state: " + *status + "</h3>\n";
                 httpd_resp_sendstr_chunk(req, txt.c_str());
             }
             else {

--- a/code/components/jomjol_tfliteclass/server_tflite.cpp
+++ b/code/components/jomjol_tfliteclass/server_tflite.cpp
@@ -378,17 +378,15 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
             return ESP_OK;
         }
 
-        if (_rawValue || _noerror) {
+
+        string query = std::string(_query);
+        if (query.find("full") == std::string::npos) {
             zw = tfliteflow.getReadout(_rawValue, _noerror);
             if (zw.length() > 0)
                 httpd_resp_sendstr_chunk(req, zw.c_str()); 
             return ESP_OK;
         }
-
-        string query = std::string(_query);
-    //    ESP_LOGD(TAG, "Query: %s, query.c_str());
-        if (query.find("full") != std::string::npos)
-        {
+        else {
             string txt, zw;
 
             std::string *status = tfliteflow.getActStatus();


### PR DESCRIPTION
@jomjol On some of my devices I see on top of the recognition page a value (probably the raw value):
![grafik](https://user-images.githubusercontent.com/1783586/221383208-d1e3c5eb-1017-41d0-afb1-fd5c2529a405.png)

I have no clue why it is there and why it is only on some of my devices.

This PR tries to fix this, can you check if it is ok?