### PR TITLE
overview_add_date_and_time

### DIFF
--- a/code/components/jomjol_flowcontroll/MainFlowControl.cpp
+++ b/code/components/jomjol_flowcontroll/MainFlowControl.cpp
@@ -1487,6 +1487,28 @@ esp_err_t handler_rssi(httpd_req_t *req)
     return ESP_OK;
 }
 
+esp_err_t handler_current_date(httpd_req_t *req)
+{
+#ifdef DEBUG_DETAIL_ON
+    LogFile.WriteHeapInfo("handler_uptime - Start");
+#endif
+
+    std::string formatedDateAndTime = getCurrentTimeString("%Y-%m-%d %H:%M:%S");
+    // std::string formatedDate = getCurrentTimeString("%Y-%m-%d");
+
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_send(req, formatedDateAndTime.c_str(), formatedDateAndTime.length());
+
+    /* Respond with an empty chunk to signal HTTP response completion */
+    httpd_resp_sendstr_chunk(req, NULL);
+
+#ifdef DEBUG_DETAIL_ON
+    LogFile.WriteHeapInfo("handler_uptime - End");
+#endif
+
+    return ESP_OK;
+}
+
 esp_err_t handler_uptime(httpd_req_t *req)
 {
 #ifdef DEBUG_DETAIL_ON
@@ -1795,6 +1817,11 @@ void register_server_main_flow_task_uri(httpd_handle_t server)
 
     camuri.uri = "/rssi";
     camuri.handler = handler_rssi;
+    camuri.user_ctx = (void *)"Light Off";
+    httpd_register_uri_handler(server, &camuri);
+
+    camuri.uri = "/date";
+    camuri.handler = handler_current_date;
     camuri.user_ctx = (void *)"Light Off";
     httpd_register_uri_handler(server, &camuri);
 

--- a/code/main/server_main.cpp
+++ b/code/main/server_main.cpp
@@ -459,7 +459,7 @@ httpd_handle_t start_webserver(void)
     config.server_port = 80;
     config.ctrl_port = 32768;
     config.max_open_sockets = 5; //20210921 --> previously 7   
-    config.max_uri_handlers = 40; // Make sure this fits all URI handlers. Memory usage in bytes: 6*max_uri_handlers
+    config.max_uri_handlers = 41; // Make sure this fits all URI handlers. Memory usage in bytes: 6*max_uri_handlers
     config.max_resp_headers = 8;                        
     config.backlog_conn = 5;                        
     config.lru_purge_enable = true; // this cuts old connections if new ones are needed.               

--- a/sd-card/html/overview.html
+++ b/sd-card/html/overview.html
@@ -118,6 +118,7 @@
 		</tr>	
 		<tr>	
 			<td class="tg-4">
+				<div id="sntp_date" ></div>
 				<div id="timestamp" ></div>	
 				<div id="cputemp" ></div>	
 				<div id="rssi" ></div>
@@ -153,6 +154,7 @@
 			loadValue("prevalue", "prevalue", "border-collapse: collapse; width: 100%");
 			loadValue("error", "error", "border-collapse: collapse; width: 100%");
 			loadStatus();
+			loadSntpDate();
 			loadCPUTemp();
 			loadRSSI();
 			loadUptime();
@@ -232,6 +234,20 @@
 			
 			xhttp.open("GET", url, true);
 			xhttp.send();		
+		}
+
+		function loadSntpDate() {
+			url = domainname + '/date';
+			var xhttp = new XMLHttpRequest();
+			xhttp.onreadystatechange = function () {
+				if (this.readyState == 4 && this.status == 200) {
+					var _rsp = xhttp.responseText;
+					$('#sntp_date').html("Date: " + _rsp);
+				}
+			}
+
+			xhttp.open("GET", url, true);
+			xhttp.send();
 		}
 
 		function loadUptime() {

--- a/sd-card/html/overview.html
+++ b/sd-card/html/overview.html
@@ -242,7 +242,7 @@
 			xhttp.onreadystatechange = function () {
 				if (this.readyState == 4 && this.status == 200) {
 					var _rsp = xhttp.responseText;
-					$('#sntp_date').html("Date: " + _rsp);
+					$('#sntp_date').html("Date/Time on device: " + _rsp);
 				}
 			}
 


### PR DESCRIPTION
Adds he devices date/time to the overview page:
![grafik](https://github.com/user-attachments/assets/f08c9c3a-7d21-42a1-8653-cacaecb0496a)

See https://github.com/jomjol/AI-on-the-edge-device/issues/3140#issuecomment-2492045772