### PR TITLE
added and activated espressif mDNS service

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "code/components/stb"]
 	path = code/components/stb
 	url = https://github.com/nothings/stb.git
+[submodule "code/esp-protocols"]
+	path = code/esp-protocols
+	url = https://github.com/espressif/esp-protocols.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,6 @@
 [submodule "code/components/stb"]
 	path = code/components/stb
 	url = https://github.com/nothings/stb.git
-[submodule "code/esp-protocols"]
-	path = code/esp-protocols
+[submodule "code/components/esp-protocols"]
+	path = code/components/esp-protocols
 	url = https://github.com/espressif/esp-protocols.git

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0)
 
-list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common components/esp-tflite-micro)
+list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common components/esp-tflite-micro esp-protocols/components/mdns)
 
 ADD_CUSTOM_COMMAND(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version.cpp

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0)
 
-list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common components/esp-tflite-micro esp-protocols/components/mdns)
+list(APPEND EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common components/esp-tflite-micro components/esp-protocols/components/mdns)
 
 ADD_CUSTOM_COMMAND(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version.cpp

--- a/code/components/jomjol_wlan/connect_wlan.cpp
+++ b/code/components/jomjol_wlan/connect_wlan.cpp
@@ -49,6 +49,9 @@
 #define ets_delay_us(a) esp_rom_delay_us(a)
 #endif
 
+#include "../../esp-protocols/components/mdns/include/mdns.h" 
+
+
 static const char *TAG = "WIFI";
 
 static bool APWithBetterRSSI = false;
@@ -657,6 +660,14 @@ esp_err_t wifi_init_sta(void)
         else {
 			LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Set hostname to: " + wlan_config.hostname);
         }
+		//initialize mDNS service
+        retval = mdns_init();
+        if (retval != ESP_OK) {
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "mdns_init failed! Error: "  + std::to_string(retval));
+        } else {
+			//set mdns hostname
+			mdns_hostname_set(wlan_config.hostname.c_str());
+	    }
     }
 
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Init successful");

--- a/code/components/jomjol_wlan/connect_wlan.cpp
+++ b/code/components/jomjol_wlan/connect_wlan.cpp
@@ -49,7 +49,7 @@
 #define ets_delay_us(a) esp_rom_delay_us(a)
 #endif
 
-#include "../../esp-protocols/components/mdns/include/mdns.h" 
+#include "../esp-protocols/components/mdns/include/mdns.h" 
 
 
 static const char *TAG = "WIFI";


### PR DESCRIPTION
Namensaufösung über mDNS, basierend auf der mDNS Komponente von Espressif https://github.com/espressif/esp-protocols
 

Zugriff über den Namen z.b. http://watermeter.local/ möglich. 
Das herausfinden der IP-Adresse wird einfacher bzw. ist nicht mehr notwendig.

Die Ordnerstruktur von esp-protocols passt nicht ganz zu AI-on-the-edge-device. Vielleicht gibt's eine bessere Variante das einzubinden als die von mir gewählte. 