### PR TITLE
Implemented late analog / digital transition

### DIFF
--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -118,6 +118,8 @@ extern "C" void app_main()
     RUN_TEST(test_doFlowPP2);
     RUN_TEST(test_doFlowPP3);
     RUN_TEST(test_doFlowPP4);
+    RUN_TEST(test_doFlowLateTransition);
+    RUN_TEST(test_doFlowEarlyTransition);
 
     // getReadoutRawString test
     RUN_TEST(test_getReadoutRawString);

--- a/sd-card/html/edit_config_param.html
+++ b/sd-card/html/edit_config_param.html
@@ -628,8 +628,8 @@
 				<label for=PostProcessing_AnalogDigitalTransitionStart_enabled><class id="PostProcessing_AnalogDigitalTransitionStart_text" style="color:black;">Analog/Digital Transition Start</class></label>
 			</td>
 			<td>
-				<input required type="number" id="PostProcessing_AnalogDigitalTransitionStart_value1" step="0.1" min="6.0" max="9.9" value="9.2"
-					oninput="(!validity.rangeUnderflow||(value=6.0)) && (!validity.rangeOverflow||(value=9.9)) && 
+				<input required type="number" id="PostProcessing_AnalogDigitalTransitionStart_value1" step="0.1" min="0.1" max="9.9" value="9.2"
+					oninput="(!validity.rangeUnderflow||(value=0.1)) && (!validity.rangeOverflow||(value=9.9)) && 
 						(!validity.stepMismatch||(value=parseInt(this.value)));">
 			</td>
 			<td>$TOOLTIP_PostProcessing_NUMBER.AnalogDigitalTransitionStart</td>


### PR DESCRIPTION
This PR implements a new analog / digital sync algorithm.

It mostly implements the case, when the last digit transitions late (e.g. after the analog value has passed zero).

Note: there are two tests failing, in particular

```cpp
    digits = { 1.1, 9.0, 4.0};
    analogs = { 9.1, 2.6, 6.25, 9.7};
    expected = "194.9259";
```
(Returns 193.9259)

Here, the accumulated post-comma value is 9.26, which is larger than 9.2 - the transition has already passed. To fix this, we could evaluate only the first analog value instead. To be discussed...

The second test failing is:

```cpp
      digits = { 1.0, 4.0, 2.0};  // 141.9269 als falsches Ergebnis
      analogs = { 9.2, 2.5, 6.8, 9.0};
      expected = "142.9269";
```
(Returns  141.9269)

In  this case, the transition value is 9.2. According to my interpretation, the 9.2 is incorrectly set, as the transition has not yet started for this test case. To be discussed...

Fixes #2743 