### PR TITLE
added support for using TLS with MQTT

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -37,6 +37,9 @@ void ClassFlowMQTT::SetInitialParameter(void)
     topicUptime = "";
     topicFreeMem = "";
 
+    caCertFilename = "";
+    clientCertFilename = "";
+    clientKeyFilename = "";
     clientname = wlan_config.hostname;
 
     OldValue = "";
@@ -102,6 +105,18 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, string& aktparamgraph)
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph))
     {
         splitted = ZerlegeZeile(aktparamgraph);
+        if ((toUpper(splitted[0]) == "CACERT") && (splitted.size() > 1))
+        {
+            this->caCertFilename = splitted[1];
+        }  
+        if ((toUpper(splitted[0]) == "CLIENTCERT") && (splitted.size() > 1))
+        {
+            this->clientCertFilename = splitted[1];
+        }  
+        if ((toUpper(splitted[0]) == "CLIENTKEY") && (splitted.size() > 1))
+        {
+            this->clientKeyFilename = splitted[1];
+        }  
         if ((toUpper(splitted[0]) == "USER") && (splitted.size() > 1))
         {
             this->user = splitted[1];
@@ -196,7 +211,8 @@ bool ClassFlowMQTT::Start(float AutoInterval)
     mqttServer_setParameter(flowpostprocessing->GetNumbers(), keepAlive, roundInterval);
 
     bool MQTTConfigCheck = MQTT_Configure(uri, clientname, user, password, maintopic, LWT_TOPIC, LWT_CONNECTED,
-                                     LWT_DISCONNECTED, keepAlive, SetRetainFlag, (void *)&GotConnected);
+                                     LWT_DISCONNECTED, caCertFilename, clientCertFilename, clientKeyFilename,
+                                     keepAlive, SetRetainFlag, (void *)&GotConnected);
 
     if (!MQTTConfigCheck) {
         return false;

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.h
@@ -19,6 +19,7 @@ protected:
     std::string OldValue;
 	ClassFlowPostProcessing* flowpostprocessing;  
     std::string user, password; 
+    std::string caCertFilename, clientCertFilename, clientKeyFilename; 
     bool SetRetainFlag;
     int keepAlive; // Seconds
     float roundInterval; // Minutes

--- a/code/components/jomjol_mqtt/interface_mqtt.h
+++ b/code/components/jomjol_mqtt/interface_mqtt.h
@@ -11,6 +11,7 @@
 
 bool MQTT_Configure(std::string _mqttURI, std::string _clientid, std::string _user, std::string _password,
                     std::string _maintopic, std::string _lwt, std::string _lwt_connected, std::string _lwt_disconnected,
+                    std::string _cacertfilename, std::string _clientcertfilename, std::string _clientkeyfilename, 
                     int _keepalive, bool SetRetainFlag, void *callbackOnConnected);
 int MQTT_Init();
 void MQTTdestroy_client(bool _disable);

--- a/sd-card/config/config.ini
+++ b/sd-card/config/config.ini
@@ -62,6 +62,9 @@ CheckDigitIncreaseConsistency = false
 RetainMessages = false
 HomeassistantDiscovery = false
 ;MeterType = other
+;CACert = /config/certs/RootCA.pem
+;ClientCert = /config/certs/client.pem.crt
+;ClientKey = /config/certs/client.pem.key
 
 ;[InfluxDB]
 ;Uri = undefined

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -753,6 +753,39 @@
 			<td>$TOOLTIP_MQTT_password</td>
 		</tr>
 
+		<tr class="MQTTItem expert" id="exMqtt">
+			<td class="indent1">
+				<input type="checkbox" id="MQTT_CACert_enabled" value="1"  onclick = 'InvertEnableItem("MQTT", "CACert")' unchecked >
+				<label for=MQTT_CACert_enabled><class id="MQTT_CACert_text" style="color:black;">Root CA Certificate file</class></label>
+			</td>
+			<td>
+				<input type="text" id="MQTT_CACert_value1">
+			</td>
+			<td>$TOOLTIP_MQTT_CACert</td>
+		</tr>
+
+		<tr class="MQTTItem expert" id="exMqtt">
+			<td class="indent1">
+				<input type="checkbox" id="MQTT_ClientCert_enabled" value="1"  onclick = 'InvertEnableItem("MQTT", "ClientCert")' unchecked >
+				<label for=MQTT_ClientCert_enabled><class id="MQTT_ClientCert_text" style="color:black;">Client Certificate file</class></label>
+			</td>
+			<td>
+				<input type="text" id="MQTT_ClientCert_value1">
+			</td>
+			<td>$TOOLTIP_MQTT_ClientCert</td>
+		</tr>
+
+		<tr class="MQTTItem expert" id="exMqtt">
+			<td class="indent1">
+				<input type="checkbox" id="MQTT_ClientKey_enabled" value="1"  onclick = 'InvertEnableItem("MQTT", "ClientKey")' unchecked >
+				<label for=MQTT_ClientKey_enabled><class id="MQTT_ClientKey_text" style="color:black;">Client Key file</class></label>
+			</td>
+			<td>
+				<input type="text" id="MQTT_ClientKey_value1">
+			</td>
+			<td>$TOOLTIP_MQTT_ClientKey</td>
+		</tr>
+
 		<tr class="MQTTItem">
 			<td class="indent1">
 				<label><class id="MQTT_RetainMessages_text" style="color:black;">Retain Messages</class></label>
@@ -2089,6 +2122,9 @@ function UpdateInput() {
     WriteParameter(param, category, "MQTT", "RetainMessages", false);
     WriteParameter(param, category, "MQTT", "HomeassistantDiscovery", false);
     WriteParameter(param, category, "MQTT", "MeterType", true);
+	WriteParameter(param, category, "MQTT", "CACert", true);
+	WriteParameter(param, category, "MQTT", "ClientCert", true);
+	WriteParameter(param, category, "MQTT", "ClientKey", true);
     
     WriteParameter(param, category, "InfluxDB", "Uri", true);	
     WriteParameter(param, category, "InfluxDB", "Database", true);	
@@ -2225,6 +2261,9 @@ function ReadParameterAll()
     ReadParameter(param, "MQTT", "RetainMessages", false);
     ReadParameter(param, "MQTT", "HomeassistantDiscovery", false);
     ReadParameter(param, "MQTT", "MeterType", true);
+	ReadParameter(param, "MQTT", "CACert", true);
+	ReadParameter(param, "MQTT", "ClientCert", true);
+	ReadParameter(param, "MQTT", "ClientKey", true);
 
     ReadParameter(param, "InfluxDB", "Uri", true);
     ReadParameter(param, "InfluxDB", "Database", true);

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -183,6 +183,9 @@ function ParseConfig() {
      ParamAddValue(param, catname, "RetainMessages");
      ParamAddValue(param, catname, "HomeassistantDiscovery");
      ParamAddValue(param, catname, "MeterType");
+     ParamAddValue(param, catname, "CACert");
+     ParamAddValue(param, catname, "ClientCert");
+     ParamAddValue(param, catname, "ClientKey");
 
      var catname = "InfluxDB";
      category[catname] = new Object(); 


### PR DESCRIPTION
 3 new entries in the config section, for setting file paths for
        - Root CA
        - Client Certificate
        - Client Private Key

If these are defined, the MQTT connection uses TLS (needed for most Cloud providers)