### PR TITLE
Update platform-espressif32 to 6.5.0

### DIFF
--- a/code/components/jomjol_fileserver_ota/miniz/miniz.h
+++ b/code/components/jomjol_fileserver_ota/miniz/miniz.h
@@ -153,7 +153,7 @@
 /*#define MINIZ_NO_MALLOC */
 
 #ifdef MINIZ_NO_INFLATE_APIS
-#define MINIZ_NO_ARCHIVE_APIS
+//#define MINIZ_NO_ARCHIVE_APIS
 #endif
 
 #ifdef MINIZ_NO_DEFLATE_APIS

--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -547,7 +547,7 @@ static esp_err_t download_get_handler(httpd_req_t *req)
                 /* Get value of expected key from query string */
                 if (httpd_query_key_value(buf, "readonly", param, sizeof(param)) == ESP_OK) {
                     ESP_LOGI(TAG, "Found URL query parameter => readonly=%s", param);
-                    readonly = param && strcmp(param,"true")==0;
+                    readonly = (strcmp(param,"true") == 0);
                 }
             }
         }

--- a/code/components/jomjol_helper/sdcard_check.cpp
+++ b/code/components/jomjol_helper/sdcard_check.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <unistd.h>
 #include <inttypes.h>
 #include <sys/stat.h>
 

--- a/code/components/jomjol_time_sntp/CMakeLists.txt
+++ b/code/components/jomjol_time_sntp/CMakeLists.txt
@@ -2,6 +2,6 @@ FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."
-                    REQUIRES esp-tflite-micro jomjol_logfile jomjol_configfile)
+                    REQUIRES esp_netif esp-tflite-micro jomjol_logfile jomjol_configfile)
 
 

--- a/code/components/jomjol_wlan/connect_wlan.cpp
+++ b/code/components/jomjol_wlan/connect_wlan.cpp
@@ -378,7 +378,7 @@ void wifi_scan(void)
 	else {
     	if (esp_wifi_scan_get_ap_records(&max_number_of_ap_found, wifi_ap_records) != ESP_OK) { // Retrieve results (and free internal heap)
 			LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "wifi_scan: esp_wifi_scan_get_ap_records: Error retrieving datasets");
-			delete wifi_ap_records;
+			delete[] wifi_ap_records;
 			return;
 		}
 	}
@@ -401,7 +401,7 @@ void wifi_scan(void)
 			APWithBetterRSSI = true;
         }
 	}
-	delete wifi_ap_records;
+	delete[] wifi_ap_records;
 }
 
 

--- a/code/dependencies.lock
+++ b/code/dependencies.lock
@@ -1,3 +1,16 @@
-manifest_hash: 63f5c6c9f0bcebc7b9ca12d2aa8b26b2c5f5218d377dc4b2375d9b9ca1df7815
+dependencies:
+  espressif/esp-nn:
+    component_hash: b32869798bdb40dec6bc99caca48cd65d42f8a9f506b9ab9c598a076f891ede9
+    source:
+      pre_release: true
+      service_url: https://api.components.espressif.com/
+      type: service
+    version: 1.0.2
+  idf:
+    component_hash: null
+    source:
+      type: idf
+    version: 5.1.2
+manifest_hash: a5f7be33336cfab90d6c2eb74757b616296d8c1e61665336749ed18905905567
 target: esp32
 version: 1.0.0

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -19,7 +19,7 @@
 
 [common:esp32-idf]
     extends = common:idf
-    platform = platformio/espressif32 @ 6.3.2
+    platform = platformio/espressif32 @ 6.5.0
     framework = espidf
     lib_deps = 
         ${common:idf.lib_deps}


### PR DESCRIPTION
This updated the ESP IDF from ` v5.0.2` to `v5.1.2`.

## Memory usage:
### Old
```
RAM:   [==        ]  15.4% (used 50312 bytes from 327680 bytes)
Flash: [========  ]  75.9% (used 1477473 bytes from 1945600 bytes)
```
### New
```
RAM:   [==        ]  15.6% (used 51004 bytes from 327680 bytes)
Flash: [========  ]  76.9% (used 1496737 bytes from 1945600 bytes)
```