### PR TITLE
fix for incorrect decimal shift?

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -96,7 +96,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
                     prev = PointerEvalHybridNew(GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float, prev, prev);
                 }
 
-                // is necessary because a number greater than 9.994999 returns a 10! (for further details see lines 159 to 161)
+                // is necessary because a number greater than 9.994999 returns a 10! (for further details see check in PointerEvalHybridNew)
                 if ((prev >= 0) && (prev < 10)) {
                     result = std::to_string(prev);
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100)  prev=" + std::to_string(prev));

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -96,6 +96,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
                     prev = PointerEvalHybridNew(GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float, prev, prev);
                 }
 
+                // is necessary because a number greater than 9.994999 returns a 10! (for further details see lines 159 to 161)
                 if ((prev >= 0) && (prev < 10)) {
                     result = std::to_string(prev);
                     LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100)  prev=" + std::to_string(prev));
@@ -155,7 +156,10 @@ int ClassFlowCNNGeneral::PointerEvalHybridNew(float number, float number_of_pred
         // on first digit is no spezial logic for transition needed
         // we use the recognition as given. The result is the int value of the recognition
         // add precisition of 2 digits and round before trunc
-        result = (int) ((int) trunc(round((number+10 % 10)*100)) )  / 100;
+        // a number greater than 9.994999 is returned as 10, this leads to an error during the decimal shift because the NUMBERS[j]->ReturnRawValue is one digit longer.
+        // To avoid this, an additional test must be carried out, see lines 99 to 106
+        // Another alternative would be "result = (int) ((int) trunc(round((number+10 % 10)*1000))) / 1000;", which could, however, lead to other errors?
+        result = (int) ((int) trunc(round((number+10 % 10)*100)))  / 100;
 
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "PointerEvalHybridNew - No predecessor - Result = " + std::to_string(result) +
                                                     " number: " + std::to_string(number) + " number_of_predecessors = " + std::to_string(number_of_predecessors)+ " eval_predecessors = " + std::to_string(eval_predecessors) + " Digit_Uncertainty = " +  std::to_string(Digit_Uncertainty));

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -157,7 +157,7 @@ int ClassFlowCNNGeneral::PointerEvalHybridNew(float number, float number_of_pred
         // we use the recognition as given. The result is the int value of the recognition
         // add precisition of 2 digits and round before trunc
         // a number greater than 9.994999 is returned as 10, this leads to an error during the decimal shift because the NUMBERS[j]->ReturnRawValue is one digit longer.
-        // To avoid this, an additional test must be carried out, see "if (CNNType == Digit)" check in getReadout()
+        // To avoid this, an additional test must be carried out, see "if ((CNNType == DoubleHyprid10) || (CNNType == Digit100))" check in getReadout()
         // Another alternative would be "result = (int) ((int) trunc(round((number+10 % 10)*1000))) / 1000;", which could, however, lead to other errors?
         result = (int) ((int) trunc(round((number+10 % 10)*100)) )  / 100;
 

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -157,7 +157,7 @@ int ClassFlowCNNGeneral::PointerEvalHybridNew(float number, float number_of_pred
         // we use the recognition as given. The result is the int value of the recognition
         // add precisition of 2 digits and round before trunc
         // a number greater than 9.994999 is returned as 10, this leads to an error during the decimal shift because the NUMBERS[j]->ReturnRawValue is one digit longer.
-        // To avoid this, an additional test must be carried out, see lines 99 to 106
+        // To avoid this, an additional test must be carried out, see "if (CNNType == Digit)" check in getReadout()
         // Another alternative would be "result = (int) ((int) trunc(round((number+10 % 10)*1000))) / 1000;", which could, however, lead to other errors?
         result = (int) ((int) trunc(round((number+10 % 10)*100)) )  / 100;
 

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -65,11 +65,11 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
 
     if (CNNType == Digit) {
         for (int i = 0; i < GENERAL[_analog]->ROI.size(); ++i) {
-            if (GENERAL[_analog]->ROI[i]->result_klasse >= 10) {
-                result = result + "N";
+            if ((GENERAL[_analog]->ROI[i]->result_klasse >= 0) && (GENERAL[_analog]->ROI[i]->result_klasse < 10)) {
+                result = result + std::to_string(GENERAL[_analog]->ROI[i]->result_klasse);
             }
             else {
-                result = result + std::to_string(GENERAL[_analog]->ROI[i]->result_klasse);
+                result = result + "N";
             }
         }
         return result;
@@ -78,7 +78,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
     if ((CNNType == DoubleHyprid10) || (CNNType == Digit100)) {
         float number = GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float;
         // NaN?
-        if (number >= 0) {
+        if ((number >= 0) && (number < 10)) {
             // is only set if it is the first digit (no analogue before!)
             if (_extendedResolution) {
                 int result_after_decimal_point = ((int) floor(number * 10)) % 10;
@@ -107,7 +107,7 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
         }
 
         for (int i = GENERAL[_analog]->ROI.size() - 2; i >= 0; --i) {
-            if (GENERAL[_analog]->ROI[i]->result_float >= 0) {
+            if ((GENERAL[_analog]->ROI[i]->result_float >= 0) && (GENERAL[_analog]->ROI[i]->result_float < 10)) {
                 prev = PointerEvalHybridNew(GENERAL[_analog]->ROI[i]->result_float, GENERAL[_analog]->ROI[i+1]->result_float, prev);
                 LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout#PointerEvalHybridNew()= " + std::to_string(prev));
                 result = std::to_string(prev) + result;

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -159,7 +159,7 @@ int ClassFlowCNNGeneral::PointerEvalHybridNew(float number, float number_of_pred
         // a number greater than 9.994999 is returned as 10, this leads to an error during the decimal shift because the NUMBERS[j]->ReturnRawValue is one digit longer.
         // To avoid this, an additional test must be carried out, see lines 99 to 106
         // Another alternative would be "result = (int) ((int) trunc(round((number+10 % 10)*1000))) / 1000;", which could, however, lead to other errors?
-        result = (int) ((int) trunc(round((number+10 % 10)*100)))  / 100;
+        result = (int) ((int) trunc(round((number+10 % 10)*100)) )  / 100;
 
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "PointerEvalHybridNew - No predecessor - Result = " + std::to_string(result) +
                                                     " number: " + std::to_string(number) + " number_of_predecessors = " + std::to_string(number_of_predecessors)+ " eval_predecessors = " + std::to_string(eval_predecessors) + " Digit_Uncertainty = " +  std::to_string(Digit_Uncertainty));

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -102,9 +102,6 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
                 }
                 else {
                     result = "N";
-                    if (_extendedResolution && (CNNType != Digit)) {
-                        result = "NN";
-                    }
                 }
             }
         }
@@ -126,7 +123,6 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
                 prev = -1;
                 result = "N" + result;
                 LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(result_float<0 /'N')  result_float=" + std::to_string(GENERAL[_analog]->ROI[i]->result_float));
-        
             }
         }
         return result;

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -95,8 +95,17 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
                 else {
                     prev = PointerEvalHybridNew(GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float, prev, prev);
                 }
-                result = std::to_string(prev);
-                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100)  prev=" + std::to_string(prev));
+
+                if ((prev >= 0) && (prev < 10)) {
+                    result = std::to_string(prev);
+                    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout(dig100)  prev=" + std::to_string(prev));
+                }
+                else {
+                    result = "N";
+                    if (_extendedResolution && (CNNType != Digit)) {
+                        result = "NN";
+                    }
+                }
             }
         }
         else {


### PR DESCRIPTION
could be a fix for the following problems:
https://github.com/jomjol/AI-on-the-edge-device/discussions/3439#discussioncomment-11574676
https://github.com/jomjol/AI-on-the-edge-device/issues/3445

The error occurs when the following conditions exist:
- CNNType = DoubleHyprid10 or Digit100
- Transition from 9 to 0 or a NaN of the last digital digit
- Extendedresolution disabled

One solution (if you only have digital digits) was/is to activate the Extendedresolution.

Unfortunately, it is impossible to fix the problem correctly, since a number of the last digit greater than 9.994999 is a correctly recognized number for some user/condition and a NaN for others user/condition?
With this fix, a number greater than 9.994999 is always classified as a NaN and the correction is made in the further steps (findDelimiterPos() / checkDigitIncreaseConsistency()).

https://github.com/jomjol/AI-on-the-edge-device/issues/3445
````
Read: 43643.610 - Pre: 4363.904 - Rate: 39279.706,3.8,3.0,6.0,4.0,3.0,7.0,10.0

should be "Read: 4364,369"
````

https://github.com/jomjol/AI-on-the-edge-device/discussions/3439#discussioncomment-11574676
````
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout _analog=0, _extendedResolution=0, prev=-1
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] PointerEvalHybridNew - No predecessor - Result = 10 number: 9.996094 number_of_predecessors = -1.000000 eval_predecessors = -1 Digital_Uncertainty = 0.200000
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout(dig100) prev=10
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] PointerEvalHybridNew - O analogue predecessor, >= 9.5 --> no zero crossing yet = 4 number: 4.863281 number_of_predecessors = 9.996094 eval_predecessors = 10 Digital_Uncertainty = 0.200000 result_after_decimal_point = 8
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#PointerEvalHybridNew()= 4
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#result= 410
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] PointerEvalHybridNew - NO analogue predecessor, no change of digits, as pre-decimal point far enough away = 5 number: 4.796875 number_of_predecessors = 4.863281 eval_predecessors = 4 Digital_Uncertainty = 0.200000
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#PointerEvalHybridNew()= 5
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#result= 5410
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] PointerEvalHybridNew - NO analogue predecessor, no change of digits, as pre-decimal point far enough away = 2 number: 2.000000 number_of_predecessors = 4.796875 eval_predecessors = 5 Digital_Uncertainty = 0.200000
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#PointerEvalHybridNew()= 2
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#result= 25410
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] PointerEvalHybridNew - NO analogue predecessor, no change of digits, as pre-decimal point far enough away = 7 number: 6.984375 number_of_predecessors = 2.000000 eval_predecessors = 2 Digital_Uncertainty = 0.200000
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#PointerEvalHybridNew()= 7
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#result= 725410
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] PointerEvalHybridNew - NO analogue predecessor, no change of digits, as pre-decimal point far enough away = 3 number: 3.000000 number_of_predecessors = 6.984375 eval_predecessors = 7 Digital_Uncertainty = 0.200000
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#PointerEvalHybridNew()= 3
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [CNN] getReadout#result= 3725410
[0d00h09m23s] 2024-12-15T14:28:15 <DBG> [POSTPROC] handleAllowNegativeRate for device: Gas
[0d00h09m23s] 2024-12-15T14:28:15 <ERR> [POSTPROC] Gas: Raw: 37254.10, Value: , Status: Rate too high - Read: 37254.10 - Pre: 3725.48 - Rate: 33528.62

should be "Read: 3725.49"
````
