### PR TITLE
speed up deletion of files

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -850,6 +850,9 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
     
 //////////////////////////////////////////////////////////////
 
+    /* Redirect onto root to see the updated file list */
+    httpd_resp_set_status(req, "303 See Other");
+    httpd_resp_set_hdr(req, "Location", directory.c_str());   
     httpd_resp_sendstr(req, "File successfully deleted");
     return ESP_OK;
 }

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -846,6 +846,11 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
             /* Delete file */
             unlink(filepath);
         }
+
+        char *pos = strrchr(filename, '/');
+        *pos = '\0'; // Cut off filename
+        directory = std::string(filename);
+        directory = "/fileserver" + directory + "/";
     }
     
 //////////////////////////////////////////////////////////////

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -837,18 +837,17 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
             return ESP_FAIL;
         }
 
-        if (stat(filepath, &file_stat) == -1) {
-            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File does not exist: " + string(filename));
-            /* Respond with 400 Bad Request */
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "File does not exist");
-            return ESP_FAIL;
+        if (stat(filepath, &file_stat) == -1) { // File does not exist
+            /* This is ok, we would delete it anyway */
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "File does not exist: " + string(filename));
+        }
+        else {
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Deleting file: " + string(filename));
+            /* Delete file */
+            unlink(filepath);
         }
 
-        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Deleting file: " + string(filename));
-        /* Delete file */
-        unlink(filepath);
-
-        directory = std::string(filepath);
+        /*directory = std::string(filepath);
         size_t zw = directory.find("/");
         size_t found = zw;
         while (zw != std::string::npos)
@@ -862,7 +861,7 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
         ESP_LOGD(TAG, "Directory: %s, start_fn: %d, found: %d", directory.c_str(), start_fn, found);
         directory = directory.substr(start_fn, found - start_fn + 1);
         directory = "/fileserver" + directory;
-        ESP_LOGD(TAG, "Directory danach 4: %s", directory.c_str());
+        ESP_LOGD(TAG, "Directory danach 4: %s", directory.c_str());*/
     }
     
 
@@ -872,8 +871,10 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
 //////////////////////////////////////////////////////////////
 
     /* Redirect onto root to see the updated file list */
-    httpd_resp_set_status(req, "303 See Other");
-    httpd_resp_set_hdr(req, "Location", directory.c_str());
+    //httpd_resp_set_status(req, "303 See Other");
+    //httpd_resp_set_hdr(req, "Location", directory.c_str());
+
+    
     httpd_resp_sendstr(req, "File successfully deleted");
     return ESP_OK;
 }

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -852,7 +852,7 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
 
     /* Redirect onto root to see the updated file list */
     httpd_resp_set_status(req, "303 See Other");
-    httpd_resp_set_hdr(req, "Location", directory.c_str());   
+    httpd_resp_set_hdr(req, "Location", directory.c_str());
     httpd_resp_sendstr(req, "File successfully deleted");
     return ESP_OK;
 }

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -846,22 +846,6 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
             /* Delete file */
             unlink(filepath);
         }
-
-        /*directory = std::string(filepath);
-        size_t zw = directory.find("/");
-        size_t found = zw;
-        while (zw != std::string::npos)
-        {
-            zw = directory.find("/", found+1);  
-            if (zw != std::string::npos)
-                found = zw;
-        }
-
-        int start_fn = strlen(((struct file_server_data *)req->user_ctx)->base_path);
-        ESP_LOGD(TAG, "Directory: %s, start_fn: %d, found: %d", directory.c_str(), start_fn, found);
-        directory = directory.substr(start_fn, found - start_fn + 1);
-        directory = "/fileserver" + directory;
-        ESP_LOGD(TAG, "Directory danach 4: %s", directory.c_str());*/
     }
     
 

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -848,17 +848,8 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
         }
     }
     
-
-
-
-
 //////////////////////////////////////////////////////////////
 
-    /* Redirect onto root to see the updated file list */
-    //httpd_resp_set_status(req, "303 See Other");
-    //httpd_resp_set_hdr(req, "Location", directory.c_str());
-
-    
     httpd_resp_sendstr(req, "File successfully deleted");
     return ESP_OK;
 }


### PR DESCRIPTION
Loading the Alignment Marks Web Page takes several seconds. This mainly is because some files get deleted during the load. Each delete action did a folder scan on the SD-Card which took quite long.

@jomjol To my understanding the folder scanning only happened to get the directory name? I think my way is simpler and faster.

Additionally, if a file should get deleted but does not exist, this PR only threats this as an info and not an error (was responded with a HTTP 400, Bad Request).