### PR TITLE
fix for ledintensity

### DIFF
--- a/code/components/jomjol_controlcamera/ClassControllCamera.h
+++ b/code/components/jomjol_controlcamera/ClassControllCamera.h
@@ -80,6 +80,8 @@ protected:
     void SanitizeZoomParams(int imageSize, int frameSizeX, int frameSizeY, int &imageWidth, int &imageHeight, int &zoomOffsetX, int &zoomOffsetY);
 
 public:
+    int LedIntensity = 4096;
+
     CCamera(void);
     esp_err_t InitCam(void);
 
@@ -98,7 +100,7 @@ public:
     void SetZoomSize(bool zoomEnabled, int zoomOffsetX, int zoomOffsetY, int imageSize, int imageVflip);
     void SetCamSharpness(bool _autoSharpnessEnabled, int _sharpnessLevel);
 
-    void SetLEDIntensity(float _intrel);
+    int SetLEDIntensity(int _intrel);
     bool testCamera(void);
     bool getCameraInitSuccessful(void);
     void useDemoMode(void);

--- a/code/components/jomjol_controlcamera/server_camera.cpp
+++ b/code/components/jomjol_controlcamera/server_camera.cpp
@@ -101,6 +101,7 @@ esp_err_t handler_capture(httpd_req_t *req)
         {
             Camera.setSensorDatenFromCCstatus(); // CCstatus >>> Kamera
             Camera.SetQualityZoomSize(CCstatus.ImageQuality, CCstatus.ImageFrameSize, CCstatus.ImageZoomEnabled, CCstatus.ImageZoomOffsetX, CCstatus.ImageZoomOffsetY, CCstatus.ImageZoomSize, CCstatus.ImageVflip);
+            Camera.LedIntensity = CCstatus.ImageLedIntensity;
             CFstatus.changedCameraSettings = false;
         }
 
@@ -159,6 +160,7 @@ esp_err_t handler_capture_with_light(httpd_req_t *req)
         {
             Camera.setSensorDatenFromCCstatus(); // CCstatus >>> Kamera
             Camera.SetQualityZoomSize(CCstatus.ImageQuality, CCstatus.ImageFrameSize, CCstatus.ImageZoomEnabled, CCstatus.ImageZoomOffsetX, CCstatus.ImageZoomOffsetY, CCstatus.ImageZoomSize, CCstatus.ImageVflip);
+            Camera.LedIntensity = CCstatus.ImageLedIntensity;
             CFstatus.changedCameraSettings = false;
         }
 
@@ -241,6 +243,7 @@ esp_err_t handler_capture_save_to_file(httpd_req_t *req)
         {
             Camera.setSensorDatenFromCCstatus(); // CCstatus >>> Kamera
             Camera.SetQualityZoomSize(CCstatus.ImageQuality, CCstatus.ImageFrameSize, CCstatus.ImageZoomEnabled, CCstatus.ImageZoomOffsetX, CCstatus.ImageZoomOffsetY, CCstatus.ImageZoomSize, CCstatus.ImageVflip);
+            Camera.LedIntensity = CCstatus.ImageLedIntensity;
             CFstatus.changedCameraSettings = false;
         }
 

--- a/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowTakeImage.cpp
@@ -499,8 +499,8 @@ bool ClassFlowTakeImage::ReadParameter(FILE *pfile, string &aktparamgraph)
         {
             if (isStringNumeric(splitted[1]))
             {
-                float ledintensity = std::stof(splitted[1]);
-                Camera.SetLEDIntensity(ledintensity);
+                int ledintensity = std::stoi(splitted[1]);
+                CCstatus.ImageLedIntensity = Camera.SetLEDIntensity(ledintensity);
             }
         }
 
@@ -559,6 +559,7 @@ bool ClassFlowTakeImage::doFlow(string zwtime)
     {
         Camera.setSensorDatenFromCCstatus(); // CCstatus >>> Kamera
         Camera.SetQualityZoomSize(CCstatus.ImageQuality, CCstatus.ImageFrameSize, CCstatus.ImageZoomEnabled, CCstatus.ImageZoomOffsetX, CCstatus.ImageZoomOffsetY, CCstatus.ImageZoomSize, CCstatus.ImageVflip);
+        Camera.LedIntensity = CCstatus.ImageLedIntensity;
         CFstatus.changedCameraSettings = false;
     }
 

--- a/code/components/jomjol_flowcontroll/MainFlowControl.cpp
+++ b/code/components/jomjol_flowcontroll/MainFlowControl.cpp
@@ -1348,9 +1348,8 @@ esp_err_t handler_editflow(httpd_req_t *req)
                 std::string _ledi = std::string(_valuechar);
                 if (isStringNumeric(_ledi))
                 {
-                    float _ImageLedIntensity = std::stof(_valuechar);
-                    Camera.SetLEDIntensity(_ImageLedIntensity);
-                    CFstatus.ImageLedIntensity = CCstatus.ImageLedIntensity;
+                    int _ImageLedIntensity = std::stoi(_valuechar);
+                    CFstatus.ImageLedIntensity = Camera.SetLEDIntensity(_ImageLedIntensity);
                 }
             }
 


### PR DESCRIPTION
When creating a new reference image, the LED intensity was always set fixed.
This sets it temporarily and only fixed when the reference image is saved.

The problem could only be noticed if you created a reference image with a change in the LED intensity, but did not save the reference image and then e.g. went to the overview page(each subsequent round is carried out with the changed LED intensity, the saved value is only used after a restart).

May be affected by this: https://github.com/jomjol/AI-on-the-edge-device/issues/3338#issuecomment-2510304579