### PR TITLE
Add GJ (gigajoule) as an energy meter unit

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -156,6 +156,9 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, string& aktparamgraph)
             else if (toUpper(splitted[1]) == "ENERGY_MWH") {
                 mqttServer_setMeterType("energy", "MWh", "h", "MW");
             }
+            else if (toUpper(splitted[1]) == "ENERGY_GJ") {
+                mqttServer_setMeterType("energy", "GJ", "h", "GJ/h");
+            }
         }
 
         if ((toUpper(splitted[0]) == "CLIENTID") && (splitted.size() > 1))

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -654,6 +654,7 @@ textarea {
 					<option value="energy_wh">Energymeter (Value: Wh, Rate: W)</option>
 					<option value="energy_kwh">Energymeter (Value: kWh, Rate: kW)</option>
 					<option value="energy_mwh">Energymeter (Value: MWh, Rate: MW)</option>
+					<option value="energy_gj">Energymeter (Value: GJ, Rate: GJ/h)</option>
 				</select>
 			</td>
 			<td>$TOOLTIP_MQTT_MeterType</td>


### PR DESCRIPTION
Some district heating meters are displaying their values in GJ and Home Assistant is also capable of accepting heating values in this format.

I added the rate as "GJ/h", even though `1 joule = 1 Ws`, so the correct rate would be `GW/s`. However it would be a silly small unit, so I think it would make more sense to use GJ/h. Let me know if I should change it.

I was able to use a sensor that had the unit of "GJ" in the HA energy dashboard by converting the value with a template sensor, but I think it is much cleaner to get the correct unit straight from the "AI-on-the-edge-device".

Testing: I did not compile and test this, just found the places where "kwh" was mentioned and added GJ there as well. Let me know if you need full testing before and I will set up a dev environment.

Thank you for this awesome project! I just tried to set it up the first time and it worked very well so far!