### PR TITLE
Fix 'AnalogToDigitTransitionStart' always using 9.2 regardless of the configured value.

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -564,7 +564,7 @@ bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, string& aktparamgraph) 
             handleDecimalSeparator(splitted[0], splitted[1]);
         }
 	    
-        if ((toUpper(_param) == "AnalogToDigitTransitionStart") && (splitted.size() > 1)) {
+        if ((toUpper(_param) == "ANALOGTODIGITTRANSITIONSTART") && (splitted.size() > 1)) {
             handleAnalogToDigitTransitionStart(splitted[0], splitted[1]);
         }
 	    


### PR DESCRIPTION
Since the October parameter rename we're always using the default 9.2 value of AnalogToDigitTransitionStart, regardless of the configuration.

This was caused by accidentally replacing the UPPERCASE string with a CamelCase version. 
As we're using `toUpper` to check if that's the config parameter to parse - this check never succeeds.

This PR replaces the CamelCase string with the UPPERCASE version, restoring the ability to configure the value of AnalogToDigitTransitionStart.