### PR TITLE
Shared psram memory2

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -373,7 +373,7 @@ bool ClassFlowControll::doFlow(string time)
         zw_time = getCurrentTimeString("%H:%M:%S");
         aktstatus = TranslateAktstatus(FlowControll[i]->name());
         aktstatusWithTime = aktstatus + " (" + zw_time + ")";
-        //LogFile.WriteToFile(ESP_LOG_INFO, TAG, aktstatusWithTime);
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "STATUS: " + aktstatusWithTime);
         #ifdef ENABLE_MQTT
             MQTTPublish(mqttServer_getMainTopic() + "/" + "status", aktstatus, qos, false);
         #endif //ENABLE_MQTT

--- a/code/components/jomjol_helper/psram.cpp
+++ b/code/components/jomjol_helper/psram.cpp
@@ -11,10 +11,23 @@ void *malloc_psram_heap(std::string name, size_t size, uint32_t caps) {
 
 	ptr = heap_caps_malloc(size, caps);
     if (ptr != NULL) {
-	    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Allocated " + to_string(size) + " bytes in PSRAM for '" + name + "'");
+	    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Allocated " + to_string(size) + " bytes in PSRAM for '" + name + "'");
 	}
     else {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to allocate " + to_string(size) + " bytes in PSRAM for '" + name + "'!");
+    }
+
+	return ptr;
+}
+
+
+void *realloc_psram_heap(std::string name, void *ptr, size_t size, uint32_t caps) {
+	ptr = heap_caps_realloc(ptr, size, caps);
+    if (ptr != NULL) {
+	    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Reallocated " + to_string(size) + " bytes in PSRAM for '" + name + "'");
+	}
+    else {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to reallocate " + to_string(size) + " bytes in PSRAM for '" + name + "'!");
     }
 
 	return ptr;
@@ -26,7 +39,7 @@ void *calloc_psram_heap(std::string name, size_t n, size_t size, uint32_t caps) 
 
 	ptr = heap_caps_calloc(n, size, caps);
     if (ptr != NULL) {
-	    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Allocated " + to_string(size) + " bytes in PSRAM for '" + name + "'");
+	    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Allocated " + to_string(size) + " bytes in PSRAM for '" + name + "'");
 	}
     else {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to allocate " + to_string(size) + " bytes in PSRAM for '" + name + "'!");
@@ -37,6 +50,6 @@ void *calloc_psram_heap(std::string name, size_t n, size_t size, uint32_t caps) 
 
 
 void free_psram_heap(std::string name, void *ptr) {
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Freeing memory in PSRAM used for '" + name + "'...");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Freeing memory in PSRAM used for '" + name + "'...");
     heap_caps_free(ptr);
 }

--- a/code/components/jomjol_helper/psram.cpp
+++ b/code/components/jomjol_helper/psram.cpp
@@ -1,11 +1,104 @@
 #include "ClassLogFile.h"
-#include "esp_heap_caps.h"
+#include "../../include/defines.h"
+#include "psram.h"
 
 static const char* TAG = "PSRAM";
 
 using namespace std;
 
 
+void *shared_region = NULL;
+uint32_t allocatedBytes = 0;
+
+
+bool reserve_psram_shared_region(void) {
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Allocating shared PSRAM region (" + 
+            std::to_string(TENSOR_ARENA_SIZE + MAX_MODEL_SIZE) + " bytes)...");
+    shared_region = malloc_psram_heap("Shared PSRAM region", TENSOR_ARENA_SIZE + MAX_MODEL_SIZE, MALLOC_CAP_SPIRAM);
+
+    if (shared_region == NULL) {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to allocating shared PSRAM region!");
+        return false;
+    }
+    else {
+        return true;
+    }
+}
+
+
+
+
+/***********************************************
+ * Memory used in Take Image (STBI)
+ ***********************************************/
+void *psram_reserve_shared_stbi_memory(size_t size) {
+    // only do it this way for the defined 4 buffers!
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Allocating memory for STBI (PSRAM, part of shared memory, " + std::to_string(size) + " bytes)...");
+    allocatedBytes += size;
+    return shared_region + allocatedBytes - size;
+}
+
+
+void *psram_reallocate_shared_stbi_memory(void *ptr, size_t newsize) {
+    // only do it this way for the defined 4 buffers!
+    char buf[20];
+    sprintf(buf, "%p", ptr);
+    LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "STBI requested realloc for " + std::string(buf) + " but this is currently unsupported!");
+    return NULL;
+}
+
+
+void psram_free_shared_stbi_memory(void *p) {
+    // only do it this way for the defined 4 buffers!
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Part of shared memory used for STBI (PSRAM, part of shared memory) is free again");
+}
+
+
+
+/***********************************************
+ * Memory used in Aligning Step 
+ ***********************************************/
+void *psram_reserve_shared_tmp_image_memory(void) {
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Allocating TMP Image (PSRAM, part of shared memory, " + std::to_string(IMAGE_SIZE) + " bytes)...");
+    allocatedBytes += IMAGE_SIZE;
+    return shared_region; // Use 1th part of the shared memory for the TMP Image (only user)
+}
+
+
+void psram_free_shared_temp_image_memory(void) {
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Shared memory used for TMP Image (PSRAM, part of shared memory) is free again");
+    allocatedBytes = 0;
+}
+
+
+
+/***********************************************
+ * Memory used in Digitalization Steps
+ ***********************************************/
+void *psram_reserve_shared_tensor_arena_memory(void) {
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Allocating Tensor Arena (PSRAM, part of shared memory, " + std::to_string(TENSOR_ARENA_SIZE) + " bytes)...");
+    allocatedBytes += TENSOR_ARENA_SIZE;
+    return shared_region; // Use 1th part of the shared memory for Tensor
+}
+
+
+void *psram_reserve_shared_model_memory(void) {
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Allocating Model memory (PSRAM, part of shared memory, " + std::to_string(MAX_MODEL_SIZE) + " bytes)...");
+    allocatedBytes += MAX_MODEL_SIZE;
+    return shared_region + allocatedBytes - MAX_MODEL_SIZE; // Use 2nd part of the shared memory (after Tensor Arena) for the model
+}
+
+
+void psram_free_shared_tensor_arena_and_model_memory(void) {
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Shared memory used for Tensor Arena and model (PSRAM, part of shared memory) is free again");
+    allocatedBytes = 0;
+}
+
+
+
+/***********************************************
+ * General
+ ***********************************************/
 void *malloc_psram_heap(std::string name, size_t size, uint32_t caps) {
 	void *ptr;
 

--- a/code/components/jomjol_helper/psram.h
+++ b/code/components/jomjol_helper/psram.h
@@ -2,6 +2,7 @@
 #include "esp_heap_caps.h"
 
 void *malloc_psram_heap(std::string name, size_t size, uint32_t caps);
+void *realloc_psram_heap(std::string name, void *ptr, size_t size, uint32_t caps);
 void *calloc_psram_heap(std::string name, size_t n, size_t size, uint32_t caps);
 
 void free_psram_heap(std::string name, void *ptr);

--- a/code/components/jomjol_helper/psram.h
+++ b/code/components/jomjol_helper/psram.h
@@ -1,8 +1,33 @@
+#pragma once
+#ifndef PSRAM_h
+#define PSRAM_h
 
 #include "esp_heap_caps.h"
+
+
+bool reserve_psram_shared_region(void);
+
+
+/* Memory used in Take Image Step */
+void *psram_reserve_shared_stbi_memory(size_t size);
+void *psram_reallocate_shared_stbi_memory(void *ptr, size_t newsize);
+void psram_free_shared_stbi_memory(void *p);
+
+
+/* Memory used in Aligning Step */
+void *psram_reserve_shared_tmp_image_memory(void);
+void psram_free_shared_temp_image_memory(void);
+
+/* Memory used in Digitalization Steps */
+void *psram_reserve_shared_tensor_arena_memory(void);
+void *psram_reserve_shared_model_memory(void);
+void psram_free_shared_tensor_arena_and_model_memory(void);
+
 
 void *malloc_psram_heap(std::string name, size_t size, uint32_t caps);
 void *realloc_psram_heap(std::string name, void *ptr, size_t size, uint32_t caps);
 void *calloc_psram_heap(std::string name, size_t n, size_t size, uint32_t caps);
 
 void free_psram_heap(std::string name, void *ptr);
+
+#endif // PSRAM_h

--- a/code/components/jomjol_image_proc/make_stb.cpp
+++ b/code/components/jomjol_image_proc/make_stb.cpp
@@ -5,9 +5,9 @@
 #include "../../include/defines.h"
 
 
-#define STBI_MALLOC(sz)           malloc_psram_heap("STBI", sz, MALLOC_CAP_SPIRAM)
-#define STBI_REALLOC(p,newsz)     realloc_psram_heap("STBI", p, newsz, MALLOC_CAP_SPIRAM)
-#define STBI_FREE(p)              free_psram_heap("STBI", p)
+#define STBI_MALLOC(sz)           psram_reserve_shared_stbi_memory(sz)
+#define STBI_REALLOC(p,newsz)     psram_reallocate_shared_stbi_memory(p, newsz)
+#define STBI_FREE(p)              psram_free_shared_stbi_memory(p)
 
 
 #define STB_IMAGE_IMPLEMENTATION

--- a/code/components/jomjol_image_proc/make_stb.cpp
+++ b/code/components/jomjol_image_proc/make_stb.cpp
@@ -1,7 +1,14 @@
 #include <stdint.h>
 #include <string>
+#include "psram.h"
 
 #include "../../include/defines.h"
+
+
+#define STBI_MALLOC(sz)           malloc_psram_heap("STBI", sz, MALLOC_CAP_SPIRAM)
+#define STBI_REALLOC(p,newsz)     realloc_psram_heap("STBI", p, newsz, MALLOC_CAP_SPIRAM)
+#define STBI_FREE(p)              free_psram_heap("STBI", p)
+
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "../stb/stb_image.h"

--- a/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
+++ b/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
@@ -251,7 +251,7 @@ bool CTfLiteClass::ReadFileToModel(std::string _fn)
         LogFile.WriteHeapInfo("CTLiteClass::Alloc modelfile start");
 #endif
 
-    modelfile = (unsigned char*)malloc_psram_heap(std::string(TAG) + "->modelfile", size, MALLOC_CAP_SPIRAM);
+    modelfile = (unsigned char*)psram_reserve_shared_model_memory();
   
 	  if(modelfile != NULL) 
     {
@@ -304,9 +304,9 @@ CTfLiteClass::CTfLiteClass()
     this->modelfile = NULL;
     this->interpreter = nullptr;
     this->input = nullptr;
-    this->output = nullptr;  
-    this->kTensorArenaSize = 800 * 1024;   /// according to testfile: 108000 - so far 600;; 2021-09-11: 200 * 1024
-    this->tensor_arena = (uint8_t*)malloc_psram_heap(std::string(TAG) + "->tensor_arena", kTensorArenaSize, MALLOC_CAP_SPIRAM);
+    this->output = nullptr;
+    this->kTensorArenaSize = TENSOR_ARENA_SIZE;
+    this->tensor_arena = (uint8_t*)psram_reserve_shared_tensor_arena_memory();
 }
 
 
@@ -315,8 +315,7 @@ CTfLiteClass::~CTfLiteClass()
   delete this->interpreter;
   delete this->error_reporter;
 
-  free_psram_heap(std::string(TAG) + "->modelfile", modelfile);
-  free_psram_heap(std::string(TAG) + "->tensor_arena", this->tensor_arena);
+  psram_free_shared_tensor_arena_and_model_memory();
 }        
 
 

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -189,6 +189,12 @@
 
 
 /////////////////////////////////////////////
+////      PSRAM Allocations              ////
+/////////////////////////////////////////////
+#define MAX_MODEL_SIZE            (unsigned int)(1.3 * 1024 * 1024) // Space for the largest model (1.3 MB)
+#define TENSOR_ARENA_SIZE         800 * 1024 // Space for the Tensor Arena, (819200 Bytes)
+#define IMAGE_SIZE                640 * 480 * 3 // Space fo a decompressed image (921600 Bytes)
+/////////////////////////////////////////////
 ////      Conditionnal definitions       ////
 /////////////////////////////////////////////
 

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -13,6 +13,7 @@
 //#include "spiram.h"
 #include "esp32/spiram.h"
 #include "esp_pm.h"
+#include "psram.h"
 
 
 // SD-Card ////////////////////
@@ -438,6 +439,9 @@ extern "C" void app_main(void)
             }
         }
     }
+
+    /* Allocate static PSRAM memory regions */
+    reserve_psram_shared_region(); // catch error
 
     // Print Device info
     // ********************************************


### PR DESCRIPTION
This is a new approach to optimize the shared PSRAM memory.
The main focus is on allocating a large region and then manage it by itself to avoid fragmentation issues.

xxx


### Old situation (v15.1.1)
Models:
Heap after 5 rounds: 



### Using shared memory
Models:
Heap after 5 rounds: 



### Using shared memory and additionally moved MQTT Outbox, Wifi and BSSI to PSRAM (when possible).
Models:
Heap after 5 rounds: 




