### PR TITLE
Bugfix InfluxDB shifting times

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
@@ -34,6 +34,7 @@ struct NumberPost {
     bool AllowNegativeRates;
     bool checkDigitIncreaseConsistency;
     time_t lastvalue;
+    time_t timeStampTimeUTC;
     string timeStamp;
     double FlowRateAct; // m3 / min
     double PreValue; // last value that was read out well

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
@@ -137,6 +137,7 @@ bool ClassFlowInfluxDB::doFlow(string zwtime)
     std::string resultraw = "";
     std::string resultrate = "";
     std::string resulttimestamp = "";
+    long int timeutc;
     string zw = "";
     string namenumber = "";
 
@@ -152,6 +153,7 @@ bool ClassFlowInfluxDB::doFlow(string zwtime)
             resulterror = (*NUMBERS)[i]->ErrorMessageText;
             resultrate = (*NUMBERS)[i]->ReturnRateValue;
             resulttimestamp = (*NUMBERS)[i]->timeStamp;
+            timeutc = (*NUMBERS)[i]->timeStampTimeUTC;
 
             if ((*NUMBERS)[i]->FieldV1.length() > 0)
             {
@@ -167,7 +169,7 @@ bool ClassFlowInfluxDB::doFlow(string zwtime)
             }
 
             if (result.length() > 0)   
-                InfluxDBPublish(measurement, namenumber, result, resulttimestamp);
+                InfluxDBPublish(measurement, namenumber, result, timeutc);
         }
     }
    

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
@@ -196,6 +196,7 @@ bool ClassFlowInfluxDBv2::doFlow(string zwtime)
     std::string resultraw = "";
     std::string resultrate = "";
     std::string resulttimestamp = "";
+    long int resulttimeutc = 0;
     string zw = "";
     string namenumber = "";
 
@@ -212,6 +213,8 @@ bool ClassFlowInfluxDBv2::doFlow(string zwtime)
             resulterror = (*NUMBERS)[i]->ErrorMessageText;
             resultrate = (*NUMBERS)[i]->ReturnRateValue;
             resulttimestamp = (*NUMBERS)[i]->timeStamp;
+            resulttimeutc = (*NUMBERS)[i]->timeStampTimeUTC;
+
 
             if ((*NUMBERS)[i]->FieldV2.length() > 0)
             {
@@ -229,8 +232,7 @@ bool ClassFlowInfluxDBv2::doFlow(string zwtime)
             printf("vor sende Influx_DB_V2 - namenumber. %s, result: %s, timestampt: %s", namenumber.c_str(), result.c_str(), resulttimestamp.c_str());
 
             if (result.length() > 0)   
-                InfluxDB_V2_Publish(measurement, namenumber, result, resulttimestamp);
-//                InfluxDB_V2_Publish(namenumber, result, resulttimestamp);
+                InfluxDB_V2_Publish(measurement, namenumber, result, resulttimeutc);
         }
     }
    

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -285,6 +285,7 @@ void ClassFlowPostProcessing::SavePreValue()
         struct tm* timeinfo = localtime(&NUMBERS[j]->lastvalue);
         strftime(buffer, 80, PREVALUE_TIME_FORMAT_OUTPUT, timeinfo);
         NUMBERS[j]->timeStamp = std::string(buffer);
+        NUMBERS[j]->timeStampTimeUTC = NUMBERS[j]->lastvalue;
 //        ESP_LOGD(TAG, "SaverPreValue %d, Value: %f, Nachkomma %d", j, NUMBERS[j]->PreValue, NUMBERS[j]->Nachkomma);
 
         _zw = NUMBERS[j]->name + "\t" + NUMBERS[j]->timeStamp + "\t" + RundeOutput(NUMBERS[j]->PreValue, NUMBERS[j]->Nachkomma) + "\n";

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -51,13 +51,17 @@ void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string
     {
         struct tm tm;
         time_t t;
+        long int influxt;
 
         strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
         t = mktime(&tm);
-//        t = t + LocalTimeToUTCOffsetSeconds;
+//        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "t zuerst: " + std::to_string(t));
+        influxt = t;
+        influxt = influxt + LocalTimeToUTCOffsetSeconds;
+//        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "influx t: " + std::to_string(influxt));
 
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
-        sprintf(nowTimestamp,"%ld000000000", (long) t);           // UTC
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp: " + _timestamp + ", Timestamp (UTC): " + std::to_string(influxt));
+        sprintf(nowTimestamp,"%ld000000000", (long) influxt);           // UTC
         payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
     }
     else
@@ -166,9 +170,10 @@ void InfluxDBPublish(std::string _measurement, std::string _key, std::string _co
 
         strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
         t = mktime(&tm);
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "t zuerst: " + std::to_string(t));
         influxt = t;
-        influxt = influxt + LocalTimeToUTCOffsetSeconds;
-//        t = t + LocalTimeToUTCOffsetSeconds;
+//        influxt = influxt + LocalTimeToUTCOffsetSeconds;
+//        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "influx t: " + std::to_string(influxt));
 
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp: " + _timestamp + ", Timestamp (UTC): " + std::to_string(influxt));
         sprintf(nowTimestamp,"%ld000000000", (long) influxt);           // UTC

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -50,20 +50,19 @@ void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string
     if (_timestamp.length() > 0)
     {
         struct tm tm;
-
         time_t t;
-        time(&t);
-        localtime_r(&t, &tm); // Extract DST setting from actual time to consider it for timestamp evaluation
 
         strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
         t = mktime(&tm);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
+//        t = t + LocalTimeToUTCOffsetSeconds;
 
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
         sprintf(nowTimestamp,"%ld000000000", (long) t);           // UTC
         payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
     }
     else
     {
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "no timestamp given");
         payload = _measurement + " " + _key + "=" + _content;
     }
 
@@ -163,24 +162,21 @@ void InfluxDBPublish(std::string _measurement, std::string _key, std::string _co
     {
         struct tm tm;
         time_t t;
+        long int influxt;
 
         strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
         t = mktime(&tm);
+        influxt = t;
+        influxt = influxt + LocalTimeToUTCOffsetSeconds;
 //        t = t + LocalTimeToUTCOffsetSeconds;
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp vorher: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
-/*
-        time(&t);
-        localtime_r(&t, &tm); // Extract DST setting from actual time to consider it for timestamp evaluation
 
-        strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
-        t = mktime(&tm);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp nachher: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
-*/
-        sprintf(nowTimestamp,"%ld000000000", (long) t);           // UTC
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp: " + _timestamp + ", Timestamp (UTC): " + std::to_string(influxt));
+        sprintf(nowTimestamp,"%ld000000000", (long) influxt);           // UTC
         payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
     }
     else
     {
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "no timestamp given");
         payload = _measurement + " " + _key + "=" + _content;
     }
 

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -161,14 +161,20 @@ void InfluxDBPublish(std::string _measurement, std::string _key, std::string _co
     if (_timestamp.length() > 0)
     {
         struct tm tm;
-
         time_t t;
+
+        strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
+        t = mktime(&tm);
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp vorher: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
+
+
+
         time(&t);
         localtime_r(&t, &tm); // Extract DST setting from actual time to consider it for timestamp evaluation
 
         strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
         t = mktime(&tm);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp nachher: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
 
         sprintf(nowTimestamp,"%ld000000000", (long) t);           // UTC
         payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -166,7 +166,7 @@ void InfluxDBPublish(std::string _measurement, std::string _key, std::string _co
 
         strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
         t = mktime(&tm);
-        t = t + LocalTimeToUTCOffsetSeconds;
+//        t = t + LocalTimeToUTCOffsetSeconds;
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp vorher: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
 /*
         time(&t);

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -5,6 +5,7 @@
 #include <time.h>
 #include "ClassLogFile.h"
 #include "esp_http_client.h"
+#include "time_sntp.h"
 #include "../../include/defines.h"
 
 
@@ -165,6 +166,7 @@ void InfluxDBPublish(std::string _measurement, std::string _key, std::string _co
 
         strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
         t = mktime(&tm);
+        t = t + LocalTimeToUTCOffsetSeconds;
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp vorher: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
 
 

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -31,7 +31,7 @@ void InfluxDB_V2_Init(std::string _uri, std::string _bucket, std::string _org, s
     _influxDB_V2_Token = _token;
 }
 
-void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp) 
+void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC) 
 {
     char response_buffer[MAX_HTTP_OUTPUT_BUFFER] = {0};
     esp_http_client_config_t http_config = {
@@ -42,26 +42,15 @@ void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string
        .user_data = response_buffer
     };
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDB_V2_Publish - Key: " + _key + ", Content: " + _content + ", Timestamp: " + _timestamp);
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDB_V2_Publish - Key: " + _key + ", Content: " + _content + ", timeUTC: " + std::to_string(_timeUTC));
 
     std::string payload;
     char nowTimestamp[21];
 
-    if (_timestamp.length() > 0)
+    if (_timeUTC > 0)
     {
-        struct tm tm;
-        time_t t;
-        long int influxt;
-
-        strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
-        t = mktime(&tm);
-//        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "t zuerst: " + std::to_string(t));
-        influxt = t;
-        influxt = influxt + LocalTimeToUTCOffsetSeconds;
-//        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "influx t: " + std::to_string(influxt));
-
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp: " + _timestamp + ", Timestamp (UTC): " + std::to_string(influxt));
-        sprintf(nowTimestamp,"%ld000000000", (long) influxt);           // UTC
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp (UTC): " + std::to_string(_timeUTC));
+        sprintf(nowTimestamp,"%ld000000000", _timeUTC);           // UTC
         payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
     }
     else
@@ -141,7 +130,7 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
     return ESP_OK;
 }
 
-void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp) {
+void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC) {
     char response_buffer[MAX_HTTP_OUTPUT_BUFFER] = {0};
     esp_http_client_config_t http_config = {
        .user_agent = "ESP32 Meter reader",
@@ -160,23 +149,12 @@ void InfluxDBPublish(std::string _measurement, std::string _key, std::string _co
     std::string payload;
     char nowTimestamp[21];
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDBPublish - Key: " + _key + ", Content: " + _content + ", Timestamp: " + _timestamp);
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDBPublish - Key: " + _key + ", Content: " + _content + ", timeUTC: " + std::to_string(_timeUTC));
 
-    if (_timestamp.length() > 0)
+    if (_timeUTC > 0)
     {
-        struct tm tm;
-        time_t t;
-        long int influxt;
-
-        strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
-        t = mktime(&tm);
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "t zuerst: " + std::to_string(t));
-        influxt = t;
-//        influxt = influxt + LocalTimeToUTCOffsetSeconds;
-//        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "influx t: " + std::to_string(influxt));
-
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp: " + _timestamp + ", Timestamp (UTC): " + std::to_string(influxt));
-        sprintf(nowTimestamp,"%ld000000000", (long) influxt);           // UTC
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp (UTC): " + std::to_string(_timeUTC));
+        sprintf(nowTimestamp,"%ld000000000", _timeUTC);           // UTC
         payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
     }
     else

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -168,16 +168,14 @@ void InfluxDBPublish(std::string _measurement, std::string _key, std::string _co
         t = mktime(&tm);
         t = t + LocalTimeToUTCOffsetSeconds;
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp vorher: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
-
-
-
+/*
         time(&t);
         localtime_r(&t, &tm); // Extract DST setting from actual time to consider it for timestamp evaluation
 
         strptime(_timestamp.c_str(), PREVALUE_TIME_FORMAT_OUTPUT, &tm);
         t = mktime(&tm);
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp nachher: " + _timestamp + ", Timestamp (UTC): " + std::to_string(t));
-
+*/
         sprintf(nowTimestamp,"%ld000000000", (long) t);           // UTC
         payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
     }

--- a/code/components/jomjol_influxdb/interface_influxdb.h
+++ b/code/components/jomjol_influxdb/interface_influxdb.h
@@ -10,11 +10,11 @@
 
 // Interface to InfluxDB v1.x
 void InfluxDBInit(std::string _influxDBURI, std::string _database, std::string _user, std::string _password);
-void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp);
+void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC);
 
 // Interface to InfluxDB v2.x
 void InfluxDB_V2_Init(std::string _uri, std::string _bucket, std::string _org, std::string _token);
-void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string _content, std::string _timestamp);
+void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC);
 
 
 

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -94,19 +94,25 @@ void setTimeZone(std::string _tzstring)
     setenv("TZ", _tzstring.c_str(), 1);
     tzset();    
 
-    _tzstring = "Time zone set to v1 " + _tzstring;
+    _tzstring = "Time zone set to " + _tzstring;
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, _tzstring);
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Dies ist ein Test!");
+//    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Dies ist ein Test!");
 
-    time_t now, t;
-    struct tm timeinfo;
+    time_t now, t, rawtime;
+    struct tm timeinfo, *ptm;
     time (&now);
     localtime_r(&now, &timeinfo);
     t = mktime(&timeinfo);
     int zwLocalTimeToUTCOffset = t - now;
 
+    time(&rawtime);
+    ptm = gmtime(&rawtime);    
 
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "LocalTimeToUTCOffset: " + std::to_string(zwLocalTimeToUTCOffset));
+    char buffer[80];
+    strftime(buffer, 80, "%z", &timeinfo);
+    std::string zw = std::string(buffer);
+
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "LocalTimeToUTCOffset: " + zw);
 }
 
 

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -93,8 +93,18 @@ void setTimeZone(std::string _tzstring)
 {
     setenv("TZ", _tzstring.c_str(), 1);
     tzset();    
+
     _tzstring = "Time zone set to " + _tzstring;
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, _tzstring);
+
+    time_t now, t;
+    struct tm timeinfo;
+    time (&now);
+    localtime_r(&now, &timeinfo);
+    t = mktime(&timeinfo);
+    int zwLocalTimeToUTCOffset = t - now;
+
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "LocalTimeToUTCOffset: " + std::to_string(zwLocalTimeToUTCOffset));
 }
 
 

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -101,23 +101,19 @@ int getUTCOffsetSeconds(std::string &zeitzone)
     time_t now;
     struct tm timeinfo;
 
-
     time (&now);
     localtime_r(&now, &timeinfo);
     char buffer[80];
     strftime(buffer, 80, "%z", &timeinfo);
-    std::string zw = std::string(buffer);
-    zeitzone = zw;
+    zeitzone = std::string(buffer);
 
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "LocalTimeToUTCOffset: Zeitzonne " + zw);
-
-    if (zw.length() == 5)
+    if (zeitzone.length() == 5)
     {
-        if (zw[0] == '-')
+        if (zeitzone[0] == '-')
             vorzeichen = -1; 
 
-        stunden = stoi(zw.substr(1, 2));
-        minuten = stoi(zw.substr(3, 2));
+        stunden = stoi(zeitzone.substr(1, 2));
+        minuten = stoi(zeitzone.substr(3, 2));
 
         offset = ((stunden * 60) + minuten) * 60;
     }
@@ -136,7 +132,7 @@ void setTimeZone(std::string _tzstring)
     std::string zeitzone;
     LocalTimeToUTCOffsetSeconds = getUTCOffsetSeconds(zeitzone);
 //    std::string zw = std::to_string(LocalTimeToUTCOffsetSeconds);
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Zeitzone: " + zeitzone + " DeltaUTC: " + std::to_string(LocalTimeToUTCOffsetSeconds) + " seconds");
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "time zone: " + zeitzone + " Delta to UTC: " + std::to_string(LocalTimeToUTCOffsetSeconds) + " seconds");
 }
 
 

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -94,8 +94,9 @@ void setTimeZone(std::string _tzstring)
     setenv("TZ", _tzstring.c_str(), 1);
     tzset();    
 
-    _tzstring = "Time zone set to " + _tzstring;
+    _tzstring = "Time zone set to v1 " + _tzstring;
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, _tzstring);
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Dies ist ein Test!");
 
     time_t now, t;
     struct tm timeinfo;
@@ -104,7 +105,8 @@ void setTimeZone(std::string _tzstring)
     t = mktime(&timeinfo);
     int zwLocalTimeToUTCOffset = t - now;
 
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "LocalTimeToUTCOffset: " + std::to_string(zwLocalTimeToUTCOffset));
+
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "LocalTimeToUTCOffset: " + std::to_string(zwLocalTimeToUTCOffset));
 }
 
 

--- a/code/components/jomjol_time_sntp/time_sntp.cpp
+++ b/code/components/jomjol_time_sntp/time_sntp.cpp
@@ -92,7 +92,7 @@ bool time_manual_reset_sync(void)
 }
 
 
-int getUTCOffsetSeconds()
+int getUTCOffsetSeconds(std::string &zeitzone)
 {
     int offset = 0;
     int vorzeichen = 1;
@@ -107,8 +107,9 @@ int getUTCOffsetSeconds()
     char buffer[80];
     strftime(buffer, 80, "%z", &timeinfo);
     std::string zw = std::string(buffer);
+    zeitzone = zw;
 
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "LocalTimeToUTCOffset: Zeitzohne " + zw);
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "LocalTimeToUTCOffset: Zeitzonne " + zw);
 
     if (zw.length() == 5)
     {
@@ -131,24 +132,11 @@ void setTimeZone(std::string _tzstring)
 
     _tzstring = "Time zone set to " + _tzstring;
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, _tzstring);
-//    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Dies ist ein Test!");
 
-    time_t now, t, rawtime;
-    struct tm timeinfo, *ptm;
-    time (&now);
-    localtime_r(&now, &timeinfo);
-    t = mktime(&timeinfo);
-    int zwLocalTimeToUTCOffset = t - now;
-
-    time(&rawtime);
-    ptm = gmtime(&rawtime);    
-
-    LocalTimeToUTCOffsetSeconds = getUTCOffsetSeconds();
-    std::string zw = std::to_string(LocalTimeToUTCOffsetSeconds);
-
-
-
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "LocalTimeToUTCOffset in Seconds: " + zw);
+    std::string zeitzone;
+    LocalTimeToUTCOffsetSeconds = getUTCOffsetSeconds(zeitzone);
+//    std::string zw = std::to_string(LocalTimeToUTCOffsetSeconds);
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Zeitzone: " + zeitzone + " DeltaUTC: " + std::to_string(LocalTimeToUTCOffsetSeconds) + " seconds");
 }
 
 

--- a/code/components/jomjol_time_sntp/time_sntp.h
+++ b/code/components/jomjol_time_sntp/time_sntp.h
@@ -28,7 +28,7 @@ bool setupTime();
 
 bool time_manual_reset_sync(void);
 
-// int LocalTimeToUTCOffset;
+extern int LocalTimeToUTCOffsetSeconds;
 
 
 #endif //TIMESNTP_H

--- a/code/components/jomjol_time_sntp/time_sntp.h
+++ b/code/components/jomjol_time_sntp/time_sntp.h
@@ -28,5 +28,7 @@ bool setupTime();
 
 bool time_manual_reset_sync(void);
 
+// int LocalTimeToUTCOffset;
+
 
 #endif //TIMESNTP_H


### PR DESCRIPTION
This address: https://github.com/jomjol/AI-on-the-edge-device/issues/2235

Problem has been indetified to happen in the time string to UTC conversion within the Influx-DB communication module.

This conversion has now been removed and the origin time stamp will be transfered directly to the influx db module, so no conversion with problems with mixing of local and utc time can happen there.
