### PR TITLE
SD card basic R/W check + folder/file presence check

### DIFF
--- a/code/components/jomjol_helper/Helper.h
+++ b/code/components/jomjol_helper/Helper.h
@@ -76,6 +76,8 @@ enum SystemStatusFlag_t {          // One bit per error
     SYSTEM_STATUS_PSRAM_BAD         = 1 << 0, //  1, Critical Error
     SYSTEM_STATUS_HEAP_TOO_SMALL    = 1 << 1, //  2, Critical Error
     SYSTEM_STATUS_CAM_BAD           = 1 << 2, //  4, Critical Error
+    SYSTEM_STATUS_SDCARD_CHECK_BAD  = 1 << 3, //  8, Critical Error
+    SYSTEM_STATUS_FOLDER_CHECK_BAD  = 1 << 4, //  16, Critical Error
 
     // Second Byte
     SYSTEM_STATUS_CAM_FB_BAD        = 1 << (0+8), //  8, Flow still might work

--- a/code/components/jomjol_helper/sdcard_check.cpp
+++ b/code/components/jomjol_helper/sdcard_check.cpp
@@ -1,0 +1,112 @@
+#include "sdcard_check.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <sys/stat.h>
+
+#include "esp_rom_crc.h" 
+#include "ClassLogFile.h"
+
+static const char *TAG = "SDCARD";
+
+int SDCardCheckRW(void)
+{
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Basic R/W check started...");
+    FILE* pFile = NULL;
+    int iCRCMessage = 0;
+   
+    pFile = fopen("/sdcard/sdcheck.txt","w");
+    if (pFile == NULL) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic R/W check: (E1) No able to open file to write");
+        return -1;
+    } 
+    else {
+        std::string sMessage = "This message is used for a SD-Card basic check!";
+        iCRCMessage = esp_rom_crc16_le(0, (uint8_t*)sMessage.c_str(), sMessage.length());
+        if (fwrite(sMessage.c_str(), sMessage.length(), 1, pFile) == 0 ) {
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic R/W check: (E2) Not able to write file");
+            fclose(pFile);
+            unlink("/sdcard/sdcheck.txt");
+            return -2;
+        }
+        fclose(pFile); 
+    }
+
+    pFile = fopen("/sdcard/sdcheck.txt","r");
+    if (pFile == NULL) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic R/W check: (E3) Not able to open file to read back");
+        unlink("/sdcard/sdcheck.txt");
+        return -3;
+    } 
+    else {
+        char cReadBuf[50];
+        if (fgets(cReadBuf, sizeof(cReadBuf), pFile) == 0) {
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic R/W check: (E4) Not able to read file back");
+            fclose(pFile);
+            unlink("/sdcard/sdcheck.txt");
+            return -4;
+        }
+        else {
+            if (esp_rom_crc16_le(0, (uint8_t*)cReadBuf, strlen(cReadBuf)) != iCRCMessage) {                 
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic R/W check: (E5) Read back, but wrong CRC");
+                fclose(pFile);
+                unlink("/sdcard/sdcheck.txt");
+                return -5;
+            }
+        }      
+        fclose(pFile);
+    }
+
+    if (unlink("/sdcard/sdcheck.txt") != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Basic R/W check: (E6) Unable to delete the file");
+        return -6;
+    }
+
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Basic R/W check successful");
+    return 0;
+}
+
+
+bool SDCardCheckFolderStructure()
+{
+    struct stat sb;
+    bool bRetval = true;
+
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Folder structure check started...");
+    /* check if path exists: config */
+    if (stat("/sdcard/config", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W1) Folder /config not found");
+        bRetval = false;
+    }
+
+    /* check if path exists: html */
+    if (stat("/sdcard/html", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W2) Folder /html not found");
+        bRetval = false;
+    }
+
+    /* check if file exists: wlan.ini */
+    if (stat("/sdcard/wlan.ini", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W3) File /wlan.ini not found");
+        bRetval = false;
+    }
+
+    /* check if file exists: config.ini */
+    if (stat("/sdcard/config/config.ini", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W4) File /config/config.ini not found");
+        bRetval = false;
+    }
+
+    /* check if file exists: index.html */
+    if (stat("/sdcard/html/index.html", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W5) File /html/index.html not found");
+        bRetval = false;
+    }
+
+    if (bRetval)
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Folder structure check successful");
+    
+    return bRetval;
+}

--- a/code/components/jomjol_helper/sdcard_check.cpp
+++ b/code/components/jomjol_helper/sdcard_check.cpp
@@ -69,44 +69,98 @@ int SDCardCheckRW(void)
 }
 
 
-bool SDCardCheckFolderStructure()
+bool SDCardCheckFolderFilePresence()
 {
     struct stat sb;
     bool bRetval = true;
 
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Folder structure check started...");
-    /* check if path exists: config */
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Folder/file presence check started...");
+    /* check if folder exists: config */
     if (stat("/sdcard/config", &sb) != 0) {
-        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W1) Folder /config not found");
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: Folder /config not found");
         bRetval = false;
     }
 
-    /* check if path exists: html */
+    /* check if folder exists: html */
     if (stat("/sdcard/html", &sb) != 0) {
-        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W2) Folder /html not found");
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: Folder /html not found");
+        bRetval = false;
+    }
+
+    /* check if folder exists: firmware */
+    if (stat("/sdcard/firmware", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: Folder /firmware not found");
+        bRetval = false;
+    }
+
+    /* check if folder exists: img_tmp */
+    if (stat("/sdcard/img_tmp", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: Folder /img_tmp not found");
+        bRetval = false;
+    }
+
+    /* check if folder exists: log */
+    if (stat("/sdcard/log", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: Folder /log not found");
+        bRetval = false;
+    }
+
+    /* check if folder exists: demo */
+    if (stat("/sdcard/demo", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: Folder /demo not found");
         bRetval = false;
     }
 
     /* check if file exists: wlan.ini */
     if (stat("/sdcard/wlan.ini", &sb) != 0) {
-        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W3) File /wlan.ini not found");
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: File /wlan.ini not found");
         bRetval = false;
     }
 
     /* check if file exists: config.ini */
     if (stat("/sdcard/config/config.ini", &sb) != 0) {
-        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W4) File /config/config.ini not found");
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: File /config/config.ini not found");
         bRetval = false;
     }
 
     /* check if file exists: index.html */
     if (stat("/sdcard/html/index.html", &sb) != 0) {
-        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Folder structure check: (W5) File /html/index.html not found");
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: File /html/index.html not found");
+        bRetval = false;
+    }
+
+    /* check if file exists: ota.html */
+    if (stat("/sdcard/html/ota_page.html", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: File /html/ota.html not found");
+        bRetval = false;
+    }
+
+    /* check if file exists: log.html */
+    if (stat("/sdcard/html/log.html", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: File /html/log.html not found");
+        bRetval = false;
+    }
+
+    /* check if file exists: common.js */
+    if (stat("/sdcard/html/common.js", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: File /html/common.js not found");
+        bRetval = false;
+    }
+
+    /* check if file exists: gethost.js */
+    if (stat("/sdcard/html/gethost.js", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: File /html/gethost.js not found");
+        bRetval = false;
+    }
+
+    /* check if file exists: version.txt */
+    if (stat("/sdcard/html/version.txt", &sb) != 0) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Folder/file check: File /html/version.txt not found");
         bRetval = false;
     }
 
     if (bRetval)
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Folder structure check successful");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Folder/file presence check successful");
     
     return bRetval;
 }

--- a/code/components/jomjol_helper/sdcard_check.h
+++ b/code/components/jomjol_helper/sdcard_check.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifndef COMPONENTS_HELPER_SDCARD_CHECK_H
+#define COMPONENTS_HELPER_SDCARD_CHECK_H
+
+#include "../../include/defines.h"
+
+int SDCardCheckRW(void);
+bool SDCardCheckFolderStructure(void);
+
+#endif /* COMPONENTS_HELPER_SDCARD_CHECK_H */

--- a/code/components/jomjol_helper/sdcard_check.h
+++ b/code/components/jomjol_helper/sdcard_check.h
@@ -6,6 +6,6 @@
 #include "../../include/defines.h"
 
 int SDCardCheckRW(void);
-bool SDCardCheckFolderStructure(void);
+bool SDCardCheckFolderFilePresence(void);
 
 #endif /* COMPONENTS_HELPER_SDCARD_CHECK_H */

--- a/code/components/jomjol_helper/statusled.cpp
+++ b/code/components/jomjol_helper/statusled.cpp
@@ -26,7 +26,7 @@ void task_StatusLED(void *pvParameter)
 		gpio_set_direction(BLINK_GPIO, GPIO_MODE_OUTPUT); // Set the GPIO as a push/pull output
 		gpio_set_level(BLINK_GPIO, 1);// LED off
 
-		for (int i=0; i<3; ) // Default: repeat 3 times
+		for (int i=0; i<2; ) // Default: repeat 2 times
 		{
 			if (!StatusLEDDataInt.bInfinite)
 				++i;

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -42,6 +42,7 @@
 #endif //ENABLE_MQTT
 #include "Helper.h"
 #include "statusled.h"
+#include "sdcard_check.h"
 
 #include "../../include/defines.h"
 //#include "server_GPIO.h"
@@ -233,7 +234,19 @@ extern "C" void app_main(void)
 
     // SD card: basic RW check
     // ********************************************
-    // TODO
+    int iSDCardStatus = SDCardCheckRW();
+    if (iSDCardStatus < 0) {
+        if (iSDCardStatus <= -1 && iSDCardStatus >= -2) { // write error
+            StatusLED(SDCARD_CHECK, 2, false);
+        }
+        else if (iSDCardStatus <= -3 && iSDCardStatus >= -5) {   // read error
+            StatusLED(SDCARD_CHECK, 3, false);
+        }
+        else if (iSDCardStatus == -6) {   // delete error
+            StatusLED(SDCARD_CHECK, 4, false);
+        }
+        //return;   // ??Stopp here, if yes -> blink infinite??
+    }
 
     // Check for updates
     // ********************************************
@@ -249,7 +262,9 @@ extern "C" void app_main(void)
 
     // SD card: Check folder structure
     // ********************************************
-	// TODO
+    if (!SDCardCheckFolderStructure()) {    // check presence of some folders / files -> only warnings
+        StatusLED(SDCARD_CHECK, 5, false);
+    }
 
     // Check version information
     // ********************************************

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -215,7 +215,10 @@ esp_err_t hello_main_handler(httpd_req_t *req)
 
     if (filetosend == "/sdcard/html/index.html") {
         if (isSetSystemStatusFlag(SYSTEM_STATUS_PSRAM_BAD) || // Initialization failed with crritical errors!
-                isSetSystemStatusFlag(SYSTEM_STATUS_CAM_BAD)) {
+            isSetSystemStatusFlag(SYSTEM_STATUS_CAM_BAD) ||
+            isSetSystemStatusFlag(SYSTEM_STATUS_SDCARD_CHECK_BAD) ||
+            isSetSystemStatusFlag(SYSTEM_STATUS_FOLDER_CHECK_BAD)) 
+        {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "We have a critical error, not serving main page!");
 
             char buf[20];
@@ -228,13 +231,13 @@ esp_err_t hello_main_handler(httpd_req_t *req)
                 }
             }
 
-            message += "<br>Please check <a href=\"https://jomjol.github.io/AI-on-the-edge-device-docs/Error-Codes\" target=_blank>jomjol.github.io/AI-on-the-edge-device-docs/Error-Codes</a> for more information!";
+            message += "<br>Please check logs with log viewer and/or <a href=\"https://jomjol.github.io/AI-on-the-edge-device-docs/Error-Codes\" target=_blank>jomjol.github.io/AI-on-the-edge-device-docs/Error-Codes</a> for more information!";
             message += "<br><br><button onclick=\"window.location.href='/reboot';\">Reboot</button>";
             message += "&nbsp;<button onclick=\"window.open('/ota_page.html');\">OTA Update</button>";
             message += "&nbsp;<button onclick=\"window.open('/log.html');\">Log Viewer</button>";
             message += "&nbsp;<button onclick=\"window.open('/info.html');\">Show System Info</button>";
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, message.c_str());
-            return ESP_FAIL;
+            httpd_resp_send(req, message.c_str(), message.length());
+            return ESP_OK;
         }
         else if (isSetupModusActive()) {
             ESP_LOGD(TAG, "System is in setup mode --> index.html --> setup.html");


### PR DESCRIPTION
Implement a basic SD card check at boot to ensure proper SD card functionaliy -> feature request #1886 

- check function 1:
  - Create file
  - Write file with some generic text
  - Read file back
  - Verify CRC
  - Delete file
  --> After error occured it boots to reduced WebUI show and error code

- check function 2:
  - Verify presence of some folders / files
  - The following folders / files get check at boot:
    /sdcard/config
    /sdcard/html
    /sdcard/demo --> created automatically in firmware
    /sdcard/firmware --> created automatically in firmware
    /sdcard/img_tmp --> created automatically in firmware
    /sdcard/log --> created automatically in firmware
    /sdcard/wlan.ini
    /sdcard/config/config.ini
    /sdcard/html/index.html
    /sdcard/html/ota_page.html
    /sdcard/html/log.html
    /sdcard/html/common.js
    /sdcard/html/gethost.js
    /sdcard/html/version.txt
     --> If one or more are not present -> load reduced WebUI and show error code

- Check indication in boot log (all OK):
![image](https://user-images.githubusercontent.com/115730895/221796077-f9470417-dbdc-49b9-8136-f0fece45e562.png)

- LED indication for the respective error cases:
![image](https://user-images.githubusercontent.com/115730895/221795110-8398cb12-7413-4fa2-befe-94250b3bb1a8.png)

###################################################
Questions:

- [X] Shall we stop the boot process in this early phase when SD card RW check fails or is it better to continue to reduced web interface?
  --> Load reduced web interface and show error code
- [X] Presence check of some folders is not garantuee that everthing on SD is OK, but could give early indication that something is at least present (only warnings, no reaction). What do you think about this? Does this make sense?
  --> Load reduced web interface and show error code

TODO:
- Update documentation