### PR TITLE
Logfile: Print start indication block after time sync

### DIFF
--- a/code/components/jomjol_logfile/ClassLogFile.cpp
+++ b/code/components/jomjol_logfile/ClassLogFile.cpp
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 #include "Helper.h"
+#include "time_sntp.h"
 #include "../../include/defines.h"
 
 static const char *TAG = "LOGFILE";
@@ -321,15 +322,23 @@ void ClassLogFile::RemoveOldLogFile()
             //ESP_LOGD(TAG, "compare log file: %s to %s", entry->d_name, cmpfilename);
             if ((strlen(entry->d_name) == strlen(cmpfilename)) && (strcmp(entry->d_name, cmpfilename) < 0)) {
                 //ESP_LOGD(TAG, "delete log file: %s", entry->d_name);
-                std::string filepath = logroot + "/" + entry->d_name; 
-                if (unlink(filepath.c_str()) == 0) {
-                    deleted ++;
-                } else {
-                    ESP_LOGE(TAG, "can't delete file: %s", entry->d_name);
-                    notDeleted ++;
+                std::string filepath = logroot + "/" + entry->d_name;
+                if ((strcmp(entry->d_name, "log_1970-01-01.txt") == 0) && getTimeWasNotSetAtBoot()) { // keep logfile log_1970-01-01.txt if time was not set at boot (some boot logs are in there)
+                    //ESP_LOGD(TAG, "Skip deleting this file: %s", entry->d_name); 
+                    notDeleted++;
                 }
-            } else {
-                notDeleted ++;
+                else {          
+                    if (unlink(filepath.c_str()) == 0) {
+                        deleted++;
+                    } 
+                    else {
+                        ESP_LOGE(TAG, "can't delete file: %s", entry->d_name);
+                        notDeleted++;
+                    }
+                }
+            } 
+            else {
+                notDeleted++;
             }
         }
     }

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -25,6 +25,7 @@ static const char *TAG = "SNTP";
 static std::string timeZone = "";
 static std::string timeServer = "undefined";
 static bool useNtp = true;
+static bool noTimeSet = false;
 
 std::string getNtpStatusText(sntp_sync_status_t status);
 static void setTimeZone(std::string _tzstring);
@@ -59,7 +60,13 @@ std::string getCurrentTimeString(const char * frm)
 
 void time_sync_notification_cb(struct timeval *tv)
 {
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is now successfully synced with NTP Server " +
+    if (noTimeSet) {
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "=================================================");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "==================== Start ======================");
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "== Logs before time sync -> log_1970-01-01.txt ==");
+        noTimeSet = false;
+    }
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is synced with NTP Server " +
             getServerName() + ": " + getCurrentTimeString("%Y-%m-%d %H:%M:%S"));
 }
 
@@ -226,6 +233,7 @@ bool setupTime() {
         if (useNtp) {
             LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Once the NTP server provides a time, we will switch to that one");
         }
+        noTimeSet = true;
     }
 
     return true;

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -25,7 +25,7 @@ static const char *TAG = "SNTP";
 static std::string timeZone = "";
 static std::string timeServer = "undefined";
 static bool useNtp = true;
-static bool noTimeSet = false;
+static bool timeWasNotSetAtBoot = false;
 
 std::string getNtpStatusText(sntp_sync_status_t status);
 static void setTimeZone(std::string _tzstring);
@@ -60,11 +60,10 @@ std::string getCurrentTimeString(const char * frm)
 
 void time_sync_notification_cb(struct timeval *tv)
 {
-    if (noTimeSet) {
+    if (timeWasNotSetAtBoot) {
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "=================================================");
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "==================== Start ======================");
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "== Logs before time sync -> log_1970-01-01.txt ==");
-        noTimeSet = false;
     }
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Time is synced with NTP Server " +
             getServerName() + ": " + getCurrentTimeString("%Y-%m-%d %H:%M:%S"));
@@ -116,6 +115,11 @@ bool getTimeIsSet(void) {
 
 bool getUseNtp(void) {
     return useNtp;
+}
+
+bool getTimeWasNotSetAtBoot(void)
+{
+    return timeWasNotSetAtBoot;
 }
 
 
@@ -232,8 +236,8 @@ bool setupTime() {
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "The local time is unknown, starting with " + std::string(strftime_buf));
         if (useNtp) {
             LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Once the NTP server provides a time, we will switch to that one");
+            timeWasNotSetAtBoot = true;
         }
-        noTimeSet = true;
     }
 
     return true;

--- a/code/components/jomjol_time_sntp/time_sntp.h
+++ b/code/components/jomjol_time_sntp/time_sntp.h
@@ -22,6 +22,7 @@ std::string ConvertTimeToString(time_t _time, const char * frm);
 
 
 bool getTimeIsSet(void);
+bool getTimeWasNotSetAtBoot(void);
 
 bool getUseNtp(void);
 bool setupTime();


### PR DESCRIPTION
- Print start indication block after time sync occured to highlight start of new logs after e.g. a cold boot (no vaild time available, so all logs before time is synced are printed to 1970-01-01.txt)
- This block is only printed when no time was set before
- The file log_1970-01-01.txt is not getting deleted if NTP time was not set at boot (e.g. after cold boot) because some of the boot logs are in there. If the time is already set during boot, the file will be handled like all other log files and will be deleted after flow is finished.

This topic was raised by @caco3