### PR TITLE
Extend InfluxDBv1 with individual topic names

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
@@ -50,7 +50,8 @@ struct NumberPost {
     int DecimalShiftInitial;
     float AnalogDigitalTransitionStart; // When is the digit > x.1, i.e. when does it start to tilt?
     int Nachkomma;
-    string Fieldname; // Fieldname in InfluxDB2  
+    string FieldnameV1; // Fieldname in InfluxDBv1  
+    string FieldnameV2; // Fieldname in InfluxDBv2  
 
     bool isExtendedResolution;
 

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
@@ -159,9 +159,9 @@ bool ClassFlowInfluxDB::doFlow(string zwtime)
             resultrate = (*NUMBERS)[i]->ReturnRateValue;
             resulttimestamp = (*NUMBERS)[i]->timeStamp;
 
-            if ((*NUMBERS)[i]->Fieldname.length() > 0)
+            if ((*NUMBERS)[i]->FieldnameV1.length() > 0)
             {
-                namenumber = (*NUMBERS)[i]->Fieldname;
+                namenumber = (*NUMBERS)[i]->FieldnameV1;
             }
             else
             {
@@ -196,11 +196,11 @@ void ClassFlowInfluxDB::handleFieldname(string _decsep, string _value)
     {
         if (_digit == "default")                        //  Set to default first (if nothing else is set)
         {
-            flowpostprocessing->NUMBERS[j]->Fieldname = _value;
+            flowpostprocessing->NUMBERS[j]->FieldnameV1 = _value;
         }
         if (flowpostprocessing->NUMBERS[j]->name == _digit)
         {
-            flowpostprocessing->NUMBERS[j]->Fieldname = _value;
+            flowpostprocessing->NUMBERS[j]->FieldnameV1 = _value;
         }
     }
 }

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.h
@@ -21,7 +21,10 @@ protected:
     std::string user, password; 
     bool InfluxDBenable;
 
-    void SetInitialParameter(void);        
+    void SetInitialParameter(void);    
+    
+    void handleFieldname(string _decsep, string _value);   
+    
 
 public:
     ClassFlowInfluxDB();

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
@@ -154,11 +154,11 @@ void ClassFlowInfluxDBv2::handleFieldname(string _decsep, string _value)
     {
         if (_digit == "default")                        //  Set to default first (if nothing else is set)
         {
-            flowpostprocessing->NUMBERS[j]->Fieldname = _value;
+            flowpostprocessing->NUMBERS[j]->FieldnameV2 = _value;
         }
         if (flowpostprocessing->NUMBERS[j]->name == _digit)
         {
-            flowpostprocessing->NUMBERS[j]->Fieldname = _value;
+            flowpostprocessing->NUMBERS[j]->FieldnameV2 = _value;
         }
     }
 }
@@ -190,9 +190,9 @@ bool ClassFlowInfluxDBv2::doFlow(string zwtime)
             resultrate = (*NUMBERS)[i]->ReturnRateValue;
             resulttimestamp = (*NUMBERS)[i]->timeStamp;
 
-            if ((*NUMBERS)[i]->Fieldname.length() > 0)
+            if ((*NUMBERS)[i]->FieldnameV2.length() > 0)
             {
-                namenumber = (*NUMBERS)[i]->Fieldname;
+                namenumber = (*NUMBERS)[i]->FieldnameV2;
             }
             else
             {

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -192,7 +192,9 @@ void InfluxDBPublish(std::string _key, std::string _content, std::string _timest
 
 
     // use the default retention policy of the database
-    std::string apiURI = _influxDBURI + "/write?db=" + _influxDBDatabase;
+//    std::string apiURI = _influxDBURI + "/write?db=" + _influxDBDatabase;
+    std::string apiURI = _influxDBURI + "/api/v2/write?bucket=" + _influxDBDatabase + "/";
+
     apiURI.shrink_to_fit();
     http_config.url = apiURI.c_str();
 

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -183,7 +183,7 @@ void InfluxDBPublish(std::string _key, std::string _content, std::string _timest
     }
     else
     {
-        payload = _influxDB_V2_Measurement + " " + _key + "=" + _content;
+        payload = _influxDBMeasurement + " " + _key + "=" + _content;
     }
 
     payload.shrink_to_fit();
@@ -192,8 +192,8 @@ void InfluxDBPublish(std::string _key, std::string _content, std::string _timest
 
 
     // use the default retention policy of the database
-//    std::string apiURI = _influxDBURI + "/write?db=" + _influxDBDatabase;
-    std::string apiURI = _influxDBURI + "/api/v2/write?bucket=" + _influxDBDatabase + "/";
+    std::string apiURI = _influxDBURI + "/write?db=" + _influxDBDatabase;
+//    std::string apiURI = _influxDBURI + "/api/v2/write?bucket=" + _influxDBDatabase + "/";
 
     apiURI.shrink_to_fit();
     http_config.url = apiURI.c_str();

--- a/sd-card/html/common.js
+++ b/sd-card/html/common.js
@@ -1,7 +1,7 @@
  
 /* The UI can also be run locally, but you have to set the IP of your devide accordingly.
  * And you also might have to disable CORS in your webbrowser! */
-var domainname_for_testing = "192.168.1.153";
+var domainname_for_testing = "192.168.178.23";
 
 
 

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -718,6 +718,24 @@ textarea {
 			</td>
 			<td>$TOOLTIP_InfluxDB_password</td>
 		</tr>
+		<tr>
+			<td class="indent1" colspan="3">
+				<br>
+				<b>InfluxDB Individual Parameters: 
+                <select id="NumbersInfluxDB_value1" onchange="numberInfluxDBChanged()">
+                </select></b>
+			</td>
+		</tr>
+		<tr>
+			<td class="indent1" style="padding-left: 75px;">
+				<input type="checkbox" id="InfluxDB_Fieldname_enabled" value="1"  onclick = 'InvertEnableItem("InfluxDB", "Fieldname")' unchecked >
+				<label for=InfluxDB_Fieldname_enabled><class id="InfluxDB_Fieldname_text" style="color:black;">Fieldname</class></label>
+			</td>
+			<td>
+				<input type="text" id="InfluxDB_Fieldname_value1">
+			</td>
+			<td>$TOOLTIP_InfluxDB_NUMBER.Fieldname</td>
+		</tr>
 
 
 
@@ -782,8 +800,8 @@ textarea {
 		<tr>
 			<td class="indent1" colspan="3">
 				<br>
-				<b>Postprocessing Individual Parameters: 
-                <select id="NumbersInfluxDB_value1" onchange="numberInfluxDBChanged()">
+				<b>InfluxDB v2 Individual Parameters: 
+                <select id="NumbersInfluxDBv2_value1" onchange="numberInfluxDBv2Changed()">
                 </select></b>
 			</td>
 		</tr>
@@ -1423,11 +1441,16 @@ function InitIndivParameter()
     var _index = document.getElementById("Numbers_value1");
     while (_index.length)
         _index.remove(0);
-	var _indexInflux = document.getElementById("NumbersInfluxDB_value1");
+
+	var _indexInflux = document.getElementById("NumbersInfluxDBv2_value1");
     while (_indexInflux.length)
 		_indexInflux.remove(0);
 
-    for (var i = 0; i < NUMBERS.length; ++i){
+	var _indexInfluxv1 = document.getElementById("NumbersInfluxDB_value1");
+    while (_indexInflux.length)
+	_indexInfluxv1.remove(0);
+
+	for (var i = 0; i < NUMBERS.length; ++i){
 		var option = document.createElement("option");
         option.text = NUMBERS[i]["name"];
         option.value = i;
@@ -1437,9 +1460,16 @@ function InitIndivParameter()
         optionInflux.text = NUMBERS[i]["name"];
         optionInflux.value = i;
 		_indexInflux.add(optionInflux);
-        }
+
+		var optionInfluxv1 = document.createElement("option");
+        optionInfluxv1.text = NUMBERS[i]["name"];
+        optionInfluxv1.value = i;
+		_indexInfluxv1.add(optionInfluxv1);
+
+	}
     _index.selectedIndex = 0; 
 	_indexInflux.selectedIndex = 0; 
+	_indexInfluxv1.selectedIndex = 0;
 }
 
 
@@ -1741,6 +1771,7 @@ function UpdateInputIndividual(sel)
 		ReadParameter(param, "PostProcessing", "ExtendedResolution", false, NUNBERSAkt)		
 		ReadParameter(param, "PostProcessing", "IgnoreLeadingNaN", false, NUNBERSAkt)		
 		ReadParameter(param, "PostProcessing", "AllowNegativeRates", false, NUNBERSAkt)		
+		ReadParameter(param, "InfluxDB", "Fieldname", true, NUNBERSAkt)
 		ReadParameter(param, "InfluxDBv2", "Fieldname", true, NUNBERSAkt)
 	}
 
@@ -1753,6 +1784,7 @@ function UpdateInputIndividual(sel)
 	WriteParameter(param, category, "PostProcessing", "ExtendedResolution", false, NUNBERSAkt);
 	WriteParameter(param, category, "PostProcessing", "IgnoreLeadingNaN", false, NUNBERSAkt);
 	WriteParameter(param, category, "PostProcessing", "AllowNegativeRates", false, NUNBERSAkt);
+	WriteParameter(param, category, "InfluxDB", "Fieldname", true, NUNBERSAkt);
 	WriteParameter(param, category, "InfluxDBv2", "Fieldname", true, NUNBERSAkt);
 }
 
@@ -1808,6 +1840,7 @@ function UpdateInput() {
 	WriteParameter(param, category, "InfluxDB", "Measurement", true);	
 	WriteParameter(param, category, "InfluxDB", "user", true);	
 	WriteParameter(param, category, "InfluxDB", "password", true);	
+	WriteParameter(param, category, "InfluxDB", "Fieldname", true);
 
 	WriteParameter(param, category, "InfluxDBv2", "Uri", true);	
 	WriteParameter(param, category, "InfluxDBv2", "Database", true);	
@@ -2086,11 +2119,26 @@ function numberChanged()
 	_neu = sel.selectedIndex;
 	UpdateInputIndividual(sel);
 
-	var _selInflux = document.getElementById("NumbersInfluxDB_value1");
+	var _selInflux = document.getElementById("NumbersInfluxDBv2_value1");
 	if (_selInflux.selectedIndex != _neu)
 		_selInflux.selectedIndex = _neu
 }
  
+function numberInfluxDBv2Changed()
+{
+	var sel = document.getElementById("NumbersInfluxDBv2_value1");
+	_neu = sel.selectedIndex;
+	UpdateInputIndividual(sel);
+
+	var _sel2 = document.getElementById("Numbers_value1");
+	if (_sel2.selectedIndex != _neu)
+		_sel2.selectedIndex = _neu
+
+	var _sel3 = document.getElementById("NumbersInfluxDB_value1");
+	if (_sel3.selectedIndex != _neu)
+		_sel3.selectedIndex = _neu
+}
+
 function numberInfluxDBChanged()
 {
 	var sel = document.getElementById("NumbersInfluxDB_value1");
@@ -2099,7 +2147,11 @@ function numberInfluxDBChanged()
 
 	var _sel2 = document.getElementById("Numbers_value1");
 	if (_sel2.selectedIndex != _neu)
-	_sel2.selectedIndex = _neu
+		_sel2.selectedIndex = _neu
+
+	var _sel3 = document.getElementById("NumbersInfluxDBv2_value1");
+	if (_sel3.selectedIndex != _neu)
+		_sel3.selectedIndex = _neu
 }
 
 LoadConfigNeu();

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -194,6 +194,7 @@ function ParseConfig() {
      ParamAddValue(param, catname, "Measurement");
      ParamAddValue(param, catname, "user");
      ParamAddValue(param, catname, "password");
+     ParamAddValue(param, catname, "Fieldname", 1, true);
 
      var catname = "InfluxDBv2";
      category[catname] = new Object(); 


### PR DESCRIPTION
In order to fully customize also the field values for InfluxDB V1, I have implemented there also numbers specific configurable field names. They now can be set independly for InfluxDB V1 and V2.

![grafik](https://user-images.githubusercontent.com/30766535/232332371-5f14e728-eb1b-41ca-9605-df14e3b46432.png)
