### PR TITLE
migrate CAM parameters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,14 +2,18 @@
 
 For a full list of changes see [Full list of changes](https://github.com/jomjol/AI-on-the-edge-device/compare/v15.7.0...v16.0.0-RC1)
 
-#### Known issues
-Please check the [issues](https://github.com/jomjol/AI-on-the-edge-device/issues) and
-[discussions](https://github.com/jomjol/AI-on-the-edge-device/discussions) before reporting a new issue.
+### :warning: Notes
+- If the image is too dark after the update or otherwise different than before, **you might need to update the camera settings** and create a **new reference image**. We extended the camera settings and some devices need reconfiguration due to this.
+- New parameters got added, please revise the settings!
+
+### Known issues
+Please check the [issues](https://github.com/jomjol/AI-on-the-edge-device/issues) and [discussions](https://github.com/jomjol/AI-on-the-edge-device/discussions) before reporting a new issue.
 
 #### Core Changes
 Those are just the major changes:
 - Add support for OV5640 camera (#3063)
 - New tflite-Models
+- Migrated CAM parameters (#3280)
 - Homeassistant service discovery: derive node_id when using nested topics (#3088)
 - Added Prometheus/OpenMetrics exporter (#3081)
 - Added Webhook (#3148, #3163, #3174)

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -97,7 +97,7 @@ static const char *TAG = "MAIN";
 bool Init_NVS_SDCard()
 {
     esp_err_t ret = nvs_flash_init();
-	
+    
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES) {
         ESP_ERROR_CHECK(nvs_flash_erase());
         ret = nvs_flash_init();
@@ -139,7 +139,7 @@ bool Init_NVS_SDCard()
     // dies führt jedoch bei schlechten Kopien des AI_THINKER Boards
     // zu Problemen mit der SD Initialisierung und eventuell sogar zur reboot-loops.
     // Um diese Probleme zu kompensieren, wird der PullUp manuel gesetzt.
-    gpio_set_pull_mode(GPIO_SDCARD_D3, GPIO_PULLUP_ONLY); // HS2_D3	
+    gpio_set_pull_mode(GPIO_SDCARD_D3, GPIO_PULLUP_ONLY); // HS2_D3    
 
     // Options for mounting the filesystem.
     // If format_if_mount_failed is set to true, SD card will be partitioned and
@@ -534,13 +534,13 @@ void migrateConfiguration(void) {
 
     if (!FileExists(CONFIG_FILE)) {
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Config file seems to be missing!");
-        return;	
+        return;    
     }
 
     std::string section = "";
-	std::ifstream ifs(CONFIG_FILE);
-  	std::string content((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
-	
+    std::ifstream ifs(CONFIG_FILE);
+      std::string content((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+    
     /* Split config file it array of lines */
     std::vector<std::string> configLines = splitString(content);
 
@@ -575,6 +575,26 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], ";Demo = true", ";Demo = false"); // Set it to its default value
             migrated = migrated | replaceString(configLines[i], ";Demo", "Demo"); // Enable it
 
+            migrated = migrated | replaceString(configLines[i], "Brightness", "CamBrightness");
+            migrated = migrated | replaceString(configLines[i], "Contrast", "CamContrast");
+            migrated = migrated | replaceString(configLines[i], "Saturation", "CamSaturation");
+            migrated = migrated | replaceString(configLines[i], "Sharpness", "CamSharpness");
+            
+            migrated = migrated | replaceString(configLines[i], "ImageQuality", "CamQuality");            
+
+            migrated = migrated | replaceString(configLines[i], "Aec2", "CamAec2");
+            migrated = migrated | replaceString(configLines[i], "AutoExposureLevel", "CamAeLevel");
+            migrated = migrated | replaceString(configLines[i], "FixedExposure", "CamAec");
+            
+            migrated = migrated | replaceString(configLines[i], "Zoom", "CamZoom");
+            migrated = migrated | replaceString(configLines[i], "ZoomMode", "CamZoomSize");
+            migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
+            migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
+            
+            migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
+            migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used
+            migrated = migrated | replaceString(configLines[i], "Negative", ";UNUSED_PARAMETER"); // This parameter is no longer used
+
             // Parameter is no longer used
             // migrated = migrated | replaceString(configLines[i], ";FixedExposure = true", ";FixedExposure = false"); // Set it to its default value
             // migrated = migrated | replaceString(configLines[i], ";FixedExposure", "FixedExposure"); // Enable it
@@ -582,12 +602,10 @@ void migrateConfiguration(void) {
 
         if (section == "[Alignment]") {
             // Parameter is no longer used
-            // migrated = migrated | replaceString(configLines[i], ";InitialMirror = true", ";InitialMirror = false"); // Set it to its default value
-            // migrated = migrated | replaceString(configLines[i], ";InitialMirror", "InitialMirror"); // Enable it
-		
-            // Parameter is no longer used
-            // migrated = migrated | replaceString(configLines[i], ";FlipImageSize = true", ";FlipImageSize = false"); // Set it to its default value
-            // migrated = migrated | replaceString(configLines[i], ";FlipImageSize", "FlipImageSize"); // Enable it
+            migrated = migrated | replaceString(configLines[i], "InitialMirror", ";UNUSED_PARAMETER"); // This parameter is no longer used
+            migrated = migrated | replaceString(configLines[i], ";InitialMirror", ";UNUSED_PARAMETER"); // This parameter is no longer used
+            migrated = migrated | replaceString(configLines[i], "FlipImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
+            migrated = migrated | replaceString(configLines[i], ";FlipImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
         }
 
         if (section == "[Digits]") {

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -590,6 +590,7 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
             migrated = migrated | replaceString(configLines[i], "Zoom", "CamZoom");
+            migrated = migrated | replaceString(configLines[i], "CamCam", "Cam"); // Reversion of redundant renamings. This is needed since "Zoom" is contained in multiple parameters and gets replaced with "CamZoom"
             
             migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
             migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -590,7 +590,7 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
             std::string linePrefix = "$";
-            migrated = migrated | replaceString(linePrefix + configLines[i), "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
+            migrated = migrated | replaceString(linePrefix + configLines[i], "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
 
             migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
             migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -589,7 +589,7 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], "ZoomMode", "CamZoomSize");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
-            migrated = migrated | replaceString("$" + configLines[i], "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
+            migrated = migrated | replaceString(std::string("$") + configLines[i], "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
 
             migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
             migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -589,9 +589,8 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], "ZoomMode", "CamZoomSize");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
-            migrated = migrated | replaceString(configLines[i], "Zoom", "CamZoom");
-            migrated = migrated | replaceString(configLines[i], "CamCam", "Cam"); // Reversion of redundant renamings. This is needed since "Zoom" is contained in multiple parameters and gets replaced with "CamZoom"
-            
+            migrated = migrated | replaceString("$" + configLines[i], "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
+
             migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
             migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used
             migrated = migrated | replaceString(configLines[i], "Negative", ";UNUSED_PARAMETER"); // This parameter is no longer used

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -589,7 +589,7 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], "ZoomMode", "CamZoomSize");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
-            migrated = migrated | replaceString(std::string("$") + configLines[i], "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
+            migrated = migrated | replaceString(std::string("$") + std::string(configLines[i]), "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
 
             migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
             migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -586,10 +586,10 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], "AutoExposureLevel", "CamAeLevel");
             migrated = migrated | replaceString(configLines[i], "FixedExposure", "CamAec");
             
-            migrated = migrated | replaceString(configLines[i], "Zoom", "CamZoom");
             migrated = migrated | replaceString(configLines[i], "ZoomMode", "CamZoomSize");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
+            migrated = migrated | replaceString(configLines[i], "Zoom", "CamZoom");
             
             migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
             migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -589,7 +589,8 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], "ZoomMode", "CamZoomSize");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
-            migrated = migrated | replaceString(std::string("$") + std::string(configLines[i]), "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
+            std::string linePrefix = "$";
+            migrated = migrated | replaceString(linePrefix + configLines[i), "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
 
             migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
             migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -727,8 +727,11 @@ void migrateConfiguration(void) {
 
         FILE* pfile = fopen(CONFIG_FILE, "w");        
         for (int i = 0; i < configLines.size(); i++) {
-            fwrite(configLines[i].c_str() , configLines[i].length(), 1, pfile);
-            fwrite("\n" , 1, 1, pfile);
+            if (!isInString(configLines[i], ";UNUSED_PARAMETER"))
+            {
+                fwrite(configLines[i].c_str() , configLines[i].length(), 1, pfile);
+                fwrite("\n" , 1, 1, pfile);
+            }
         }
         fclose(pfile);
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Config file migrated. Saved backup to " + string(CONFIG_FILE_BACKUP));

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -589,8 +589,10 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], "ZoomMode", "CamZoomSize");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
             migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
-            std::string linePrefix = "$";
-            migrated = migrated | replaceString(linePrefix + configLines[i], "$Zoom", "$CamZoom"); // Make sure "Zoom" stands at the start of the line since it is not uniqly used in this parameter
+
+            if (configLines[i].find("Zoom") == 0) { // Parameter starts with "Zoom"
+                migrated = migrated | replaceString(configLines[i], "Zoom", "CamZoom");
+            }
 
             migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
             migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -575,28 +575,27 @@ void migrateConfiguration(void) {
             migrated = migrated | replaceString(configLines[i], ";Demo = true", ";Demo = false"); // Set it to its default value
             migrated = migrated | replaceString(configLines[i], ";Demo", "Demo"); // Enable it
 
-            migrated = migrated | replaceString(configLines[i], "Brightness", "CamBrightness");
-            migrated = migrated | replaceString(configLines[i], "Contrast", "CamContrast");
-            migrated = migrated | replaceString(configLines[i], "Saturation", "CamSaturation");
-            migrated = migrated | replaceString(configLines[i], "Sharpness", "CamSharpness");
-            
-            migrated = migrated | replaceString(configLines[i], "ImageQuality", "CamQuality");            
+            if (configLines[i].find("Brightness") == 0) { // Parameter starts with "Brightness"
+                migrated = migrated | replaceString(configLines[i], "Brightness", "CamBrightness");
+                migrated = migrated | replaceString(configLines[i], "Contrast", "CamContrast");
+                migrated = migrated | replaceString(configLines[i], "Saturation", "CamSaturation");
+                migrated = migrated | replaceString(configLines[i], "Sharpness", "CamSharpness");
 
-            migrated = migrated | replaceString(configLines[i], "Aec2", "CamAec2");
-            migrated = migrated | replaceString(configLines[i], "AutoExposureLevel", "CamAeLevel");
-            migrated = migrated | replaceString(configLines[i], "FixedExposure", "CamAec");
-            
-            migrated = migrated | replaceString(configLines[i], "ZoomMode", "CamZoomSize");
-            migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
-            migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
+                migrated = migrated | replaceString(configLines[i], "ImageQuality", "CamQuality");
 
-            if (configLines[i].find("Zoom") == 0) { // Parameter starts with "Zoom"
+                migrated = migrated | replaceString(configLines[i], "Aec2", "CamAec2");
+                migrated = migrated | replaceString(configLines[i], "AutoExposureLevel", "CamAeLevel");
+                migrated = migrated | replaceString(configLines[i], "FixedExposure", "CamAec");
+
+                migrated = migrated | replaceString(configLines[i], "ZoomMode", "CamZoomSize");
+                migrated = migrated | replaceString(configLines[i], "ZoomOffsetX", "CamZoomOffsetX");
+                migrated = migrated | replaceString(configLines[i], "ZoomOffsetY", "CamZoomOffsetY");
                 migrated = migrated | replaceString(configLines[i], "Zoom", "CamZoom");
-            }
 
-            migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
-            migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used
-            migrated = migrated | replaceString(configLines[i], "Negative", ";UNUSED_PARAMETER"); // This parameter is no longer used
+                migrated = migrated | replaceString(configLines[i], "ImageSize", ";UNUSED_PARAMETER"); // This parameter is no longer used
+                migrated = migrated | replaceString(configLines[i], "Grayscale", ";UNUSED_PARAMETER"); // This parameter is no longer used
+                migrated = migrated | replaceString(configLines[i], "Negative", ";UNUSED_PARAMETER"); // This parameter is no longer used
+            }
 
             // Parameter is no longer used
             // migrated = migrated | replaceString(configLines[i], ";FixedExposure = true", ";FixedExposure = false"); // Set it to its default value


### PR DESCRIPTION
Added migration of CAM parameters:
```
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'Brightness = 0' to 'CamBrightness = 0'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'Contrast = 0' to 'CamContrast = 0'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'Saturation = 0' to 'CamSaturation = 0'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'Sharpness = 0' to 'CamSharpness = 0'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'ImageQuality = 12' to 'CamQuality = 12'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'ImageSize = VGA' to ';UNUSED_PARAMETER = VGA'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'Zoom = false' to 'CamZoom = false'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'ZoomMode = 0' to 'CamZoomSize = 0'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'ZoomOffsetX = 0' to 'CamZoomOffsetX = 0'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'ZoomOffsetY = 0' to 'CamZoomOffsetY = 0'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'Grayscale = false' to ';UNUSED_PARAMETER = false'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'Negative = false' to ';UNUSED_PARAMETER = false'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'Aec2 = false' to 'CamAec2 = false'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'AutoExposureLevel = 0' to 'CamAeLevel = 0'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'FixedExposure = false' to 'CamAec = false'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'InitialMirror = false' to ';UNUSED_PARAMETER = false'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'FlipImageSize = false' to ';UNUSED_PARAMETER = false'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line 'main.AnalogDigitalTransitionStart = 9.2' to 'main.AnalogToDigitTransitionStart = 9.2'
[0d00h00m02s] 2024-10-01T21:53:28 <ERR> [HELPER] Migrated Configfile line ';main.Fieldname = undefined' to ';main.Field = undefined'
[0d00h00m02s] 2024-10-01T21:53:28 <INF> [MAIN] Config file migrated. Saved backup to /sdcard/config/config.bak
```

See https://github.com/jomjol/AI-on-the-edge-device/issues/3277