### PR TITLE
Extend Homeassistant discovery with button for flow start

### DIFF
--- a/code/components/jomjol_mqtt/interface_mqtt.cpp
+++ b/code/components/jomjol_mqtt/interface_mqtt.cpp
@@ -388,13 +388,7 @@ bool mqtt_handler_flow_start(std::string _topic, char* _data, int _data_len)
 {
     ESP_LOGD(TAG, "Handler called: topic %s, data %.*s", _topic.c_str(), _data_len, _data);
 
-    if (_data_len > 0) {
-        MQTTCtrlFlowStart(_topic);
-    }
-    else {
-        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "handler_flow_start: handler called, but no data");
-    }
-
+    MQTTCtrlFlowStart(_topic);
     return ESP_OK;
 }
 

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -119,7 +119,6 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
         }
         else if (field == "flowstart") { // Special case: Button
             payload += "\"cmd_t\":\"~/ctrl/flow_start\","; // Add command topic
-            payload += "\"pl_prs\":\"1\",";
         }
         else {
             payload += "\"state_topic\": \"~/" + field + "\",";

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -118,7 +118,7 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
             payload += "\"value_template\": \"{{ 'OFF' if 'no error' in value else 'ON'}}\",";
         }
         else if (field == "flowstart") { // Special case: Button
-            payload += "\"cmd_t\":\"~" + "/ctrl/flow_start" + "\","; // Add command topic
+            payload += "\"cmd_t\":\"~/ctrl/flow_start\","; // Add command topic
             payload += "\"pl_prs\":\"1\",";
         }
         else {

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -85,8 +85,11 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
      * This means a maintopic "home/test/watermeter" is transformed to the discovery topic "homeassistant/sensor/watermeter/..."
     */
     std::string node_id = createNodeId(maintopic);
-    if (field == "problem") { // Special binary sensor which is based on error topic
+    if (field == "problem") { // Special case: Binary sensor which is based on error topic
         topicFull = "homeassistant/binary_sensor/" + node_id + "/" + configTopic + "/config";
+    }
+    else if (field == "flowstart") { // Special case: Button
+        topicFull = "homeassistant/button/" + node_id + "/" + configTopic + "/config";
     }
     else {
         topicFull = "homeassistant/sensor/" + node_id + "/" + configTopic + "/config";
@@ -101,7 +104,7 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
         "\"icon\": \"mdi:" + icon + "\",";        
 
     if (group != "") {
-        if (field == "problem") { // Special binary sensor which is based on error topic
+        if (field == "problem") { // Special case: Binary sensor which is based on error topic
             payload += "\"state_topic\": \"~/" + group + "/error\",";
             payload += "\"value_template\": \"{{ 'OFF' if 'no error' in value else 'ON'}}\",";
         }
@@ -110,9 +113,13 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
         }
     }
     else {
-        if (field == "problem") { // Special binary sensor which is based on error topic
+        if (field == "problem") { // Special case: Binary sensor which is based on error topic
             payload += "\"state_topic\": \"~/error\",";
             payload += "\"value_template\": \"{{ 'OFF' if 'no error' in value else 'ON'}}\",";
+        }
+        else if (field == "flowstart") { // Special case: Button
+            payload += "\"cmd_t\":\"~" + "/ctrl/flow_start" + "\","; // Add command topic
+            payload += "\"pl_prs\":\"1\",";
         }
         else {
             payload += "\"state_topic\": \"~/" + field + "\",";
@@ -176,6 +183,7 @@ bool MQTThomeassistantDiscovery(int qos) {
     allSendsSuccessed |= sendHomeAssistantDiscoveryTopic("",     "interval",        "Interval",          "clock-time-eight-outline", "min",  ""           ,    "measurement", "diagnostic", qos);
     allSendsSuccessed |= sendHomeAssistantDiscoveryTopic("",     "IP",              "IP",                "network-outline",           "",    "",               "",            "diagnostic", qos);
     allSendsSuccessed |= sendHomeAssistantDiscoveryTopic("",     "status",          "Status",            "list-status",               "",    "",               "",            "diagnostic", qos);
+    allSendsSuccessed |= sendHomeAssistantDiscoveryTopic("",     "flowstart",       "Manual Flow Start", "timer-play-outline",        "",    "update",         "",            "config",     qos);
 
 
     for (int i = 0; i < (*NUMBERS).size(); ++i) {

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -183,7 +183,7 @@ bool MQTThomeassistantDiscovery(int qos) {
     allSendsSuccessed |= sendHomeAssistantDiscoveryTopic("",     "interval",        "Interval",          "clock-time-eight-outline", "min",  ""           ,    "measurement", "diagnostic", qos);
     allSendsSuccessed |= sendHomeAssistantDiscoveryTopic("",     "IP",              "IP",                "network-outline",           "",    "",               "",            "diagnostic", qos);
     allSendsSuccessed |= sendHomeAssistantDiscoveryTopic("",     "status",          "Status",            "list-status",               "",    "",               "",            "diagnostic", qos);
-    allSendsSuccessed |= sendHomeAssistantDiscoveryTopic("",     "flowstart",       "Manual Flow Start", "timer-play-outline",        "",    "update",         "",            "config",     qos);
+    allSendsSuccessed |= sendHomeAssistantDiscoveryTopic("",     "flowstart",       "Manual Flow Start", "timer-play-outline",        "",    "",               "",            "",           qos);
 
 
     for (int i = 0; i < (*NUMBERS).size(); ++i) {


### PR DESCRIPTION
See https://github.com/jomjol/AI-on-the-edge-device/issues/3302

- [x]     ctrl/flow_start
- [x] Remove `if (_data_len > 0) { `, see https://github.com/jomjol/AI-on-the-edge-device/issues/3302#issuecomment-2422087912 

##  ctrl/flow_start
Adds a button to to Homeassistant to trigger the flow:
![grafik](https://github.com/user-attachments/assets/dbcd13d7-3803-47b0-b0a0-64411bb7a6c7)

## out of scope for this Pull request:
- [ ]     ctrl/set_prevalue
- [ ]     GPIO/GPIO{PinNumber} -> but only those pins which have MQTT enabled