### PR TITLE
Disable wifi power saving

### DIFF
--- a/code/components/jomjol_wlan/connect_wlan.cpp
+++ b/code/components/jomjol_wlan/connect_wlan.cpp
@@ -562,6 +562,12 @@ esp_err_t wifi_init_sta(void)
 		return retval;
 	}
 
+	retval = esp_wifi_set_ps(WIFI_PS_NONE);		// Disable wifi power saving
+	if (retval != ESP_OK) {
+		LogFile.WriteToFile(ESP_LOG_WARN, TAG, "esp_wifi_set_ps: Warning: "  + std::to_string(retval));
+		return retval;
+	}
+
     if (!wlan_config.ipaddress.empty() && !wlan_config.gateway.empty() && !wlan_config.netmask.empty())
     {
         if (wlan_config.dns.empty()) {


### PR DESCRIPTION
I have a decent (-67dBm) connection from the meter out in the garage, but packet loss was >90%.  Once the initial setup was done it could report to MQTT, but the UI was almost unusable.  Disabling the wifi power save mode completely resolves this for me.  Not sure how widespread the issue is or if it's an interaction with particular AP's, I'm using a Unifi U6 Lite.  

As suggested in https://github.com/jomjol/AI-on-the-edge-device/issues/3122, this could be added as a configurable parameter.  Understood if you'd prefer not to merge as is, in which case hopefully this is still useful to others.

- [esp_wifi_get_ps](https://docs.espressif.com/projects/esp-idf/en/v5.2.2/esp32/api-reference/network/esp_wifi.html#_CPPv415esp_wifi_set_ps14wifi_ps_type_t)
- https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/include/esp_wifi_types_generic.h#L288