### PR TITLE
Reboot task - increase waiting time

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -623,7 +623,7 @@ void doReboot()
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "task_reboot not created -> force reboot without killing flow");
         task_reboot((void*) false);
     }
-    vTaskDelay(10000 / portTICK_PERIOD_MS); // Prevent serving web client fetch response until system is shuting down
+    vTaskDelay(20000 / portTICK_PERIOD_MS); // Prevent serving web client fetch response until system is shuting down
 }
 
 


### PR DESCRIPTION
For some reason since 15.1 and newer reboot logic is not working reliable anymore for me. It takes sometimes way longer to handle e.g. MQTT disconnect / MQTT destroy. 

Sometimes it's not rebooting at all, but sometimes it's still working --> Increase waiting time to give single shutdown tasks more time to complete.

@caco3, @jomjol: Can you please check this topic on your side.