### PR TITLE
Bugfix for boot loop

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -19,7 +19,6 @@ static const char* TAG = "CNN";
     static heap_trace_record_t trace_record[NUM_RECORDS]; // This buffer must be in internal RAM
 #endif
 
-
 ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalign, t_CNNType _cnntype) : ClassFlowImage(NULL, TAG) {
     string cnnmodelfile = "";
     modelxsize = 1;
@@ -35,7 +34,6 @@ ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalign, t_CNNTy
     flowpostalignment = _flowalign;
     imagesRetention = 5;
 }
-
 
 string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution, int prev, float _before_narrow_Analog, float analogDigitalTransitionStart) {
     string result = "";    
@@ -198,7 +196,6 @@ int ClassFlowCNNGeneral::PointerEvalHybridNew(float number, float number_of_pred
         return result;
     }
 
-    
     // remains only >= 9.x --> no zero crossing yet --> 2.8 --> 2, 
     // and from 9.7(DigitalTransitionRangeLead) 3.1 --> 2
     // everything >=x.4 can be considered as current number in transition. With 9.x predecessor the current
@@ -218,7 +215,6 @@ int ClassFlowCNNGeneral::PointerEvalHybridNew(float number, float number_of_pred
                                                 " number: " + std::to_string(number) + " number_of_predecessors = " + std::to_string(number_of_predecessors)+ " eval_predecessors = " + std::to_string(eval_predecessors) + " Digital_Uncertainty = " +  std::to_string(Digital_Uncertainty) + " result_after_decimal_point = " + std::to_string(result_after_decimal_point));
     return result;
 }
-
 
 int ClassFlowCNNGeneral::PointerEvalAnalogToDigitNew(float number, float numeral_preceder,  int eval_predecessors, float analogDigitalTransitionStart) {
     int result;
@@ -259,7 +255,6 @@ int ClassFlowCNNGeneral::PointerEvalAnalogToDigitNew(float number, float numeral
     return result;
 }
 
-
 int ClassFlowCNNGeneral::PointerEvalAnalogNew(float number, int numeral_preceder) {
     float number_min, number_max;
     int result;
@@ -296,7 +291,6 @@ int ClassFlowCNNGeneral::PointerEvalAnalogNew(float number, int numeral_preceder
     return result;
 }
 
-
 bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, string& aktparamgraph) {
     std::vector<string> splitted;
 
@@ -322,7 +316,6 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, string& aktparamgraph) {
         return true;
     }
 
-
     while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph)) {
         splitted = ZerlegeZeile(aktparamgraph);
         if ((toUpper(splitted[0]) == "ROIIMAGESLOCATION") && (splitted.size() > 1)) {
@@ -336,7 +329,9 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, string& aktparamgraph) {
         }
 
         if ((toUpper(splitted[0]) == "ROIIMAGESRETENTION") && (splitted.size() > 1)) {
-            this->imagesRetention = std::stoi(splitted[1]);
+            if (isStringNumeric(splitted[1])) {
+                this->imagesRetention = std::stoi(splitted[1]);
+            }
         }
 
         if ((toUpper(splitted[0]) == "MODEL") && (splitted.size() > 1)) {
@@ -344,7 +339,9 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, string& aktparamgraph) {
         }
         
         if ((toUpper(splitted[0]) == "CNNGOODTHRESHOLD") && (splitted.size() > 1)) {
-            CNNGoodThreshold = std::stof(splitted[1]);
+            if (isStringNumeric(splitted[1])) {
+                CNNGoodThreshold = std::stof(splitted[1]);
+            }
         }
         
         if (splitted.size() >= 5) {
@@ -366,9 +363,7 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, string& aktparamgraph) {
         }
 
         if ((toUpper(splitted[0]) == "SAVEALLFILES") && (splitted.size() > 1)) {
-            if (toUpper(splitted[1]) == "TRUE") {
-                SaveAllFiles = true;
-            }
+            SaveAllFiles = alphanumericToBoolean(splitted[1]);
         }
     }
 
@@ -377,7 +372,6 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, string& aktparamgraph) {
         disabled = true; // An error occured, disable this CNN!
         return false;
     }
-
 
     for (int _ana = 0; _ana < GENERAL.size(); ++_ana) {
         for (int i = 0; i < GENERAL[_ana]->ROI.size(); ++i) {
@@ -391,7 +385,6 @@ bool ClassFlowCNNGeneral::ReadParameter(FILE* pfile, string& aktparamgraph) {
     return true;
 }
 
-
 general* ClassFlowCNNGeneral::FindGENERAL(string _name_number) {
     for (int i = 0; i < GENERAL.size(); ++i) {
         if (GENERAL[i]->name == _name_number) {
@@ -401,7 +394,6 @@ general* ClassFlowCNNGeneral::FindGENERAL(string _name_number) {
     
     return NULL;
 }
-
 
 general* ClassFlowCNNGeneral::GetGENERAL(string _name, bool _create = true) {
     string _analog, _roi;
@@ -445,7 +437,6 @@ general* ClassFlowCNNGeneral::GetGENERAL(string _name, bool _create = true) {
     return _ret;
 }
 
-
 string ClassFlowCNNGeneral::getHTMLSingleStep(string host) {
     string result, zw;
     std::vector<HTMLInfo*> htmlinfo;
@@ -468,7 +459,6 @@ string ClassFlowCNNGeneral::getHTMLSingleStep(string host) {
 
     return result;
 }
-
 
 bool ClassFlowCNNGeneral::doFlow(string time) {
 #ifdef HEAP_TRACING_CLASS_FLOW_CNN_GENERAL_DO_ALING_AND_CUT
@@ -499,7 +489,6 @@ bool ClassFlowCNNGeneral::doFlow(string time) {
 
     return true;
 }
-
 
 bool ClassFlowCNNGeneral::doAlignAndCut(string time) {
     if (disabled) {
@@ -537,7 +526,6 @@ bool ClassFlowCNNGeneral::doAlignAndCut(string time) {
     return true;
 } 
 
-
 void ClassFlowCNNGeneral::DrawROI(CImageBasis *_zw) {
     if (_zw->ImageOkay()) { 
         if (CNNType == Analogue || CNNType == Analogue100) {
@@ -563,7 +551,6 @@ void ClassFlowCNNGeneral::DrawROI(CImageBasis *_zw) {
         }
     }
 } 
-
 
 bool ClassFlowCNNGeneral::getNetworkParameter() {
     if (disabled) {
@@ -636,7 +623,6 @@ bool ClassFlowCNNGeneral::getNetworkParameter() {
     delete tflite;
     return true;
 }
-
 
 bool ClassFlowCNNGeneral::doNeuralNetwork(string time) {
     if (disabled) {
@@ -842,7 +828,6 @@ bool ClassFlowCNNGeneral::doNeuralNetwork(string time) {
     return true;
 }
 
-
 bool ClassFlowCNNGeneral::isExtendedResolution(int _number) {
     if (CNNType == Digital) {
         return false;
@@ -850,7 +835,6 @@ bool ClassFlowCNNGeneral::isExtendedResolution(int _number) {
     
     return true;
 }
-
 
 std::vector<HTMLInfo*> ClassFlowCNNGeneral::GetHTMLInfo() {
     std::vector<HTMLInfo*> result;
@@ -894,11 +878,9 @@ std::vector<HTMLInfo*> ClassFlowCNNGeneral::GetHTMLInfo() {
     return result;
 }
 
-
 int ClassFlowCNNGeneral::getNumberGENERAL() {
     return GENERAL.size();
 }
-
 
 string ClassFlowCNNGeneral::getNameGENERAL(int _analog) {
     if (_analog < GENERAL.size()) {
@@ -908,7 +890,6 @@ string ClassFlowCNNGeneral::getNameGENERAL(int _analog) {
     return "GENERAL DOES NOT EXIST";
 }
 
-
 general* ClassFlowCNNGeneral::GetGENERAL(int _analog) {
     if (_analog < GENERAL.size()) {
         return GENERAL[_analog];
@@ -916,7 +897,6 @@ general* ClassFlowCNNGeneral::GetGENERAL(int _analog) {
 
     return NULL;
 }
-
 
 void ClassFlowCNNGeneral::UpdateNameNumbers(std::vector<std::string> *_name_numbers) {
     for (int _dig = 0; _dig < GENERAL.size(); _dig++) {
@@ -933,7 +913,6 @@ void ClassFlowCNNGeneral::UpdateNameNumbers(std::vector<std::string> *_name_numb
         }
     }
 }
-
 
 string ClassFlowCNNGeneral::getReadoutRawString(int _analog) 
 {
@@ -963,4 +942,3 @@ string ClassFlowCNNGeneral::getReadoutRawString(int _analog)
     }
     return rt;
 }
-

--- a/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowControll.cpp
@@ -32,7 +32,6 @@ static const char* TAG = "FLOWCTRL";
 
 //#define DEBUG_DETAIL_ON
 
-
 std::string ClassFlowControll::doSingleStep(std::string _stepname, std::string _host){
     std::string _classname = "";
     std::string result = "";
@@ -68,8 +67,11 @@ std::string ClassFlowControll::doSingleStep(std::string _stepname, std::string _
 
     for (int i = 0; i < FlowControll.size(); ++i)
         if (FlowControll[i]->name().compare(_classname) == 0){
-            if (!(FlowControll[i]->name().compare("ClassFlowTakeImage") == 0))      // if it is a TakeImage, the image does not need to be included, this happens automatically with the html query.
+            if (!(FlowControll[i]->name().compare("ClassFlowTakeImage") == 0)) {
+                // if it is a TakeImage, the image does not need to be included, this happens automatically with the html query.
                 FlowControll[i]->doFlow("");
+            }
+		
             result = FlowControll[i]->getHTMLSingleStep(_host);
         }
 
@@ -78,36 +80,46 @@ std::string ClassFlowControll::doSingleStep(std::string _stepname, std::string _
     return result;
 }
 
-
 std::string ClassFlowControll::TranslateAktstatus(std::string _input)
 {
-    if (_input.compare("ClassFlowTakeImage") == 0)
+    if (_input.compare("ClassFlowTakeImage") == 0) {
         return ("Take Image");
-    if (_input.compare("ClassFlowAlignment") == 0)
+    }
+
+    if (_input.compare("ClassFlowAlignment") == 0) {
         return ("Aligning");
-    if (_input.compare("ClassFlowCNNGeneral") == 0)
+    }
+
+    if (_input.compare("ClassFlowCNNGeneral") == 0) {
         return ("Digitalization of ROIs");
+    }
+
     #ifdef ENABLE_MQTT
-        if (_input.compare("ClassFlowMQTT") == 0)
+        if (_input.compare("ClassFlowMQTT") == 0) {
             return ("Sending MQTT");
+        }
     #endif //ENABLE_MQTT
+		
     #ifdef ENABLE_INFLUXDB
-        if (_input.compare("ClassFlowInfluxDB") == 0)
+        if (_input.compare("ClassFlowInfluxDB") == 0) {
             return ("Sending InfluxDB");
-        if (_input.compare("ClassFlowInfluxDBv2") == 0)
+        }
+		
+        if (_input.compare("ClassFlowInfluxDBv2") == 0) {
             return ("Sending InfluxDBv2");
+        }
     #endif //ENABLE_INFLUXDB
-    if (_input.compare("ClassFlowPostProcessing") == 0)
+		
+    if (_input.compare("ClassFlowPostProcessing") == 0) {
         return ("Post-Processing");
+    }
 
     return "Unkown Status";
 }
 
-
 std::vector<HTMLInfo*> ClassFlowControll::GetAllDigital() 
 {
-    if (flowdigit)
-    {
+    if (flowdigit) {
         ESP_LOGD(TAG, "ClassFlowControll::GetAllDigital - flowdigit != NULL");
         return flowdigit->GetHTMLInfo();
     }
@@ -116,64 +128,62 @@ std::vector<HTMLInfo*> ClassFlowControll::GetAllDigital()
     return empty;
 }
 
-
 std::vector<HTMLInfo*> ClassFlowControll::GetAllAnalog()
 {
-    if (flowanalog)
+    if (flowanalog) {
         return flowanalog->GetHTMLInfo();
+    }
 
     std::vector<HTMLInfo*> empty;
     return empty;
 }
 
-
 t_CNNType ClassFlowControll::GetTypeDigital()
 {
-    if (flowdigit)
+    if (flowdigit) {
         return flowdigit->getCNNType();
+    }
 
     return t_CNNType::None;
 }
-
 
 t_CNNType ClassFlowControll::GetTypeAnalog()
 {
-    if (flowanalog)
+    if (flowanalog) {
         return flowanalog->getCNNType();
+    }
 
     return t_CNNType::None;
 }
-
 
 #ifdef ALGROI_LOAD_FROM_MEM_AS_JPG
 void ClassFlowControll::DigitalDrawROI(CImageBasis *_zw)
 {
-    if (flowdigit)
+    if (flowdigit) {
         flowdigit->DrawROI(_zw);
+    }
 }
-
 
 void ClassFlowControll::AnalogDrawROI(CImageBasis *_zw)
 {
-    if (flowanalog)
+    if (flowanalog) {
         flowanalog->DrawROI(_zw);
+    }
 }
 #endif
-
 
 #ifdef ENABLE_MQTT
 bool ClassFlowControll::StartMQTTService() 
 {
     /* Start the MQTT service */
-        for (int i = 0; i < FlowControll.size(); ++i) {
-            if (FlowControll[i]->name().compare("ClassFlowMQTT") == 0) {
-                return ((ClassFlowMQTT*) (FlowControll[i]))->Start(AutoInterval);
-            }  
-        } 
+    for (int i = 0; i < FlowControll.size(); ++i) {
+        if (FlowControll[i]->name().compare("ClassFlowMQTT") == 0) {
+            return ((ClassFlowMQTT*) (FlowControll[i]))->Start(AutoInterval);
+        }  
+    } 
     return false;
 }
 #endif //ENABLE_MQTT
-
 
 void ClassFlowControll::SetInitialParameter(void)
 {
@@ -189,7 +199,6 @@ void ClassFlowControll::SetInitialParameter(void)
     aktstatusWithTime = aktstatus;
 }
 
-
 bool ClassFlowControll::getIsAutoStart(void)
 {
     return AutoStart;
@@ -201,68 +210,76 @@ void ClassFlowControll::setAutoStartInterval(long &_interval)
     _interval = AutoInterval * 60 * 1000; // AutoInterval: minutes -> ms
 }
 
-
 ClassFlow* ClassFlowControll::CreateClassFlow(std::string _type)
 {
     ClassFlow* cfc = NULL;
 
     _type = trim(_type);
 
-    if (toUpper(_type).compare("[TAKEIMAGE]") == 0)
-    {
+    if (toUpper(_type).compare("[TAKEIMAGE]") == 0) {
         cfc = new ClassFlowTakeImage(&FlowControll);
         flowtakeimage = (ClassFlowTakeImage*) cfc;
     }
-    if (toUpper(_type).compare("[ALIGNMENT]") == 0)
-    {
+	
+    if (toUpper(_type).compare("[ALIGNMENT]") == 0) {
         cfc = new ClassFlowAlignment(&FlowControll);
         flowalignment = (ClassFlowAlignment*) cfc;
     }
-    if (toUpper(_type).compare("[ANALOG]") == 0)
-    {
+	
+    if (toUpper(_type).compare("[ANALOG]") == 0) {
         cfc = new ClassFlowCNNGeneral(flowalignment);
         flowanalog = (ClassFlowCNNGeneral*) cfc;
     }
-    if (toUpper(_type).compare(0, 7, "[DIGITS") == 0)
-    {
+	
+    if (toUpper(_type).compare(0, 7, "[DIGITS") == 0) {
         cfc = new ClassFlowCNNGeneral(flowalignment);
         flowdigit = (ClassFlowCNNGeneral*) cfc;
     }
+	
     #ifdef ENABLE_MQTT
-    if (toUpper(_type).compare("[MQTT]") == 0)
+    if (toUpper(_type).compare("[MQTT]") == 0) {
         cfc = new ClassFlowMQTT(&FlowControll);
+    }
     #endif //ENABLE_MQTT
+	
     #ifdef ENABLE_INFLUXDB
-    if (toUpper(_type).compare("[INFLUXDB]") == 0)
+    if (toUpper(_type).compare("[INFLUXDB]") == 0) {
         cfc = new ClassFlowInfluxDB(&FlowControll);
-    if (toUpper(_type).compare("[INFLUXDBV2]") == 0)
+    }
+
+    if (toUpper(_type).compare("[INFLUXDBV2]") == 0) {
         cfc = new ClassFlowInfluxDBv2(&FlowControll);
+    }
     #endif //ENABLE_INFLUXDB  
 
-    if (toUpper(_type).compare("[POSTPROCESSING]") == 0)
-    {
+    if (toUpper(_type).compare("[POSTPROCESSING]") == 0) {
         cfc = new ClassFlowPostProcessing(&FlowControll, flowanalog, flowdigit); 
         flowpostprocessing = (ClassFlowPostProcessing*) cfc;
     }
 
-    if (cfc)                            // Attached only if it is not [AutoTimer], because this is for FlowControll
+    if (cfc) {                           
+        // Attached only if it is not [AutoTimer], because this is for FlowControll
         FlowControll.push_back(cfc);
+    }
 
-    if (toUpper(_type).compare("[AUTOTIMER]") == 0)
-        cfc = this;    
+    if (toUpper(_type).compare("[AUTOTIMER]") == 0) {
+        cfc = this;
+    }
 
-    if (toUpper(_type).compare("[DATALOGGING]") == 0)
-        cfc = this;  
+    if (toUpper(_type).compare("[DATALOGGING]") == 0) {
+        cfc = this;
+    }
 
-    if (toUpper(_type).compare("[DEBUG]") == 0)
-        cfc = this;  
+    if (toUpper(_type).compare("[DEBUG]") == 0) {
+        cfc = this;
+    }
 
-    if (toUpper(_type).compare("[SYSTEM]") == 0)
-        cfc = this;          
+    if (toUpper(_type).compare("[SYSTEM]") == 0) {
+        cfc = this;
+    }
 
     return cfc;
 }
-
 
 void ClassFlowControll::InitFlow(std::string config)
 {
@@ -284,48 +301,43 @@ void ClassFlowControll::InitFlow(std::string config)
     line = "";
 
     char zw[1024];
-    if (pFile != NULL)
-    {
+	
+    if (pFile != NULL) {
         fgets(zw, 1024, pFile);
         ESP_LOGD(TAG, "%s", zw);
         line = std::string(zw);
     }
 
-    while ((line.size() > 0) && !(feof(pFile)))
-    {
+    while ((line.size() > 0) && !(feof(pFile))) {
         cfc = CreateClassFlow(line);
-//        printf("Name: %s\n", cfc->name().c_str());
-        if (cfc)
-        {
+        // printf("Name: %s\n", cfc->name().c_str());
+	    
+        if (cfc) {
             ESP_LOGD(TAG, "Start ReadParameter (%s)", line.c_str());
             cfc->ReadParameter(pFile, line);
         }
-        else
-        {
+        else {
             line = "";
-            if (fgets(zw, 1024, pFile) && !feof(pFile))
-                {
-                    ESP_LOGD(TAG, "Read: %s", zw);
-                    line = std::string(zw);
-                }
+		
+            if (fgets(zw, 1024, pFile) && !feof(pFile)) {
+                ESP_LOGD(TAG, "Read: %s", zw);
+                line = std::string(zw);
+            }
         }
     }
 
     fclose(pFile);
 }
 
-
 std::string* ClassFlowControll::getActStatusWithTime()
 {
     return &aktstatusWithTime;
 }
 
-
 std::string* ClassFlowControll::getActStatus()
 {
     return &aktstatus;
 }
-
 
 void ClassFlowControll::setActStatus(std::string _aktstatus)
 {
@@ -333,13 +345,11 @@ void ClassFlowControll::setActStatus(std::string _aktstatus)
     aktstatusWithTime = aktstatus;
 }
 
-
 void ClassFlowControll::doFlowTakeImageOnly(string time)
 {
     std::string zw_time;
 
-    for (int i = 0; i < FlowControll.size(); ++i)
-    {
+    for (int i = 0; i < FlowControll.size(); ++i) {
         if (FlowControll[i]->name() == "ClassFlowTakeImage") {
             zw_time = getCurrentTimeString("%H:%M:%S");
             aktstatus = TranslateAktstatus(FlowControll[i]->name());
@@ -352,7 +362,6 @@ void ClassFlowControll::doFlowTakeImageOnly(string time)
         }
     }
 }
-
 
 bool ClassFlowControll::doFlow(string time)
 {
@@ -373,8 +382,7 @@ bool ClassFlowControll::doFlow(string time)
 
     //checkNtpStatus(0);
 
-    for (int i = 0; i < FlowControll.size(); ++i)
-    {
+    for (int i = 0; i < FlowControll.size(); ++i) {
         zw_time = getCurrentTimeString("%H:%M:%S");
         aktstatus = TranslateAktstatus(FlowControll[i]->name());
         aktstatusWithTime = aktstatus + " (" + zw_time + ")";
@@ -391,7 +399,7 @@ bool ClassFlowControll::doFlow(string time)
         if (!FlowControll[i]->doFlow(time)){
             repeat++;
             LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Fehler im vorheriger Schritt - wird zum " + to_string(repeat) + ". Mal wiederholt");
-            if (i) i -= 1;    // vPrevious step must be repeated (probably take pictures)
+            if (i) { i -= 1; }   // vPrevious step must be repeated (probably take pictures)
             result = false;
             if (repeat > 5) {
                 LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Wiederholung 5x nicht erfolgreich --> reboot");
@@ -399,8 +407,7 @@ bool ClassFlowControll::doFlow(string time)
                 //Step was repeated 5x --> reboot
             }
         }
-        else
-        {
+        else {
             result = true;
         }
         
@@ -424,27 +431,29 @@ bool ClassFlowControll::doFlow(string time)
 string ClassFlowControll::getReadoutAll(int _type)
 {
     std::string out = "";
-    if (flowpostprocessing)
-    {
+	
+    if (flowpostprocessing) {
         std::vector<NumberPost*> *numbers = flowpostprocessing->GetNumbers();
 
-        for (int i = 0; i < (*numbers).size(); ++i)
-        {
+        for (int i = 0; i < (*numbers).size(); ++i) {
             out = out + (*numbers)[i]->name + "\t";
+		
             switch (_type) {
                 case READOUT_TYPE_VALUE:
                     out = out + (*numbers)[i]->ReturnValue;
                     break;
                 case READOUT_TYPE_PREVALUE:
-                    if (flowpostprocessing->PreValueUse)
-                    {
-                        if ((*numbers)[i]->PreValueOkay)
+                    if (flowpostprocessing->PreValueUse) {
+                        if ((*numbers)[i]->PreValueOkay) {
                             out = out + (*numbers)[i]->ReturnPreValue;
-                        else
-                            out = out + "PreValue too old";                
+			}
+                        else {
+                            out = out + "PreValue too old"; 
+			}
                     }
-                    else
+                    else {
                         out = out + "PreValue deactivated";
+		    }
                     break;
                 case READOUT_TYPE_RAWVALUE:
                     out = out + (*numbers)[i]->ReturnRawValue;
@@ -453,8 +462,10 @@ string ClassFlowControll::getReadoutAll(int _type)
                     out = out + (*numbers)[i]->ErrorMessageText;
                     break;
             }
-            if (i < (*numbers).size()-1)
+		
+            if (i < (*numbers).size()-1) {
                 out = out + "\r\n";
+	    }
         }
     //    ESP_LOGD(TAG, "OUT: %s", out.c_str());
     }
@@ -462,27 +473,23 @@ string ClassFlowControll::getReadoutAll(int _type)
     return out;
 }	
 
-
 string ClassFlowControll::getReadout(bool _rawvalue = false, bool _noerror = false, int _number = 0)
 {
-    if (flowpostprocessing)
+    if (flowpostprocessing) {
         return flowpostprocessing->getReadoutParam(_rawvalue, _noerror, _number);
+    }
 
     return std::string("");
 }
 
-
 string ClassFlowControll::GetPrevalue(std::string _number)	
 {
-    if (flowpostprocessing)
-    {
+    if (flowpostprocessing) {
         return flowpostprocessing->GetPreValue(_number);   
     }
 
-
     return std::string("");    
 }
-
 
 bool ClassFlowControll::UpdatePrevalue(std::string _newvalue, std::string _numbers, bool _extern)
 {
@@ -504,10 +511,12 @@ bool ClassFlowControll::UpdatePrevalue(std::string _newvalue, std::string _numbe
     }
     
     if (flowpostprocessing) {
-        if (flowpostprocessing->SetPreValue(newvalueAsDouble, _numbers, _extern))
+        if (flowpostprocessing->SetPreValue(newvalueAsDouble, _numbers, _extern)) {
             return true;
-        else
+	}
+        else {
             return false;
+	}
     }
     else {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "UpdatePrevalue: ERROR - Class Post-Processing not initialized");
@@ -515,93 +524,85 @@ bool ClassFlowControll::UpdatePrevalue(std::string _newvalue, std::string _numbe
     }
 }
 
-
 bool ClassFlowControll::ReadParameter(FILE* pfile, string& aktparamgraph)
 {
     std::vector<string> splitted;
 
     aktparamgraph = trim(aktparamgraph);
 
-    if (aktparamgraph.size() == 0)
-        if (!this->GetNextParagraph(pfile, aktparamgraph))
+    if (aktparamgraph.size() == 0) {
+        if (!this->GetNextParagraph(pfile, aktparamgraph)) {
             return false;
-
+	}
+    }
 
     if ((toUpper(aktparamgraph).compare("[AUTOTIMER]") != 0) && (toUpper(aktparamgraph).compare("[DEBUG]") != 0) &&
-        (toUpper(aktparamgraph).compare("[SYSTEM]") != 0 && (toUpper(aktparamgraph).compare("[DATALOGGING]") != 0)))      // Paragraph passt nicht zu Debug oder DataLogging
+        (toUpper(aktparamgraph).compare("[SYSTEM]") != 0 && (toUpper(aktparamgraph).compare("[DATALOGGING]") != 0))) {     
+        // Paragraph passt nicht zu Debug oder DataLogging
         return false;
+    }
 
-    while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph))
-    {
+    while (this->getNextLine(pfile, &aktparamgraph) && !this->isNewParagraph(aktparamgraph)) {
         splitted = ZerlegeZeile(aktparamgraph, " =");
-        if ((toUpper(splitted[0]) == "AUTOSTART") && (splitted.size() > 1))
-        {
-            if (toUpper(splitted[1]) == "TRUE")
+	    
+        if ((toUpper(splitted[0]) == "AUTOSTART") && (splitted.size() > 1)) {
+            AutoStart = alphanumericToBoolean(splitted[1]);
+        }
+
+        if ((toUpper(splitted[0]) == "INTERVAL") && (splitted.size() > 1)) {
+            if (isStringNumeric(splitted[1]))
             {
-                AutoStart = true;
+                AutoInterval = std::stof(splitted[1]);
             }
         }
 
-        if ((toUpper(splitted[0]) == "INTERVAL") && (splitted.size() > 1))
-        {
-            AutoInterval = std::stof(splitted[1]);
+        if ((toUpper(splitted[0]) == "DATALOGACTIVE") && (splitted.size() > 1)) {
+            LogFile.SetDataLogToSD(alphanumericToBoolean(splitted[1]));
         }
 
-        if ((toUpper(splitted[0]) == "DATALOGACTIVE") && (splitted.size() > 1))
-        {
-            if (toUpper(splitted[1]) == "TRUE")
+        if ((toUpper(splitted[0]) == "DATAFILESRETENTION") && (splitted.size() > 1)) {
+            if (isStringNumeric(splitted[1]))
             {
-                LogFile.SetDataLogToSD(true);
-            }
-            else {
-                LogFile.SetDataLogToSD(false);
+                LogFile.SetDataLogRetention(std::stoi(splitted[1]));
             }
         }
 
-        if ((toUpper(splitted[0]) == "DATAFILESRETENTION") && (splitted.size() > 1))
-        {
-            LogFile.SetDataLogRetention(std::stoi(splitted[1]));
-        }
-
-        if ((toUpper(splitted[0]) == "LOGLEVEL") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "LOGLEVEL") && (splitted.size() > 1)) {
             /* matches esp_log_level_t */
-            if ((toUpper(splitted[1]) == "TRUE") || (toUpper(splitted[1]) == "2"))
-            {
+            if ((toUpper(splitted[1]) == "TRUE") || (toUpper(splitted[1]) == "2")) {
                 LogFile.setLogLevel(ESP_LOG_WARN);
             }
-            else if ((toUpper(splitted[1]) == "FALSE") || (toUpper(splitted[1]) == "0") || (toUpper(splitted[1]) == "1"))
-            {
+            else if ((toUpper(splitted[1]) == "FALSE") || (toUpper(splitted[1]) == "0") || (toUpper(splitted[1]) == "1")) {
                 LogFile.setLogLevel(ESP_LOG_ERROR);
             }
-            else if (toUpper(splitted[1]) == "3")
-            {
+            else if (toUpper(splitted[1]) == "3") {
                 LogFile.setLogLevel(ESP_LOG_INFO);
             }
-            else if (toUpper(splitted[1]) == "4")
-            {
+            else if (toUpper(splitted[1]) == "4") {
                 LogFile.setLogLevel(ESP_LOG_DEBUG);
             }
 
             /* If system reboot was not triggered by user and reboot was caused by execption -> keep log level to DEBUG */
-            if (!getIsPlannedReboot() && (esp_reset_reason() == ESP_RST_PANIC))
+            if (!getIsPlannedReboot() && (esp_reset_reason() == ESP_RST_PANIC)) {
                 LogFile.setLogLevel(ESP_LOG_DEBUG);
+	    }
         }
-        if ((toUpper(splitted[0]) == "LOGFILESRETENTION") && (splitted.size() > 1))
-        {
-            LogFile.SetLogFileRetention(std::stoi(splitted[1]));
+	    
+        if ((toUpper(splitted[0]) == "LOGFILESRETENTION") && (splitted.size() > 1)) {
+            if (isStringNumeric(splitted[1]))
+            {
+                LogFile.SetLogFileRetention(std::stoi(splitted[1]));
+            }
         }
 
         /* TimeServer and TimeZone got already read from the config, see setupTime () */
         
         #if (defined WLAN_USE_ROAMING_BY_SCANNING || (defined WLAN_USE_MESH_ROAMING && defined WLAN_USE_MESH_ROAMING_ACTIVATE_CLIENT_TRIGGERED_QUERIES))
-        if ((toUpper(splitted[0]) == "RSSITHRESHOLD") && (splitted.size() > 1))
-        {
+        if ((toUpper(splitted[0]) == "RSSITHRESHOLD") && (splitted.size() > 1)) {
             int RSSIThresholdTMP = atoi(splitted[1].c_str());
             RSSIThresholdTMP = min(0, max(-100, RSSIThresholdTMP)); // Verify input limits (-100 - 0)
             
-            if (ChangeRSSIThreshold(WLAN_CONFIG_FILE, RSSIThresholdTMP))
-            {
+            if (ChangeRSSIThreshold(WLAN_CONFIG_FILE, RSSIThresholdTMP)) {
                 // reboot necessary so that the new wlan.ini is also used !!!
                 fclose(pfile);
                 LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Rebooting to activate new RSSITHRESHOLD ...");
@@ -610,10 +611,8 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, string& aktparamgraph)
         }
         #endif
 
-        if ((toUpper(splitted[0]) == "HOSTNAME") && (splitted.size() > 1))
-        {
-            if (ChangeHostName(WLAN_CONFIG_FILE, splitted[1]))
-            {
+        if ((toUpper(splitted[0]) == "HOSTNAME") && (splitted.size() > 1)) {
+            if (ChangeHostName(WLAN_CONFIG_FILE, splitted[1])) {
                 // reboot necessary so that the new wlan.ini is also used !!!
                 fclose(pfile);
                 LogFile.WriteToFile(ESP_LOG_WARN, TAG, "Rebooting to activate new HOSTNAME...");             
@@ -621,23 +620,19 @@ bool ClassFlowControll::ReadParameter(FILE* pfile, string& aktparamgraph)
             }
         }
 
-        if ((toUpper(splitted[0]) == "SETUPMODE") && (splitted.size() > 1))
-        {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                SetupModeActive = true;
-            }        
+        if ((toUpper(splitted[0]) == "SETUPMODE") && (splitted.size() > 1)) {
+            SetupModeActive = alphanumericToBoolean(splitted[1]);        
         }
     }
     return true;
 }
-
 
 int ClassFlowControll::CleanTempFolder() {
     const char* folderPath = "/sdcard/img_tmp";
     
     ESP_LOGD(TAG, "Clean up temporary folder to avoid damage of sdcard sectors: %s", folderPath);
     DIR *dir = opendir(folderPath);
+	
     if (!dir) {
         ESP_LOGE(TAG, "Failed to stat dir: %s", folderPath);
         return -1;
@@ -645,30 +640,32 @@ int ClassFlowControll::CleanTempFolder() {
 
     struct dirent *entry;
     int deleted = 0;
+	
     while ((entry = readdir(dir)) != NULL) {
         std::string path = string(folderPath) + "/" + entry->d_name;
-		if (entry->d_type == DT_REG) {
-			if (unlink(path.c_str()) == 0) {
-				deleted ++;
-			} else {
-				ESP_LOGE(TAG, "can't delete file: %s", path.c_str());
-			}
-        } else if (entry->d_type == DT_DIR) {
-			deleted += removeFolder(path.c_str(), TAG);
-		}
+	if (entry->d_type == DT_REG) {
+	    if (unlink(path.c_str()) == 0) {
+		deleted ++;
+	    } 
+	    else {
+		ESP_LOGE(TAG, "can't delete file: %s", path.c_str());
+	    }
+        } 
+	else if (entry->d_type == DT_DIR) {
+	    deleted += removeFolder(path.c_str(), TAG);
+	}
     }
+	
     closedir(dir);
     ESP_LOGD(TAG, "%d files deleted", deleted);
     
     return 0;
 }
 
-
 esp_err_t ClassFlowControll::SendRawJPG(httpd_req_t *req)
 {
     return flowtakeimage != NULL ? flowtakeimage->SendRawJPG(req) : ESP_FAIL;
 }
-
 
 esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
 {
@@ -901,12 +898,10 @@ esp_err_t ClassFlowControll::GetJPGStream(std::string _fn, httpd_req_t *req)
     return result;
 }
 
-
 string ClassFlowControll::getNumbersName()
 {
     return flowpostprocessing->getNumbersName();
 }
-
 
 string ClassFlowControll::getJSON()
 {

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -341,11 +341,7 @@ void ClassFlowPostProcessing::handleDecimalExtendedResolution(string _decsep, st
     }
 
     for (int j = 0; j < NUMBERS.size(); ++j) {
-        bool _zwdc = false;
-
-        if (toUpper(_value) == "TRUE") {
-            _zwdc = true;
-        }
+        bool _zwdc = alphanumericToBoolean(_value);
 
         // Set to default first (if nothing else is set)
         if ((_digit == "default") || (NUMBERS[j]->name == _digit)) {
@@ -368,7 +364,10 @@ void ClassFlowPostProcessing::handleDecimalSeparator(string _decsep, string _val
 
     for (int j = 0; j < NUMBERS.size(); ++j) {
         int _zwdc = 0;
-        _zwdc = stoi(_value);
+	    
+        if (isStringNumeric(_value)) {
+            _zwdc = std::stoi(_value);
+        }
 
         //  Set to default first (if nothing else is set)
         if ((_digit == "default") || (NUMBERS[j]->name == _digit)) {
@@ -394,7 +393,10 @@ void ClassFlowPostProcessing::handleAnalogDigitalTransitionStart(string _decsep,
 
     for (int j = 0; j < NUMBERS.size(); ++j) {
         float _zwdc = 9.2;
-        _zwdc = stof(_value);
+	    
+        if (isStringNumeric(_value)) {
+            _zwdc = std::stof(_value);
+        }
 
         // Set to default first (if nothing else is set)
         if ((_digit == "default") || (NUMBERS[j]->name == _digit)) {
@@ -417,15 +419,11 @@ void ClassFlowPostProcessing::handleAllowNegativeRate(string _decsep, string _va
     }
   
     for (int j = 0; j < NUMBERS.size(); ++j) {
-        bool _rt = false;
-
-        if (toUpper(_value) == "TRUE") {
-            _rt = true;
-        }
+        bool _zwdc = alphanumericToBoolean(_value);
 
         // Set to default first (if nothing else is set)
         if ((_digit == "default") || (NUMBERS[j]->name == _digit)) {
-            NUMBERS[j]->AllowNegativeRates = _rt;
+            NUMBERS[j]->AllowNegativeRates = _zwdc;
         }
     }
 }
@@ -443,15 +441,15 @@ void ClassFlowPostProcessing::handleMaxRateType(string _decsep, string _value) {
     }
 
     for (int j = 0; j < NUMBERS.size(); ++j) {
-        t_RateType _rt = AbsoluteChange;
+        t_RateType _zwdc = AbsoluteChange;
 
         if (toUpper(_value) == "RATECHANGE") {
-            _rt = RateChange;
+            _zwdc = RateChange;
         }
 
         // Set to default first (if nothing else is set)			
         if ((_digit == "default") || (NUMBERS[j]->name == _digit)) {
-            NUMBERS[j]->RateType = _rt;
+            NUMBERS[j]->RateType = _zwdc;
         }
     }
 }
@@ -470,7 +468,10 @@ void ClassFlowPostProcessing::handleMaxRateValue(string _decsep, string _value) 
 	
     for (int j = 0; j < NUMBERS.size(); ++j) {
         float _zwdc = 1;
-        _zwdc = stof(_value);
+	    
+        if (isStringNumeric(_value)) {
+            _zwdc = std::stof(_value);
+        }
 
         // Set to default first (if nothing else is set)			
         if ((_digit == "default") || (NUMBERS[j]->name == _digit)) {
@@ -524,13 +525,11 @@ bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, string& aktparamgraph) 
         }
 	    
         if ((toUpper(_param) == "PREVALUEUSE") && (splitted.size() > 1)) {
-            if (toUpper(splitted[1]) == "TRUE") {
-                PreValueUse = true;
-            }
+            PreValueUse = alphanumericToBoolean(splitted[1]);
         }
 	    
         if ((toUpper(_param) == "CHECKDIGITINCREASECONSISTENCY") && (splitted.size() > 1)) {
-            if (toUpper(splitted[1]) == "TRUE") {
+            if (alphanumericToBoolean(splitted[1])) {
                 for (_n = 0; _n < NUMBERS.size(); ++_n) {
                     NUMBERS[_n]->checkDigitIncreaseConsistency = true;
                 }
@@ -542,19 +541,17 @@ bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, string& aktparamgraph) 
         }
 			
         if ((toUpper(_param) == "ERRORMESSAGE") && (splitted.size() > 1)) {
-            if (toUpper(splitted[1]) == "TRUE") {
-                ErrorMessage = true;
-            }
+            ErrorMessage = alphanumericToBoolean(splitted[1]);
         }
 			
         if ((toUpper(_param) == "IGNORELEADINGNAN") && (splitted.size() > 1)) {
-            if (toUpper(splitted[1]) == "TRUE") {
-                IgnoreLeadingNaN = true;
-            }
+            IgnoreLeadingNaN = alphanumericToBoolean(splitted[1]);
         }
 
         if ((toUpper(_param) == "PREVALUEAGESTARTUP") && (splitted.size() > 1)) {
-            PreValueAgeStartup = std::stoi(splitted[1]);
+            if (isStringNumeric(splitted[1])) {
+                PreValueAgeStartup = std::stoi(splitted[1]);
+            }
         }
     }
 

--- a/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
@@ -96,31 +96,30 @@ bool ClassFlowTakeImage::ReadParameter(FILE *pfile, string &aktparamgraph)
 
         else if ((toUpper(splitted[0]) == "RAWIMAGESRETENTION") && (splitted.size() > 1))
         {
-            this->imagesRetention = std::stod(splitted[1]);
+            if (isStringNumeric(splitted[1]))
+            {
+                this->imagesRetention = std::stod(splitted[1]);
+            }          
         }
 
         else if ((toUpper(splitted[0]) == "SAVEALLFILES") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.SaveAllFiles = 1;
-            }
-            else
-            {
-                CCstatus.SaveAllFiles = 0;
-            }
+            CCstatus.SaveAllFiles = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "WAITBEFORETAKINGPICTURE") && (splitted.size() > 1))
         {
-            int _WaitBeforePicture = std::stoi(splitted[1]);
-            if (_WaitBeforePicture != 0)
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.WaitBeforePicture = _WaitBeforePicture;
-            }
-            else
-            {
-                CCstatus.WaitBeforePicture = 2;
+                int _WaitBeforePicture = std::stoi(splitted[1]);
+                if (_WaitBeforePicture != 0)
+                {
+                    CCstatus.WaitBeforePicture = _WaitBeforePicture;
+                }
+                else
+                {
+                    CCstatus.WaitBeforePicture = 2;
+                }
             }
         }
 
@@ -159,59 +158,52 @@ bool ClassFlowTakeImage::ReadParameter(FILE *pfile, string &aktparamgraph)
 
         else if ((toUpper(splitted[0]) == "CAMQUALITY") && (splitted.size() > 1))
         {
-            int _ImageQuality = std::stoi(splitted[1]);
-            if ((_ImageQuality >= 0) && (_ImageQuality <= 63))
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.ImageQuality = _ImageQuality;
+                int _ImageQuality = std::stoi(splitted[1]);
+                CCstatus.ImageQuality = clipInt(_ImageQuality, 63, 6);
             }
         }
 
         else if ((toUpper(splitted[0]) == "CAMBRIGHTNESS") && (splitted.size() > 1))
         {
-            int _ImageBrightness = std::stoi(splitted[1]);
-            if ((_ImageBrightness >= -2) && (_ImageBrightness <= 2))
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.ImageBrightness = _ImageBrightness;
+                int _ImageBrightness = std::stoi(splitted[1]);
+                CCstatus.ImageBrightness = clipInt(_ImageBrightness, 2, -2);
             }
         }
 
         else if ((toUpper(splitted[0]) == "CAMCONTRAST") && (splitted.size() > 1))
         {
-            int _ImageContrast = std::stoi(splitted[1]);
-            if ((_ImageContrast >= -2) && (_ImageContrast <= 2))
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.ImageContrast = _ImageContrast;
+                int _ImageContrast = std::stoi(splitted[1]);
+                CCstatus.ImageContrast = clipInt(_ImageContrast, 2, -2);
             }
         }
 
         else if ((toUpper(splitted[0]) == "CAMSATURATION") && (splitted.size() > 1))
         {
-            int _ImageSaturation = std::stoi(splitted[1]);
-            if ((_ImageSaturation >= -2) && (_ImageSaturation <= 2))
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.ImageSaturation = _ImageSaturation;
+                int _ImageSaturation = std::stoi(splitted[1]);
+                CCstatus.ImageSaturation = clipInt(_ImageSaturation, 2, -2);
             }
         }
 
         else if ((toUpper(splitted[0]) == "CAMSHARPNESS") && (splitted.size() > 1))
         {
-            int _ImageSharpness = std::stoi(splitted[1]);
-            if ((_ImageSharpness >= -2) && (_ImageSharpness <= 2))
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.ImageSharpness = _ImageSharpness;
+                int _ImageSharpness = std::stoi(splitted[1]);
+                CCstatus.ImageSharpness = clipInt(_ImageSharpness, 2, -2);
             }
         }
 
         else if ((toUpper(splitted[0]) == "CAMAUTOSHARPNESS") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageAutoSharpness = 1;
-            }
-            else
-            {
-                CCstatus.ImageAutoSharpness = 0;
-            }
+            CCstatus.ImageAutoSharpness = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMSPECIALEFFECT") && (splitted.size() > 1))
@@ -274,222 +266,135 @@ bool ClassFlowTakeImage::ReadParameter(FILE *pfile, string &aktparamgraph)
 
         else if ((toUpper(splitted[0]) == "CAMAWB") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageAwb = 1;
-            }
-            else
-            {
-                CCstatus.ImageAwb = 0;
-            }
+            CCstatus.ImageAwb = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMAWBGAIN") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageAwbGain = 1;
-            }
-            else
-            {
-                CCstatus.ImageAwbGain = 0;
-            }
+            CCstatus.ImageAwbGain = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMAEC") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageAec = 1;
-            }
-            else
-            {
-                CCstatus.ImageAec = 0;
-            }
+            CCstatus.ImageAec = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMAEC2") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageAec2 = 1;
-            }
-            else
-            {
-                CCstatus.ImageAec2 = 0;
-            }
+            CCstatus.ImageAec2 = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMAELEVEL") && (splitted.size() > 1))
         {
-            int _ImageAeLevel = std::stoi(splitted[1]);
-            if ((_ImageAeLevel >= -2) && (_ImageAeLevel <= 2))
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.ImageAeLevel = _ImageAeLevel;
+                int _ImageAeLevel = std::stoi(splitted[1]);
+                CCstatus.ImageAeLevel = clipInt(_ImageAeLevel, 2, -2);
             }
         }
 
         else if ((toUpper(splitted[0]) == "CAMAECVALUE") && (splitted.size() > 1))
         {
-            int _ImageAecValue = std::stoi(splitted[1]);
-            if ((_ImageAecValue >= 0) && (_ImageAecValue <= 1200))
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.ImageAecValue = _ImageAecValue;
+                int _ImageAecValue = std::stoi(splitted[1]);
+                CCstatus.ImageAecValue = clipInt(_ImageAecValue, 1200, 0);
             }
         }
 
         else if ((toUpper(splitted[0]) == "CAMAGC") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageAgc = 1;
-            }
-            else
-            {
-                CCstatus.ImageAgc = 0;
-            }
+            CCstatus.ImageAgc = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMAGCGAIN") && (splitted.size() > 1))
         {
-            int _ImageAgcGain = std::stoi(splitted[1]);
-            if ((_ImageAgcGain >= 0) && (_ImageAgcGain <= 30))
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.ImageAgcGain = _ImageAgcGain;
+                int _ImageAgcGain = std::stoi(splitted[1]);
+                CCstatus.ImageAgcGain = clipInt(_ImageAgcGain, 30, 0);
             }
         }
 
         else if ((toUpper(splitted[0]) == "CAMBPC") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageBpc = 1;
-            }
-            else
-            {
-                CCstatus.ImageBpc = 0;
-            }
+            CCstatus.ImageBpc = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMWPC") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageWpc = 1;
-            }
-            else
-            {
-                CCstatus.ImageWpc = 0;
-            }
+            CCstatus.ImageWpc = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMRAWGMA") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageRawGma = 1;
-            }
-            else
-            {
-                CCstatus.ImageRawGma = 0;
-            }
+            CCstatus.ImageRawGma = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMLENC") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageLenc = 1;
-            }
-            else
-            {
-                CCstatus.ImageLenc = 0;
-            }
+            CCstatus.ImageLenc = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMHMIRROR") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageHmirror = 1;
-            }
-            else
-            {
-                CCstatus.ImageHmirror = 0;
-            }
+            CCstatus.ImageHmirror = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMVFLIP") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageVflip = 1;
-            }
-            else
-            {
-                CCstatus.ImageVflip = 0;
-            }
+            CCstatus.ImageVflip = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMDCW") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageDcw = 1;
-            }
-            else
-            {
-                CCstatus.ImageDcw = 0;
-            }
+            CCstatus.ImageDcw = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMZOOM") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
-            {
-                CCstatus.ImageZoomEnabled = 1;
-            }
-            else
-            {
-                CCstatus.ImageZoomEnabled = 0;
-            }
+            CCstatus.ImageZoomEnabled = alphanumericToBoolean(splitted[1]);
         }
 
         else if ((toUpper(splitted[0]) == "CAMZOOMOFFSETX") && (splitted.size() > 1))
         {
-            CCstatus.ImageZoomOffsetX = std::stoi(splitted[1]);
+            if (isStringNumeric(splitted[1]))
+            {
+                CCstatus.ImageZoomOffsetX = std::stoi(splitted[1]);
+            }
         }
 
         else if ((toUpper(splitted[0]) == "CAMZOOMOFFSETY") && (splitted.size() > 1))
         {
-            CCstatus.ImageZoomOffsetY = std::stoi(splitted[1]);
+            if (isStringNumeric(splitted[1]))
+            {
+                CCstatus.ImageZoomOffsetY = std::stoi(splitted[1]);
+            }
         }
 
         else if ((toUpper(splitted[0]) == "CAMZOOMSIZE") && (splitted.size() > 1))
         {
-            int _ImageZoomSize = std::stoi(splitted[1]);
-            if (_ImageZoomSize >= 0)
+            if (isStringNumeric(splitted[1]))
             {
-                CCstatus.ImageZoomSize = _ImageZoomSize;
+                CCstatus.ImageZoomSize = std::stoi(splitted[1]);
             }
         }
 
         else if ((toUpper(splitted[0]) == "LEDINTENSITY") && (splitted.size() > 1))
         {
-            float ledintensity = std::stof(splitted[1]);
-            Camera.SetLEDIntensity(ledintensity);
+            if (isStringNumeric(splitted[1]))
+            {
+                float ledintensity = std::stof(splitted[1]);
+                Camera.SetLEDIntensity(ledintensity);
+            }
         }
 
         else if ((toUpper(splitted[0]) == "DEMO") && (splitted.size() > 1))
         {
-            if (toUpper(splitted[1]) == "TRUE")
+            CCstatus.DemoMode = alphanumericToBoolean(splitted[1]);
+            if (CCstatus.DemoMode == true)
             {
-                CCstatus.DemoMode = true;
                 Camera.useDemoMode();
-            }
-            else
-            {
-                CCstatus.DemoMode = false;
             }
         }
     }

--- a/code/components/jomjol_flowcontroll/MainFlowControl.cpp
+++ b/code/components/jomjol_flowcontroll/MainFlowControl.cpp
@@ -551,7 +551,7 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
         bool _noerror = false;
         bool _all = false;
         std::string _type = "value";
-        string zw;
+        std::string zw;
 
         ESP_LOGD(TAG, "handler water counter uri: %s", req->uri);
 
@@ -629,12 +629,12 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
         }
 
         std::string *status = flowctrl.getActStatus();
-        string query = std::string(_query);
+        std::string query = std::string(_query);
         //    ESP_LOGD(TAG, "Query: %s, query.c_str());
 
         if (query.find("full") != std::string::npos)
         {
-            string txt;
+            std::string txt;
             txt = "<body style=\"font-family: arial\">";
 
             if ((countRounds <= 1) && (*status != std::string("Flow finished")))
@@ -659,7 +659,7 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
 
         if (query.find("full") != std::string::npos)
         {
-            string txt, zw;
+            std::string txt, zw;
 
             if ((countRounds <= 1) && (*status != std::string("Flow finished")))
             {
@@ -686,7 +686,7 @@ esp_err_t handler_wasserzaehler(httpd_req_t *req)
                         }
                         else
                         {
-                            zw = to_string((int)htmlinfodig[i]->val);
+                            zw = std::to_string((int)htmlinfodig[i]->val);
                         }
 
                         txt += "<td style=\"width: 100px\"><h4>" + zw + "</h4><p><img src=\"/img_tmp/" + htmlinfodig[i]->filename + "\"></p></td>\n";
@@ -783,7 +783,7 @@ esp_err_t handler_editflow(httpd_req_t *req)
 
     char _query[200];
     char _valuechar[30];
-    string _task;
+    std::string _task;
 
     if (httpd_req_get_url_query_str(req, _query, 200) == ESP_OK)
     {
@@ -792,7 +792,7 @@ esp_err_t handler_editflow(httpd_req_t *req)
 #ifdef DEBUG_DETAIL_ON
             ESP_LOGD(TAG, "task is found: %s", _valuechar);
 #endif
-            _task = string(_valuechar);
+            _task = std::string(_valuechar);
         }
     }
 
@@ -816,12 +816,12 @@ esp_err_t handler_editflow(httpd_req_t *req)
 
     if (_task.compare("copy") == 0)
     {
-        string in, out, zw;
+        std::string in, out, zw;
 
         httpd_query_key_value(_query, "in", _valuechar, 30);
-        in = string(_valuechar);
+        in = std::string(_valuechar);
         httpd_query_key_value(_query, "out", _valuechar, 30);
-        out = string(_valuechar);
+        out = std::string(_valuechar);
 
 #ifdef DEBUG_DETAIL_ON
         ESP_LOGD(TAG, "in: %s", in.c_str());
@@ -839,31 +839,43 @@ esp_err_t handler_editflow(httpd_req_t *req)
 
     if (_task.compare("cutref") == 0)
     {
-        string in, out, zw;
-        int x, y, dx, dy;
+        std::string in, out, zw;
+        int x = 0, y = 0, dx = 20, dy = 20;
         bool enhance = false;
 
         httpd_query_key_value(_query, "in", _valuechar, 30);
-        in = string(_valuechar);
+        in = std::string(_valuechar);
 
         httpd_query_key_value(_query, "out", _valuechar, 30);
-        out = string(_valuechar);
+        out = std::string(_valuechar);
 
         httpd_query_key_value(_query, "x", _valuechar, 30);
-        string _x = string(_valuechar);
-        x = stoi(_x);
+        std::string _x = std::string(_valuechar);
+        if (isStringNumeric(_x))
+        {
+            x = std::stoi(_x);
+        }
 
         httpd_query_key_value(_query, "y", _valuechar, 30);
-        string _y = string(_valuechar);
-        y = stoi(_y);
+        std::string _y = std::string(_valuechar);
+        if (isStringNumeric(_y))
+        {
+            y = std::stoi(_y);
+        }
 
         httpd_query_key_value(_query, "dx", _valuechar, 30);
-        string _dx = string(_valuechar);
-        dx = stoi(_dx);
+        std::string _dx = std::string(_valuechar);
+        if (isStringNumeric(_dx))
+        {
+            dx = std::stoi(_dx);
+        }
 
         httpd_query_key_value(_query, "dy", _valuechar, 30);
-        string _dy = string(_valuechar);
-        dy = stoi(_dy);
+        std::string _dy = std::string(_valuechar);
+        if (isStringNumeric(_dy))
+        {
+            dy = std::stoi(_dy);
+        }
 
 #ifdef DEBUG_DETAIL_ON
         ESP_LOGD(TAG, "in: %s", in.c_str());
@@ -876,7 +888,7 @@ esp_err_t handler_editflow(httpd_req_t *req)
 
         if (httpd_query_key_value(_query, "enhance", _valuechar, 10) == ESP_OK)
         {
-            string _enhance = string(_valuechar);
+            string _enhance = std::string(_valuechar);
 
             if (_enhance.compare("true") == 0)
             {
@@ -887,7 +899,7 @@ esp_err_t handler_editflow(httpd_req_t *req)
         in = "/sdcard" + in;
         out = "/sdcard" + out;
 
-        string out2 = out.substr(0, out.length() - 4) + "_org.jpg";
+        std::string out2 = out.substr(0, out.length() - 4) + "_org.jpg";
 
         if ((flowctrl.SetupModeActive || (*flowctrl.getActStatus() == std::string("Flow finished"))) && psram_init_shared_memory_for_take_image_step())
         {
@@ -939,295 +951,236 @@ esp_err_t handler_editflow(httpd_req_t *req)
 
             if (httpd_query_key_value(_query, "waitb", _valuechar, 30) == ESP_OK)
             {
-                int _waitb = std::stoi(_valuechar);
-                if (_waitb != 0)
+                std::string _waitb = std::string(_valuechar);
+                if (isStringNumeric(_waitb))
                 {
-                    CFstatus.WaitBeforePicture = _waitb;
+                    CFstatus.WaitBeforePicture = std::stoi(_valuechar);
                 }
             }
 
             if (httpd_query_key_value(_query, "qual", _valuechar, 30) == ESP_OK)
             {
-                int _qual = std::stoi(_valuechar);
-                if ((_qual >= 0) && (_qual <= 63))
+                std::string _qual = std::string(_valuechar);
+                if (isStringNumeric(_qual))
                 {
-                    CFstatus.ImageQuality = _qual;
+                    int _qual_ = std::stoi(_valuechar);
+                    CFstatus.ImageQuality = clipInt(_qual_, 63, 6);
                 }
             }
 
             if (httpd_query_key_value(_query, "bri", _valuechar, 30) == ESP_OK)
             {
-                int _bri = std::stoi(_valuechar);
-                if ((_bri >= -2) && (_bri <= 2))
+                std::string _bri = std::string(_valuechar);
+                if (isStringNumeric(_bri))
                 {
-                    CFstatus.ImageBrightness = _bri;
+                    int _bri_ = std::stoi(_valuechar);
+                    CFstatus.ImageBrightness = clipInt(_bri_, 2, -2);
                 }
             }
 
             if (httpd_query_key_value(_query, "con", _valuechar, 30) == ESP_OK)
             {
-                int _con = std::stoi(_valuechar);
-                if ((_con >= -2) && (_con <= 2))
+                std::string _con = std::string(_valuechar);
+                if (isStringNumeric(_con))
                 {
-                    CFstatus.ImageContrast = _con;
+                    int _con_ = std::stoi(_valuechar);
+                    CFstatus.ImageContrast = clipInt(_con_, 2, -2);
                 }
             }
 
             if (httpd_query_key_value(_query, "sat", _valuechar, 30) == ESP_OK)
             {
-                int _sat = std::stoi(_valuechar);
-                if ((_sat >= -2) && (_sat <= 2))
+                std::string _sat = std::string(_valuechar);
+                if (isStringNumeric(_sat))
                 {
-                    CFstatus.ImageSaturation = _sat;
+                    int _sat_ = std::stoi(_valuechar);
+                    CFstatus.ImageSaturation = clipInt(_sat_, 2, -2);
                 }
             }
 
             if (httpd_query_key_value(_query, "shp", _valuechar, 30) == ESP_OK)
             {
-                int _shp = std::stoi(_valuechar);
-                if ((_shp >= -2) && (_shp <= 2))
+                std::string _shp = std::string(_valuechar);
+                if (isStringNumeric(_shp))
                 {
-                    CFstatus.ImageSharpness = _shp;
+                    int _shp_ = std::stoi(_valuechar);
+                    CFstatus.ImageSaturation = clipInt(_shp_, 2, -2);
                 }
             }
 
             if (httpd_query_key_value(_query, "ashp", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageAutoSharpness = 1;
-                }
-                else
-                {
-                    CFstatus.ImageAutoSharpness = 0;
-                }
+                std::string _ashp = std::string(_valuechar);
+                CFstatus.ImageAutoSharpness = alphanumericToBoolean(_ashp);
             }
 
             if (httpd_query_key_value(_query, "spe", _valuechar, 30) == ESP_OK)
             {
-                int _spe = std::stoi(_valuechar);
-                if ((_spe >= 0) && (_spe <= 6))
+                std::string _spe = std::string(_valuechar);
+                if (isStringNumeric(_spe))
                 {
-                    CFstatus.ImageSpecialEffect = _spe;
+                    int _spe_ = std::stoi(_valuechar);
+                    CFstatus.ImageSpecialEffect = clipInt(_spe_, 6, 0);
                 }
             }
 
             if (httpd_query_key_value(_query, "wbm", _valuechar, 30) == ESP_OK)
             {
-                int _wbm = std::stoi(_valuechar);
-                if ((_wbm >= 0) && (_wbm <= 4))
+                std::string _wbm = std::string(_valuechar);
+                if (isStringNumeric(_wbm))
                 {
-                    CFstatus.ImageWbMode = _wbm;
+                    int _wbm_ = std::stoi(_valuechar);
+                    CFstatus.ImageWbMode = clipInt(_wbm_, 4, 0);
                 }
             }
 
             if (httpd_query_key_value(_query, "awb", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageAwb = 1;
-                }
-                else
-                {
-                    CFstatus.ImageAwb = 0;
-                }
+                std::string _awb = std::string(_valuechar);
+                CFstatus.ImageAwb = alphanumericToBoolean(_awb);
             }
 
             if (httpd_query_key_value(_query, "awbg", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageAwbGain = 1;
-                }
-                else
-                {
-                    CFstatus.ImageAwbGain = 0;
-                }
+                std::string _awbg = std::string(_valuechar);
+                CFstatus.ImageAwbGain = alphanumericToBoolean(_awbg);
             }
 
             if (httpd_query_key_value(_query, "aec", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageAec = 1;
-                }
-                else
-                {
-                    CFstatus.ImageAec = 0;
-                }
+                std::string _aec = std::string(_valuechar);
+                CFstatus.ImageAec = alphanumericToBoolean(_aec);
             }
 
             if (httpd_query_key_value(_query, "aec2", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageAec2 = 1;
-                }
-                else
-                {
-                    CFstatus.ImageAec2 = 0;
-                }
+                std::string _aec2 = std::string(_valuechar);
+                CFstatus.ImageAec2 = alphanumericToBoolean(_aec2);
             }
 
             if (httpd_query_key_value(_query, "ael", _valuechar, 30) == ESP_OK)
             {
-                int _ael = std::stoi(_valuechar);
-                if ((_ael >= -2) && (_ael <= 2))
+                std::string _ael = std::string(_valuechar);
+                if (isStringNumeric(_ael))
                 {
-                    CFstatus.ImageAeLevel = _ael;
+                    int _ael_ = std::stoi(_valuechar);
+                    CFstatus.ImageAeLevel = clipInt(_ael_, 2, -2);
                 }
             }
 
             if (httpd_query_key_value(_query, "aecv", _valuechar, 30) == ESP_OK)
             {
-                int _aecv = std::stoi(_valuechar);
-                if ((_aecv >= 0) && (_aecv <= 1200))
+                std::string _aecv = std::string(_valuechar);
+                if (isStringNumeric(_aecv))
                 {
-                    CFstatus.ImageAecValue = _aecv;
+                    int _aecv_ = std::stoi(_valuechar);
+                    CFstatus.ImageAecValue = clipInt(_aecv_, 1200, 0);
                 }
             }
 
             if (httpd_query_key_value(_query, "agc", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageAgc = 1;
-                }
-                else
-                {
-                    CFstatus.ImageAgc = 0;
-                }
+                std::string _agc = std::string(_valuechar);
+                CFstatus.ImageAgc = alphanumericToBoolean(_agc);
             }
 
             if (httpd_query_key_value(_query, "agcg", _valuechar, 30) == ESP_OK)
             {
-                int _agcg = std::stoi(_valuechar);
-                if ((_agcg >= 0) && (_agcg <= 30))
+                std::string _agcg = std::string(_valuechar);
+                if (isStringNumeric(_agcg))
                 {
-                    CFstatus.ImageAgcGain = _agcg;
+                    int _agcg_ = std::stoi(_valuechar);
+                    CFstatus.ImageAgcGain = clipInt(_agcg_, 30, 0);
                 }
             }
 
             if (httpd_query_key_value(_query, "bpc", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageBpc = 1;
-                }
-                else
-                {
-                    CFstatus.ImageBpc = 0;
-                }
+                std::string _bpc = std::string(_valuechar);
+                CFstatus.ImageBpc = alphanumericToBoolean(_bpc);
             }
 
             if (httpd_query_key_value(_query, "wpc", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageWpc = 1;
-                }
-                else
-                {
-                    CFstatus.ImageWpc = 0;
-                }
+                std::string _wpc = std::string(_valuechar);
+                CFstatus.ImageWpc = alphanumericToBoolean(_wpc);
             }
 
             if (httpd_query_key_value(_query, "rgma", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageRawGma = 1;
-                }
-                else
-                {
-                    CFstatus.ImageRawGma = 0;
-                }
+                std::string _rgma = std::string(_valuechar);
+                CFstatus.ImageRawGma = alphanumericToBoolean(_rgma);
             }
 
             if (httpd_query_key_value(_query, "lenc", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageLenc = 1;
-                }
-                else
-                {
-                    CFstatus.ImageLenc = 0;
-                }
+                std::string _lenc = std::string(_valuechar);
+                CFstatus.ImageLenc = alphanumericToBoolean(_lenc);
             }
 
             if (httpd_query_key_value(_query, "mirror", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageHmirror = 1;
-                }
-                else
-                {
-                    CFstatus.ImageHmirror = 0;
-                }
+                std::string _mirror = std::string(_valuechar);
+                CFstatus.ImageHmirror = alphanumericToBoolean(_mirror);
             }
 
             if (httpd_query_key_value(_query, "flip", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageVflip = 1;
-                }
-                else
-                {
-                    CFstatus.ImageVflip = 0;
-                }
+                std::string _flip = std::string(_valuechar);
+                CFstatus.ImageVflip = alphanumericToBoolean(_flip);
             }
 
             if (httpd_query_key_value(_query, "dcw", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageDcw = 1;
-                }
-                else
-                {
-                    CFstatus.ImageDcw = 0;
-                }
+                std::string _dcw = std::string(_valuechar);
+                CFstatus.ImageDcw = alphanumericToBoolean(_dcw);
             }
 
             if (httpd_query_key_value(_query, "zoom", _valuechar, 30) == ESP_OK)
             {
-                if (std::stoi(_valuechar) != 0)
-                {
-                    CFstatus.ImageZoomEnabled = 1;
-                }
-                else
-                {
-                    CFstatus.ImageZoomEnabled = 0;
-                }
+                std::string _zoom = std::string(_valuechar);
+                CFstatus.ImageZoomEnabled = alphanumericToBoolean(_zoom);
             }
 
             if (httpd_query_key_value(_query, "zoomx", _valuechar, 30) == ESP_OK)
             {
-                CFstatus.ImageZoomOffsetX = std::stoi(_valuechar);
+                std::string _zoomx = std::string(_valuechar);
+                if (isStringNumeric(_zoomx))
+                {
+                    int _ImageZoomOffsetX = std::stoi(_valuechar);
+                    CFstatus.ImageZoomOffsetX = clipInt(_ImageZoomOffsetX, 960, -960);
+                }
             }
 
             if (httpd_query_key_value(_query, "zoomy", _valuechar, 30) == ESP_OK)
             {
-                CFstatus.ImageZoomOffsetY = std::stoi(_valuechar);
+                std::string _zoomy = std::string(_valuechar);
+                if (isStringNumeric(_zoomy))
+                {
+                    int _ImageZoomOffsetY = std::stoi(_valuechar);
+                    CFstatus.ImageZoomOffsetY = clipInt(_ImageZoomOffsetY, 720, -720);
+                }
             }
 
             if (httpd_query_key_value(_query, "zooms", _valuechar, 30) == ESP_OK)
             {
-                int _ImageZoomSize = std::stoi(_valuechar);
-                if (_ImageZoomSize >= 0)
+                std::string _zooms = std::string(_valuechar);
+                if (isStringNumeric(_zooms))
                 {
-                    CFstatus.ImageZoomSize = _ImageZoomSize;
+                    int _ImageZoomSize = std::stoi(_valuechar);
+                    CFstatus.ImageZoomSize = clipInt(_ImageZoomSize, 29, 0);
                 }
             }
 
             if (httpd_query_key_value(_query, "ledi", _valuechar, 30) == ESP_OK)
             {
-                float _ImageLedIntensity = std::stof(_valuechar);
-                Camera.SetLEDIntensity(_ImageLedIntensity);
-                CFstatus.ImageLedIntensity = CCstatus.ImageLedIntensity;
+                std::string _ledi = std::string(_valuechar);
+                if (isStringNumeric(_ledi))
+                {
+                    float _ImageLedIntensity = std::stof(_valuechar);
+                    Camera.SetLEDIntensity(_ImageLedIntensity);
+                    CFstatus.ImageLedIntensity = CCstatus.ImageLedIntensity;
+                }
             }
 
             if (_task.compare("cam_settings") == 0)

--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -105,7 +105,7 @@
     #define LOGFILE_LAST_PART_BYTES 80 * 1024 // 80 kBytes  // Size of partial log file to return 
 
     #define SERVER_FILER_SCRATCH_BUFSIZE  4096 
-    #define SERVER_HELPER_SCRATCH_BUFSIZE  8192
+    #define SERVER_HELPER_SCRATCH_BUFSIZE  4096
     #define SERVER_OTA_SCRATCH_BUFSIZE  1024 
 
 


### PR DESCRIPTION
Should solve the problem with reading the config.ini, or should prevent boot loops if the config.ini is incorrect.

When reading the config.ini, std::stoi(), std::stof() and std::stod() are used, but if the config.ini contains for example, "MaxRateValue = 0,05", "MaxRateValue = 0.05e" or "MaxRateValue = ", a boot loop occurs

The change first checks whether the value is actually a number and only then uses std::stoi(), std::stof() or std::stod() to set the value.