### PR TITLE
fix(fileserver): avoid sending *two* "last-chunk" sequences

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -588,7 +588,9 @@ static esp_err_t download_get_handler(httpd_req_t *req)
         /* Read file in chunks into the scratch buffer */
         chunksize = fread(chunk, 1, SERVER_FILER_SCRATCH_BUFSIZE, fd);
 
-        /* Send the buffer contents as HTTP response chunk */
+        /* Send buffer contents as HTTP chunk. If empty this functions as a
+         * last-chunk message, signaling end-of-response, to the HTTP client.
+         * See RFC 2616, section 3.6.1 for details on Chunked Transfer Encoding. */
         if (httpd_resp_send_chunk(req, chunk, chunksize) != ESP_OK) {
             fclose(fd);
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "File sending failed!");
@@ -606,8 +608,6 @@ static esp_err_t download_get_handler(httpd_req_t *req)
     fclose(fd);
     ESP_LOGD(TAG, "File successfully sent");
 
-    /* Respond with an empty chunk to signal HTTP response completion */
-    httpd_resp_send_chunk(req, NULL, 0);
     return ESP_OK;
 }
 


### PR DESCRIPTION
Because a zero-sized chunk indicates the end of a HTTP response sending another such zero-sized chunk is not interpretable by the HTTP client.

See [RFC2616 3.6.1] "Chunked Transfer Encoding" for details.

[RFC2616 3.6.1]: https://datatracker.ietf.org/doc/html/rfc2616#section-3.6.1