### PR TITLE
Fix time offset issues in InfluxDB component.

### DIFF
--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -46,33 +46,12 @@ void InfluxDB_V2_Publish(std::string _key, std::string _content, std::string _ti
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDB_V2_Publish - Key: " + _key + ", Content: " + _content + ", Timestamp: " + _timestamp);
 
-    // Format:     #define PREVALUE_TIME_FORMAT_OUTPUT "%Y-%m-%dT%H:%M:%S%z"
-
+    time_t now = time(NULL);
     char nowTimestamp[21];
-    std::string payload;
-
-    if (_timestamp.length() > 0)
-    {
-        struct tm tm;
-        strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
-        time_t t = mktime(&tm); // Time in Localtime (looks like timezone is not used by strptime)
-
-        struct tm * ptm;
-        ptm = gmtime ( &t );
-        time_t utc = mktime(ptm);
-        utc = 2*t - utc;        // Take care of timezone (looks difficult, but is easy: t = t + (t - utc), weil t-utc = timezone)
-
-        sprintf(nowTimestamp,"%ld000000000", (long) utc);           // UTC
-
-        payload = _influxDB_V2_Measurement + " " + _key + "=" + _content + " " + nowTimestamp;
-//        payload = _influxDB_V2_Measurement + " " + _key + "=774 " + nowTimestamp;
-    }
-    else
-    {
-        payload = _influxDB_V2_Measurement + " " + _key + "=" + _content;
-//        payload = _influxDB_V2_Measurement + " " + _key + "=774";
-    }
-
+    // pad with zeroes to get nanoseconds
+    sprintf(nowTimestamp,"%jd000000000", (intmax_t)now);
+ 
+    std::string payload = _influxDBMeasurement + " " + _key + "=" + _content + " " + nowTimestamp;
     payload.shrink_to_fit();
 
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "sending line to influxdb:" + payload);
@@ -159,30 +138,12 @@ void InfluxDBPublish(std::string _key, std::string _content, std::string _timest
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDBPublish - Key: " + _key + ", Content: " + _content + ", Timestamp: " + _timestamp);
 
+    time_t now = time(NULL);
     char nowTimestamp[21];
-    std::string payload;
-
-    if (_timestamp.length() > 0)
-    {
-        struct tm tm;
-        strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
-        time_t t = mktime(&tm); // Time in Localtime (looks like timezone is not used by strptime)
-
-        struct tm * ptm;
-        ptm = gmtime ( &t );
-        time_t utc = mktime(ptm);
-        utc = 2*t - utc;        // Take care of timezone (looks difficult, but is easy: t = t + (t - utc), weil t-utc = timezone)
-
-        sprintf(nowTimestamp,"%ld000000000", (long) utc);           // UTC
-
-        payload = _influxDBMeasurement + " " + _key + "=" + _content + " " + nowTimestamp;
-//        payload = _influxDBMeasurement + " " + _key + "=774 " + nowTimestamp;
-    }
-    else
-    {
-        payload = _influxDBMeasurement + " " + _key + "=" + _content;
-    }
-
+    // pad with zeroes to get nanoseconds
+    sprintf(nowTimestamp,"%jd000000000", (intmax_t)now);
+ 
+    std::string payload = _influxDBMeasurement + " " + _key + "=" + _content + " " + nowTimestamp;
     payload.shrink_to_fit();
 
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "sending line to influxdb:" + payload);


### PR DESCRIPTION
Closes #2273.
Closes #2150.

This reverts back to using the UTC time to send timestamps to InfluxDB.