### PR TITLE
fix(tflite): Fix memory leaks in tflite integration

### DIFF
--- a/code/components/jomjol_tfliteclass/CTfLiteClass.h
+++ b/code/components/jomjol_tfliteclass/CTfLiteClass.h
@@ -5,39 +5,18 @@
 
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
-#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
-#include "tensorflow/lite/micro/kernels/micro_ops.h"
-
-#include "tensorflow/lite/micro/tflite_bridge/micro_error_reporter.h"
-#include "tensorflow/lite/micro/micro_interpreter.h"
 #include "tensorflow/lite/schema/schema_generated.h"
-#include "tensorflow/lite/micro/kernels/micro_ops.h"
+
 #include "esp_err.h"
 #include "esp_log.h"
 
 #include "CImageBasis.h"
 
 
-
-#ifdef SUPRESS_TFLITE_ERRORS
-#include "tensorflow/lite/core/api/error_reporter.h"
-#include "tensorflow/lite/micro/compatibility.h"
-#include "tensorflow/lite/micro/debug_log.h"
-///// OwnErrorReporter to prevent printing of Errors (especially unavoidable in CalculateActivationRangeQuantized@kerne_util.cc)
-namespace tflite {
-    class OwnMicroErrorReporter : public ErrorReporter {
-        public:
-           int Report(const char* format, va_list args) override;
-    };
-}  // namespace tflite
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-#endif
-
-
 class CTfLiteClass
 {
     protected:
-        tflite::ErrorReporter *error_reporter;
+        tflite::MicroMutableOpResolver<10> resolver;  
         const tflite::Model* model;
         tflite::MicroInterpreter* interpreter;
         TfLiteTensor* output = nullptr;     
@@ -54,6 +33,7 @@ class CTfLiteClass
 
         long GetFileSize(std::string filename);
         bool ReadFileToModel(std::string _fn);
+        void MakeStaticResolver();
 
     public:
         CTfLiteClass();
@@ -73,7 +53,5 @@ class CTfLiteClass
         void GetInputDimension(bool silent);
         int ReadInputDimenstion(int _dim);
 };
-
-void MakeStaticResolver();
 
 #endif //CTFLITECLASS_H

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -167,15 +167,6 @@
     #define LWT_DISCONNECTED "connection lost"
 
 
-    //CTfLiteClass
-    #define TFLITE_MINIMAL_CHECK(x)                              \
-        if (!(x)) {                                                \
-            fprintf(stderr, "Error at %s:%d\n", __FILE__, __LINE__); \
-            exit(1);                                                 \
-        }
-    // #define SUPRESS_TFLITE_ERRORS // use, to avoid error messages from TFLITE
-
-
     // connect_wlan.cpp
     //******************************
     /* WIFI roaming functionalities 802.11k+v (uses ca. 6kB - 8kB internal RAM; if SCAN CACHE activated: + 1kB / beacon)


### PR DESCRIPTION
- Fix memory leaks in TFLite integration
  - Fix OP resolver loading
  - Fix leak in error reporter handling (missing deletion) 
    --> reporter functionality deleted entirely (optional feature and was not fully implemented at all)
- Cleanup header includes and unsued tlfite defines