### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,7 +396,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       
     - name: Get version of last release
       id: last_release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,4 +427,4 @@ jobs:
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v3
+      uses: actions/deploy-pages@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
   release: 
     runs-on: ubuntu-latest
     needs: [pack-for-update, pack-for-manual_setup, pack-for-remote_setup]
-    #Disabled for testing if: startsWith(github.ref, 'refs/tags/') 
+    if: startsWith(github.ref, 'refs/tags/') 
 
     # Sets permissions of the GITHUB_TOKEN to allow updating the branches
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
   release: 
     runs-on: ubuntu-latest
     needs: [pack-for-update, pack-for-manual_setup, pack-for-remote_setup]
-    if: startsWith(github.ref, 'refs/tags/') 
+    #Disabled for testing if: startsWith(github.ref, 'refs/tags/') 
 
     # Sets permissions of the GITHUB_TOKEN to allow updating the branches
     permissions:
@@ -396,7 +396,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       
     - name: Get version of last release
       id: last_release
@@ -416,14 +416,15 @@ jobs:
         echo "Updating index and manifest file..."
         sed -i 's/$VERSION/${{ steps.last_release.outputs.tag_name }}/g' docs/index.html
         sed -i 's/$VERSION/${{ steps.last_release.outputs.tag_name }}/g' docs/manifest.json
+
     - name: Setup Pages
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@v2
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v1
       with:
         path: 'docs'
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v1  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,4 +427,4 @@ jobs:
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4  
+      uses: actions/deploy-pages@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,4 +427,4 @@ jobs:
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1  
+      uses: actions/deploy-pages@v4  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,4 +427,4 @@ jobs:
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,4 +427,4 @@ jobs:
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v3  # Note: v4 does not work!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,10 +418,10 @@ jobs:
         sed -i 's/$VERSION/${{ steps.last_release.outputs.tag_name }}/g' docs/manifest.json
 
     - name: Setup Pages
-      uses: actions/configure-pages@v2
+      uses: actions/configure-pages@v4
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v2
       with:
         path: 'docs'
 


### PR DESCRIPTION
`deploy-pages@v4` fails to work:
```

0s
Run actions/deploy-pages@v4
Fetching artifact metadata for "github-pages" in this workflow run
Found 3 artifact(s)
Error: Fetching artifact metadata failed. Is githubstatus.com reporting issues with API requests, Pages, or Actions? Please re-run the deployment at a later time.
Error: Error: No artifacts named "github-pages" were found for this workflow run. Ensure artifacts are uploaded with actions/artifact@v4 or later.
    at getArtifactMetadata (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/api-client.js:85:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/deployment.js:66:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4/src/index.js:30:1)
Error: Error: No artifacts named "github-pages" were found for this workflow run. Ensure artifacts are uploaded with actions/artifact@v4 or later.
```