### PR TITLE
Update the Homeasistant Discovery topics

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ Only changes since RC4 are listed:
     - `value` has now only set the `State Class` to `total_increasing` if `Allow Negative Rates` is NOT set. Else it uses `measurement` as it could go down. Before it was always set to `total_increasing`.
     - The `rate_per_time_unit` topic of an **Energy** meter needs a `Device Class`=`power`. For `gas` and `water` it should be `volume_flow_rate`. Before the `Device Class` was always set to `""`.
 
+  **:warning: Please check your Homeassistant instance to make sure it is handled correctly!**
+
 #### Bug Fixes
 Only changes since RC3 are listed:
  - None

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,10 +8,10 @@ Please check the [issues](https://github.com/jomjol/AI-on-the-edge-device/issues
 
 #### Core Changes
 Only changes since RC4 are listed:
-- Updated the Homeasistant Discovery topics (#3332)
-    - `raw` has now set the `State Class` to `measurement`. Before the `State Class` was always set to `""`. 
-    - `value` has now only set the `State Class` to `total_increasing` if `Allow Negative Rates` is NOT set. Else it uses `measurement` as it could go down. Before it was always set to `total_increasing`.
-    - The `rate_per_time_unit` topic of an **Energy** meter needs a `Device Class`=`power`. For `gas` and `water` it should be `volume_flow_rate`. Before the `Device Class` was always set to `""`.
+- Updated the Homeassistant Discovery topics (#3332):
+    - `raw` has now set the `State Class` to `measurement`. Before it was always set to `""`. 
+    - `value` has now only set the `State Class` to `total_increasing` if the parameter `Allow Negative Rates` is **not** set. Else it uses `measurement` since the rate could also be negative. Before it was always set to `total_increasing`.
+    - The `rate_per_time_unit` topic of an **Energy** meter needs a `Device Class`=`power`. For `gas` and `water` it should be `volume_flow_rate`. Before it was always set to `""`.
 
   **:warning: Please check your Homeassistant instance to make sure it is handled correctly!**
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,25 @@
+## [16.0.0-RC5] - 2024-10-xx
+
+For a full list of changes see [Full list of changes](https://github.com/jomjol/AI-on-the-edge-device/compare/v15.7.0...v16.0.0-RC1)
+
+#### Known issues
+Please check the [issues](https://github.com/jomjol/AI-on-the-edge-device/issues) and
+[discussions](https://github.com/jomjol/AI-on-the-edge-device/discussions) before reporting a new issue.
+
+#### Core Changes
+Only changes since RC4 are listed:
+- Updated the Homeasistant Discovery topics (#3332)
+    - `raw` has now set the `State Class` to `measurement`. Before the `State Class` was always set to `""`. 
+    - `value` has now only set the `State Class` to `total_increasing` if `Allow Negative Rates` is NOT set. Else it uses `measurement` as it could go down. Before it was always set to `total_increasing`.
+    - The `rate_per_time_unit` topic of an **Energy** meter needs a `Device Class`=`power`. For `gas` and `water` it should be `volume_flow_rate`. Before the `Device Class` was always set to `""`.
+
+#### Bug Fixes
+Only changes since RC3 are listed:
+ - None
+
+
+
+
 ## [16.0.0-RC4] - 2024-10-06
 
 For a full list of changes see [Full list of changes](https://github.com/jomjol/AI-on-the-edge-device/compare/v15.7.0...v16.0.0-RC1)
@@ -7,7 +29,7 @@ Please check the [issues](https://github.com/jomjol/AI-on-the-edge-device/issues
 [discussions](https://github.com/jomjol/AI-on-the-edge-device/discussions) before reporting a new issue.
 
 #### Core Changes
-Only changes since RC2 are listed:
+Only changes since RC3 are listed:
 - Update esp32-camera submodule to `v2.0.13` (#3316)
 - Added contributor list (#3317)
 - Added files for demo mode (#3315)

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -151,7 +151,7 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, string& aktparamgraph)
                 mqttServer_setMeterType("water", "L", "h", "L/h");
             }
             else if (toUpper(splitted[1]) == "WATER_FT3") {
-                mqttServer_setMeterType("water", "ft³", "m", "ft³/m"); // Minutes
+                mqttServer_setMeterType("water", "ft³", "m", "ft³/m"); // m = Minutes
             }
             else if (toUpper(splitted[1]) == "WATER_GAL") {
                 mqttServer_setMeterType("water", "gal", "h", "gal/h");
@@ -160,7 +160,7 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, string& aktparamgraph)
                 mqttServer_setMeterType("gas", "m³", "h", "m³/h");
             }
             else if (toUpper(splitted[1]) == "GAS_FT3") {
-                mqttServer_setMeterType("gas", "ft³", "m", "ft³/m"); // Minutes
+                mqttServer_setMeterType("gas", "ft³", "m", "ft³/m"); // m = Minutes
             }
             else if (toUpper(splitted[1]) == "ENERGY_WH") {
                 mqttServer_setMeterType("energy", "Wh", "h", "W");

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -193,7 +193,7 @@ bool MQTThomeassistantDiscovery(int qos) {
         /* Energy meters need a different Device Class, see https://github.com/jomjol/AI-on-the-edge-device/issues/3333 */
         std::string rate_device_class = "volume_flow_rate";
         if (meterType == "energy") {
-            value_state_class = "power";
+            rate_device_class = "power";
         }
 
     //                                                       Group | Field                          | User Friendly Name                | Icon                   | Unit                 | Device Class | State Class       | Entity Category

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -184,6 +184,7 @@ bool MQTThomeassistantDiscovery(int qos) {
             group = "";
         }
 
+        /* If "Allow neg. rate" is true, use "measurement" instead of "total_increasing" for the State Class, see https://github.com/jomjol/AI-on-the-edge-device/issues/3331 */
         std::string value_state_class = "total_increasing";
         if ((*NUMBERS)[i]->AllowNegativeRates) {
             value_state_class = "measurement";

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -190,13 +190,19 @@ bool MQTThomeassistantDiscovery(int qos) {
             value_state_class = "measurement";
         }
 
+        /* Energy meters need a different Device Class, see https://github.com/jomjol/AI-on-the-edge-device/issues/3333 */
+        std::string rate_device_class = "volume_flow_rate";
+        if (meterType == "energy") {
+            value_state_class = "power";
+        }
+
     //                                                       Group | Field                          | User Friendly Name                | Icon                   | Unit                 | Device Class | State Class       | Entity Category
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "value",                      "Value",                            "gauge",                 valueUnit,             meterType,      value_state_class, "", qos); // State Class = "total_increasing" if <NUMBERS>.AllowNegativeRates = false, else use "measurement"
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "raw",                        "Raw Value",                        "raw",                   valueUnit,             meterType,      "measurement",      "diagnostic", qos);
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "error",                      "Error",                            "alert-circle-outline",  "",                    "",             "",                 "diagnostic", qos);
         /* Not announcing "rate" as it is better to use rate_per_time_unit resp. rate_per_digitization_round */
         // allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate",               "Rate (Unit/Minute)",               "swap-vertical",         "",        "",            "",                 ""); // Legacy, always Unit per Minute
-        allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate_per_time_unit",         "Rate (" + rateUnit + ")",          "swap-vertical",         rateUnit,              "",             "measurement",      "", qos);
+        allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate_per_time_unit",         "Rate (" + rateUnit + ")",          "swap-vertical",         rateUnit,              rate_device_class, "measurement",      "", qos);
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate_per_digitization_round",  "Change since last Digitization round",  "arrow-expand-vertical", valueUnit,  "",             "measurement",      "", qos); // correctly the Unit is Unit/Interval!
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "timestamp",                  "Timestamp",                     "clock-time-eight-outline", "",                    "timestamp",    "",                 "diagnostic", qos);
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "json",                       "JSON",                             "code-json",             "",                    "",             "",                 "diagnostic", qos);

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -184,9 +184,14 @@ bool MQTThomeassistantDiscovery(int qos) {
             group = "";
         }
 
+        std::string value_state_class = "total_increasing";
+        if ((*NUMBERS)[i]->AllowNegativeRates) {
+            value_state_class = "measurement";
+        }
+
     //                                                       Group | Field                          | User Friendly Name                | Icon                   | Unit                 | Device Class | State Class       | Entity Category
-        allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "value",                      "Value",                            "gauge",                 valueUnit,             meterType,      "total_increasing", "", qos);
-        allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "raw",                        "Raw Value",                        "raw",                   "",                    "",             "",                 "diagnostic", qos);
+        allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "value",                      "Value",                            "gauge",                 valueUnit,             meterType,      value_state_class, "", qos); // State Class = "total_increasing" if <NUMBERS>.AllowNegativeRates = false, else use "measurement"
+        allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "raw",                        "Raw Value",                        "raw",                   valueUnit,             meterType,      "measurement",      "diagnostic", qos);
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "error",                      "Error",                            "alert-circle-outline",  "",                    "",             "",                 "diagnostic", qos);
         /* Not announcing "rate" as it is better to use rate_per_time_unit resp. rate_per_digitization_round */
         // allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate",               "Rate (Unit/Minute)",               "swap-vertical",         "",        "",            "",                 ""); // Legacy, always Unit per Minute


### PR DESCRIPTION
This PR tries to fix https://github.com/jomjol/AI-on-the-edge-device/issues/3331 and https://github.com/jomjol/AI-on-the-edge-device/issues/3333

---

Changes:
    - `raw` has now set the `State Class` to `measurement`. Before it was always set to `""`. 
    - `value` has now only set the `State Class` to `total_increasing` if the parameter `Allow Negative Rates` is **not** set. Else it uses `measurement` since the rate could also be negative. Before it was always set to `total_increasing`.
    - The `rate_per_time_unit` topic of an **Energy** meter needs a `Device Class`=`power`. For `gas` and `water` it should be `volume_flow_rate`. Before it was always set to `""`.