### PR TITLE
Handle crash on corrupted model

### DIFF
--- a/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
+++ b/code/components/jomjol_tfliteclass/CTfLiteClass.cpp
@@ -206,6 +206,7 @@ bool CTfLiteClass::MakeAllocate()
 
     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "CTfLiteClass::MakeAllocate");
     this->interpreter = new tflite::MicroInterpreter(this->model, resolver, this->tensor_arena, this->kTensorArenaSize);
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Trying to load the model. If it crashes here, it ist most likely due to a corrupted model!");
 
     if (this->interpreter) 
     {


### PR DESCRIPTION
See https://github.com/jomjol/AI-on-the-edge-device/issues/3184

- Upgraded esp-tflite-micro to 1.3.1
  But this does not solve the crash if the the model is corrupted.
- Added log message to hint in case it crashes on loading a corrupted model:
  ```[0d00h05m17s] 2024-09-02T08:23:26 <DBG> [TFLITE] CTfLiteClass::LoadModel
  [0d00h05m17s] 2024-09-02T08:23:26 <DBG> [TFLITE] CTfLiteClass::ReadFileToModel: /sdcard/config/corrupted.tflite
  [0d00h05m17s] 2024-09-02T08:23:26 <DBG> [TFLITE] Loading Model /sdcard/config/corrupted.tflite /size: 1037931 bytes...
  [0d00h05m17s] 2024-09-02T08:23:26 <DBG> [PSRAM] Allocating Model memory (1363148 bytes, use shared memory in PSRAM)...
  [0d00h05m18s] 2024-09-02T08:23:27 <DBG> [TFLITE] CTfLiteClass::MakeAllocate
  [0d00h05m18s] 2024-09-02T08:23:27 <DBG> [TFLITE] Trying to load the model. If it crashes here, it ist most likely due to a corrupted model!
  [0d00h00m00s] 2024-09-02T06:23:26 <INF> [MAIN] =================================================
  [0d00h00m00s] 2024-09-02T06:23:26 <INF> [MAIN] ==================== Start ======================
  [0d00h00m00s] 2024-09-02T06:23:26 <INF> [MAIN] =================================================
  ```