### PR TITLE
Fixed problems when decimal shifts != 0

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
@@ -31,7 +31,6 @@ protected:
     ClassFlowTakeImage *flowTakeImage;
 
     bool LoadPreValue(void);
-    string ShiftDecimal(string in, int _decShift);
 
     string ErsetzteN(string, double _prevalue);
     float checkDigitConsistency(double input, int _decilamshift, bool _isanalog, double _preValue);
@@ -78,6 +77,8 @@ public:
     std::vector<NumberPost*>* GetNumbers(){return &NUMBERS;};
 
     string name(){return "ClassFlowPostProcessing";};
+
+    static string ShiftDecimal(string in, int _decShift);
 };
 
 

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -138,6 +138,14 @@ void task_UnityTesting(void *pvParameter)
         RUN_TEST(test_doFlowPP3);
         printf("---------------------------------------------------------------------------\n");
         RUN_TEST(test_doFlowPP4);
+        printf("---------------------------------------------------------------------------\n");
+        RUN_TEST(test_doFlowLateTransition);
+        printf("---------------------------------------------------------------------------\n");
+        RUN_TEST(test_doFlowEarlyTransition);
+        printf("---------------------------------------------------------------------------\n");
+        RUN_TEST(test_doFlowIssue2857);
+        printf("---------------------------------------------------------------------------\n");
+        RUN_TEST(test_doFlowLateTransitionHanging);
     UNITY_END();
 
     while(1);
@@ -149,26 +157,11 @@ void task_UnityTesting(void *pvParameter)
  */
 extern "C" void app_main()
 {
-  initGPIO();
-  Init_NVS_SDCard();
-  esp_log_level_set("*", ESP_LOG_DEBUG);        // set all components to ERROR level
+    initGPIO();
+    Init_NVS_SDCard();
+    esp_log_level_set("*", ESP_LOG_DEBUG);        // set all components to DEBUG level
 
-  UNITY_BEGIN();
-    RUN_TEST(testNegative_Issues);
-   RUN_TEST(testNegative);
-   /*
-    RUN_TEST(test_analogToDigit_Standard);
-    RUN_TEST(test_analogToDigit_Transition);
-    RUN_TEST(test_doFlowPP);
-    RUN_TEST(test_doFlowPP1);
-    RUN_TEST(test_doFlowPP2);
-    RUN_TEST(test_doFlowPP3);
-    RUN_TEST(test_doFlowPP4);
-    RUN_TEST(test_doFlowLateTransition);
-    RUN_TEST(test_doFlowEarlyTransition);
-
-    // getReadoutRawString test
-    RUN_TEST(test_getReadoutRawString);
-  */
-  UNITY_END();
+    // Create dedicated testing task (heap size can be configured - large enough to handle a lot of testing cases)
+    // ********************************************
+    xTaskCreate(&task_UnityTesting, "task_UnityTesting", 12 * 1024, NULL, tskIDLE_PRIORITY+2, NULL);
 }


### PR DESCRIPTION
The main reason was a wrong digital / analog sync, if decimal shifts were != 0.

The fix is not beautiful - I temporally revert the decimal shift to make it easier to sync the analog and digital part.
At the end, it is applied again. It works though.

I also fixed hanging digits for late transition, which happened at my own installation only.
Also reverted back to the improved unit test system of @Slider0007, which seemed to be mistakenly overwritten by someone.

Fixed #2857

@Slider0007 Please have a look, in particular at `test_suite_flowcontroll.cpp`. I went back to your testing setup. Not sure, why it was the old code again?!