### PR TITLE
  update platformIO to 6.7.0 (ESP IDF 5.2.1)

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlow.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlow.cpp
@@ -67,11 +67,6 @@ string ClassFlow::getHTMLSingleStep(string host){
 	return "";
 }
 
-string ClassFlow::getReadout()
-{
-	return string();
-}
-
 std::string ClassFlow::GetParameterName(std::string _input)
 {
     string _param;

--- a/code/components/jomjol_flowcontroll/ClassFlow.h
+++ b/code/components/jomjol_flowcontroll/ClassFlow.h
@@ -46,7 +46,6 @@ public:
 	virtual bool ReadParameter(FILE* pfile, string &aktparamgraph);
 	virtual bool doFlow(string time);
 	virtual string getHTMLSingleStep(string host);
-	virtual string getReadout();
 	virtual string name(){return "ClassFlow";};
 
 };

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -468,22 +468,7 @@ string ClassFlowControll::getReadout(bool _rawvalue = false, bool _noerror = fal
     if (flowpostprocessing)
         return flowpostprocessing->getReadoutParam(_rawvalue, _noerror, _number);
 
-    string zw = "";
-    string result = "";
-
-    for (int i = 0; i < FlowControll.size(); ++i)
-    {
-        zw = FlowControll[i]->getReadout();
-        if (zw.length() > 0)
-        {
-            if (result.length() == 0)
-                result = zw;
-            else
-                result = result + "\t" + zw;
-        }
-    }
-
-    return result;
+    return std::string("");
 }
 
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -19,7 +19,8 @@
 
 [common:esp32-idf]
     extends = common:idf
-    platform = platformio/espressif32 @ 6.5.0
+    ; PlatformIO releases, see https://github.com/platformio/platform-espressif32/releases
+    platform = platformio/espressif32 @ 6.7.0
     framework = espidf
     lib_deps = 
         ${common:idf.lib_deps}


### PR DESCRIPTION
## TODO
- [x] Fix errors
  ```
  components/jomjol_flowcontroll/ClassFlow.h:49:24: error: 'virtual std::string ClassFlow::getReadout()' was hidden [-Werror=overloaded-virtual=]
   49 |         virtual string getReadout();
  ```
- [x] Currently throws warnings due to
  ```
   components/jomjol_fileserver_ota/miniz/miniz.c:6250:34: warning: comparison is always false due to limited range of data type [-Wtype-limits]
   6250 |         if (((mz_uint64)buf_size > 0xFFFFFFFF) || (uncomp_size > 0xFFFFFFFF))
        | 
  ```
  
  See https://github.com/richgel999/miniz/issues/303