### PR TITLE
Set prevalue using MQTT + set prevalue to RAW value (REST+MQTT)

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowControll.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.h
@@ -46,9 +46,9 @@ public:
 	bool doFlow(string time);
 	void doFlowTakeImageOnly(string time);
 	bool getStatusSetupModus(){return SetupModeActive;};
-	string getReadout(bool _rawvalue, bool _noerror);
+	string getReadout(bool _rawvalue, bool _noerror, int _number);
 	string getReadoutAll(int _type);	
-	string UpdatePrevalue(std::string _newvalue, std::string _numbers, bool _extern);
+	bool UpdatePrevalue(std::string _newvalue, std::string _numbers, bool _extern);
 	string GetPrevalue(std::string _number = "");	
 	bool ReadParameter(FILE* pfile, string& aktparamgraph);	
 	string getJSON();

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
@@ -68,7 +68,7 @@ public:
     void SavePreValue();
     string getJsonFromNumber(int i, std::string _lineend);
     string GetPreValue(std::string _number = "");
-    void SetPreValue(double zw, string _numbers, bool _extern = false);
+    bool SetPreValue(double zw, string _numbers, bool _extern = false);
 
     std::string GetJSON(std::string _lineend = "\n");
     std::string getNumbersName();

--- a/code/components/jomjol_mqtt/CMakeLists.txt
+++ b/code/components/jomjol_mqtt/CMakeLists.txt
@@ -2,4 +2,4 @@ FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."
-                    REQUIRES tflite-lib mqtt jomjol_tfliteclass jomjol_helper jomjol_mqtt jomjol_wlan)
+                    REQUIRES tflite-lib mqtt jomjol_tfliteclass jomjol_helper jomjol_mqtt jomjol_wlan json)

--- a/code/components/jomjol_mqtt/interface_mqtt.cpp
+++ b/code/components/jomjol_mqtt/interface_mqtt.cpp
@@ -6,6 +6,7 @@
 #include "mqtt_client.h"
 #include "ClassLogFile.h"
 #include "server_tflite.h"
+#include "cJSON.h"
 #include "../../include/defines.h"
 
 static const char *TAG = "MQTT IF";
@@ -336,14 +337,51 @@ bool getMQTTisConnected() {
 }
 
 
-bool mqtt_handler_flow_start(std::string _topic, char* _data, int _data_len) {
+bool mqtt_handler_flow_start(std::string _topic, char* _data, int _data_len) 
+{
     ESP_LOGD(TAG, "Handler called: topic %s, data %.*s", _topic.c_str(), _data_len, _data);
 
     if (_data_len > 0) {
         MQTTCtrlFlowStart(_topic);
     }
+    else {
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "handler_flow_start: handler called, but no data");
+    }
 
     return ESP_OK;
+}
+
+
+bool mqtt_handler_set_prevalue(std::string _topic, char* _data, int _data_len) 
+{
+    //ESP_LOGD(TAG, "Handler called: topic %s, data %.*s", _topic.c_str(), _data_len, _data);
+    //example: {"numbersname": "main", "value": 12345.1234567}
+
+    if (_data_len > 0) {    // Check if data length > 0
+        cJSON *jsonData = cJSON_Parse(_data);
+        cJSON *numbersname = cJSON_GetObjectItemCaseSensitive(jsonData, "numbersname");
+        cJSON *value = cJSON_GetObjectItemCaseSensitive(jsonData, "value");
+
+        if (cJSON_IsString(numbersname) && (numbersname->valuestring != NULL)) {    // Check if numbersname is valid
+            if (cJSON_IsNumber(value)) {   // Check if value is a number
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handler_set_prevalue called: numbersname: " + std::string(numbersname->valuestring) + 
+                                                                                         ", value: " + std::to_string(value->valuedouble));
+                if (tfliteflow.UpdatePrevalue(std::to_string(value->valuedouble), std::string(numbersname->valuestring), true))
+                    return ESP_OK;
+            }
+            else {
+                LogFile.WriteToFile(ESP_LOG_WARN, TAG, "handler_set_prevalue: value not a valid number (\"value\": 12345.12345)");
+            }
+        }
+        else {
+            LogFile.WriteToFile(ESP_LOG_WARN, TAG, "handler_set_prevalue: numbersname not a valid string (\"numbersname\": \"main\")");
+        }
+    }
+    else {
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "handler_set_prevalue: handler called, but no data received");
+    }
+
+    return ESP_FAIL;
 }
 
 
@@ -358,9 +396,14 @@ void MQTTconnected(){
             }
         }
 
-        /* Subcribe to topics */
-        std::function<bool(std::string topic, char* data, int data_len)> subHandler = mqtt_handler_flow_start;     
-        MQTTregisterSubscribeFunction(maintopic + "/ctrl/flow_start", subHandler);        // subcribe to maintopic/ctrl/flow_start
+        // Subcribe to topics
+        // Note: Further subsriptions are handled in GPIO class
+        //*****************************************
+        std::function<bool(std::string topic, char* data, int data_len)> subHandler1 = mqtt_handler_flow_start;     
+        MQTTregisterSubscribeFunction(maintopic + "/ctrl/flow_start", subHandler1);        // subcribe to maintopic/ctrl/flow_start
+
+        std::function<bool(std::string topic, char* data, int data_len)> subHandler2 = mqtt_handler_set_prevalue;     
+        MQTTregisterSubscribeFunction(maintopic + "/ctrl/set_prevalue", subHandler2);      // subcribe to maintopic/ctrl/set_prevalue
 
        if (subscribeFunktionMap != NULL) {
             for(std::map<std::string, std::function<bool(std::string, char*, int)>>::iterator it = subscribeFunktionMap->begin(); it != subscribeFunktionMap->end(); ++it) {


### PR DESCRIPTION
Implements feature request #2174

- MQTT: Add feature to set prevalue
  - subcription topic: `{maintopic}/ctrl/set_prevalue`
  - data in JSON notation: `{"numbersname": "main", "value": 12345.67890}`
    - positive value: set to given value
    - negative value (e.g.: -1): set to RAW value (if a valid RAW value is available)
-  REST API: Add feature to set prevalue also to RAW value
   - (positive value: set to given value -> already existing function)
   - negative value (e.g.: -1): set to RAW value (if a valid RAW value is available)
- Use double precision throughout the setting process to ensure enough valid decimal places (constistency)
- Additional error handling and messages (REST API & logfile)
- Add REST API usage message