### PR TITLE
Update PlatformIO to 6.3.2

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -19,7 +19,7 @@
 
 [common:esp32-idf]
     extends = common:idf
-    platform = platformio/espressif32 @ 6.3.1
+    platform = platformio/espressif32 @ 6.3.2
     framework = espidf
     lib_deps = 
         ${common:idf.lib_deps}


### PR DESCRIPTION
See https://github.com/platformio/platform-espressif32/releases/tag/v6.3.2

This seems to fix the build issue in https://github.com/jomjol/AI-on-the-edge-device/issues/2494