### PR TITLE
Rewrite InfluxDB Interfache

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
@@ -120,7 +120,7 @@ bool ClassFlowInfluxDB::ReadParameter(FILE* pfile, string& aktparamgraph)
 
 /////////////////////// NEW //////////////////////////
 //        InfluxDBInit(uri, database, user, password);
-        influxDB.InfluxDBInit(uri, database, user, password);
+        influxDB.InfluxDBInitV1(uri, database, user, password);
 /////////////////////// NEW //////////////////////////
 
         InfluxDBenable = true;

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.cpp
@@ -117,7 +117,12 @@ bool ClassFlowInfluxDB::ReadParameter(FILE* pfile, string& aktparamgraph)
     { 
 //        ESP_LOGD(TAG, "Init InfluxDB with uri: %s, measurement: %s, user: %s, password: %s", uri.c_str(), measurement.c_str(), user.c_str(), password.c_str());
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init InfluxDB with uri: " + uri + ", user: " + user + ", password: " + password);
-        InfluxDBInit(uri, database, user, password); 
+
+/////////////////////// NEW //////////////////////////
+//        InfluxDBInit(uri, database, user, password);
+        influxDB.InfluxDBInit(uri, database, user, password);
+/////////////////////// NEW //////////////////////////
+
         InfluxDBenable = true;
     } else {
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDB init skipped as we are missing some parameters");
@@ -169,7 +174,12 @@ bool ClassFlowInfluxDB::doFlow(string zwtime)
             }
 
             if (result.length() > 0)   
-                InfluxDBPublish(measurement, namenumber, result, timeutc);
+//////////////////////// NEW //////////////////////////            
+//                InfluxDBPublish(measurement, namenumber, result, timeutc);
+                influxDB.InfluxDBPublish(measurement, namenumber, result, timeutc);
+//////////////////////// NEW //////////////////////////
+
+
         }
     }
    

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDB.h
@@ -8,6 +8,7 @@
 #include "ClassFlow.h"
 
 #include "ClassFlowPostProcessing.h"
+#include "interface_influxdb.h"
 
 #include <string>
 
@@ -20,6 +21,8 @@ protected:
 	ClassFlowPostProcessing* flowpostprocessing;  
     std::string user, password; 
     bool InfluxDBenable;
+
+    InfluxDB influxDB;
 
     void SetInitialParameter(void);    
     

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.cpp
@@ -123,7 +123,14 @@ bool ClassFlowInfluxDBv2::ReadParameter(FILE* pfile, string& aktparamgraph)
     { 
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Init InfluxDB with uri: " + uri + ", org: " + dborg + ", token: *****");
 //        printf("vor V2 Init\n");
-        InfluxDB_V2_Init(uri, bucket, dborg, dbtoken); 
+
+
+////////////////////////////////////////// NEW ////////////////////////////////////////////
+//        InfluxDB_V2_Init(uri, bucket, dborg, dbtoken);
+//        InfluxDB_V2_Init(uri, bucket, dborg, dbtoken); 
+        influxdb.InfluxDBInitV2(uri, bucket, dborg, dbtoken);
+////////////////////////////////////////// NEW ////////////////////////////////////////////
+
 //        printf("nach V2 Init\n");
         InfluxDBenable = true;
     } else {
@@ -232,7 +239,8 @@ bool ClassFlowInfluxDBv2::doFlow(string zwtime)
             printf("vor sende Influx_DB_V2 - namenumber. %s, result: %s, timestampt: %s", namenumber.c_str(), result.c_str(), resulttimestamp.c_str());
 
             if (result.length() > 0)   
-                InfluxDB_V2_Publish(measurement, namenumber, result, resulttimeutc);
+                influxdb.InfluxDBPublish(measurement, namenumber, result, resulttimeutc);
+//                InfluxDB_V2_Publish(measurement, namenumber, result, resulttimeutc);
         }
     }
    

--- a/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowInfluxDBv2.h
@@ -9,6 +9,8 @@
 
 #include "ClassFlowPostProcessing.h"
 
+#include "interface_influxdb.h"
+
 #include <string>
 
 class ClassFlowInfluxDBv2 :
@@ -20,6 +22,8 @@ protected:
     std::string OldValue;
 	ClassFlowPostProcessing* flowpostprocessing;  
     bool InfluxDBenable;
+
+    InfluxDB influxdb;
 
     void SetInitialParameter(void);     
 

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -8,236 +8,9 @@
 #include "time_sntp.h"
 #include "../../include/defines.h"
 
-
 static const char *TAG = "INFLUXDB";
 
-std::string _influxDBURI;
-std::string _influxDBDatabase;
-std::string _influxDBUser;
-std::string _influxDBPassword;
-
-std::string _influxDB_V2_URI;
-std::string _influxDB_V2_Bucket;
-std::string _influxDB_V2_Token;
-std::string _influxDB_V2_Org;
-
-
-/**/
-/////////////////////////////////////////////////////////////////////////////////////
-    void InfluxDB::InfluxDBInitV1(std::string _influxDBURI, std::string _database, std::string _user, std::string _password) {
-        version = INFLUXDB_V1;
-        influxDBURI = _influxDBURI;
-        database = _database;
-        user = _user;
-        password = _password;
-
-        esp_http_client_config_t config = {};
-        config.url = influxDBURI.c_str();
-        config.auth_type = HTTP_AUTH_TYPE_BASIC;
-        config.username = user.c_str();
-        config.password = password.c_str();
-
-        httpClient = esp_http_client_init(&config);
-        if (!httpClient) {
-            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to initialize HTTP client (V1)");
-        } else {
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "HTTP client initialized successfully (V1)");
-        }
-    }
-
-    void InfluxDB::InfluxDBInitV2(std::string _influxDBURI, std::string _bucket, std::string _org, std::string _token) {
-        version = INFLUXDB_V2;
-        influxDBURI = _influxDBURI;
-        bucket = _bucket;
-        org = _org;
-        token = _token;
-
-        esp_http_client_config_t config = {};
-        config.user_agent = "ESP32 Meter reader",
-        config.method = HTTP_METHOD_POST;
-
-        httpClient = esp_http_client_init(&config);
-        if (!httpClient) {
-            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to initialize HTTP client (V2)");
-        } else {
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "HTTP client initialized successfully (V2)");
-        }
-    }
-
-
-    // Destroy the InfluxDB connection
-    void InfluxDB::InfluxDBdestroy() {
-        if (httpClient) {
-            esp_http_client_cleanup(httpClient);
-            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "HTTP client cleaned up");
-        }
-    }
-
-    // Publish data to the InfluxDB server
-    void InfluxDB::InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC) {
-        if (!httpClient) {
-            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "HTTP client not initialized, try to initialize it.");
-            switch (version) {
-                case INFLUXDB_V1:
-                    InfluxDBInitV1(influxDBURI, database, user, password);
-                    if (!httpClient) {
-                        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "HTTP client couldl not be not initialized");
-                        return;
-                    }
-                    break;
-                case INFLUXDB_V2:
-                    InfluxDBInitV2(influxDBURI, bucket, org, token);
-                    if (!httpClient) {
-                        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "HTTP client couldl not be not initialized");
-                        return;
-                    }
-                    break;
-            }
-        }
-
-    std::string apiURI;        
-
-/////////////////
-
-    std::string payload;
-    char nowTimestamp[21];
-
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDBPublish - Key: " + _key + ", Content: " + _content + ", timeUTC: " + std::to_string(_timeUTC));
-
-    if (_timeUTC > 0)
-    {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp (UTC): " + std::to_string(_timeUTC));
-        sprintf(nowTimestamp,"%ld000000000", _timeUTC);           // UTC
-        payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
-    }
-    else
-    {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "no timestamp given");
-        payload = _measurement + " " + _key + "=" + _content;
-    }
-
-    payload.shrink_to_fit();
-
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "sending line to influxdb:" + payload);
-
-    esp_err_t err;
-
-    switch (version) {
-        case INFLUXDB_V1: 
-            apiURI = _influxDBURI + "/write?db=" + _influxDBDatabase;
-            apiURI.shrink_to_fit();
-
-            esp_http_client_set_url(httpClient, apiURI.c_str());
-            esp_http_client_set_method(httpClient, HTTP_METHOD_POST);
-            esp_http_client_set_header(httpClient, "Content-Type", "text/plain");
-            esp_http_client_set_post_field(httpClient, payload.c_str(), payload.length());
-
-            err = esp_http_client_perform(httpClient);
-            if (err == ESP_OK) {
-                LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Data published successfully: " + payload);
-            } else {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to publish data: " + std::string(esp_err_to_name(err)));
-            }
-            break;
-        case INFLUXDB_V2:
-            apiURI = _influxDB_V2_URI + "/api/v2/write?org=" + org + "&bucket=" + bucket;
-            apiURI.shrink_to_fit();
-
-            esp_http_client_set_url(httpClient, apiURI.c_str());
-            esp_http_client_set_method(httpClient, HTTP_METHOD_POST);
-            esp_http_client_set_header(httpClient, "Content-Type", "text/plain");
-            std::string _zw = "Token " + token;
-            esp_http_client_set_header(httpClient, "Authorization", _zw.c_str());
-            esp_http_client_set_post_field(httpClient, payload.c_str(), payload.length());
-
-            err = esp_http_client_perform(httpClient);
-            if (err == ESP_OK) {
-                LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Data published successfully: " + payload);
-            } else {
-                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to publish data: " + std::string(esp_err_to_name(err)));
-            }
-        break;
-    }
-    }
-
-/////////////////////////////////////////////////////////////////////////////////////
-
-/*
-
-static esp_err_t http_event_handler(esp_http_client_event_t *evt);
-
-void InfluxDB_V2_Init(std::string _uri, std::string _bucket, std::string _org, std::string _token)
-{
-    _influxDB_V2_URI = _uri;
-    _influxDB_V2_Bucket = _bucket;
-    _influxDB_V2_Org = _org;
-    _influxDB_V2_Token = _token;
-}
-
-void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC) 
-{
-    char response_buffer[MAX_HTTP_OUTPUT_BUFFER] = {0};
-    esp_http_client_config_t http_config = {
-       .user_agent = "ESP32 Meter reader",
-       .method = HTTP_METHOD_POST,
-       .event_handler = http_event_handler,
-       .buffer_size = MAX_HTTP_OUTPUT_BUFFER,
-       .user_data = response_buffer
-    };
-
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDB_V2_Publish - Key: " + _key + ", Content: " + _content + ", timeUTC: " + std::to_string(_timeUTC));
-
-    std::string payload;
-    char nowTimestamp[21];
-
-    if (_timeUTC > 0)
-    {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp (UTC): " + std::to_string(_timeUTC));
-        sprintf(nowTimestamp,"%ld000000000", _timeUTC);           // UTC
-        payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
-    }
-    else
-    {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "no timestamp given");
-        payload = _measurement + " " + _key + "=" + _content;
-    }
-
-    payload.shrink_to_fit();
-
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "sending line to influxdb:" + payload);
-
-    std::string apiURI = _influxDB_V2_URI + "/api/v2/write?org=" + _influxDB_V2_Org + "&bucket=" + _influxDB_V2_Bucket;
-    apiURI.shrink_to_fit();
-    http_config.url = apiURI.c_str();
-    ESP_LOGI(TAG, "http_config: %s", http_config.url); // Add mark on log to see when it restarted
-
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "API URI: " + apiURI);
-
-    esp_http_client_handle_t http_client = esp_http_client_init(&http_config);
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "client is initialized");
-
-    esp_http_client_set_header(http_client, "Content-Type", "text/plain");
-    std::string _zw = "Token " + _influxDB_V2_Token;
-    //    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Tokenheader: %s\n", _zw.c_str());
-    esp_http_client_set_header(http_client, "Authorization", _zw.c_str());
-
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "header is set");
-
-    ESP_ERROR_CHECK(esp_http_client_set_post_field(http_client, payload.c_str(), payload.length()));
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "post payload is set");
-
-    esp_err_t err = ESP_ERROR_CHECK_WITHOUT_ABORT(esp_http_client_perform(http_client));
-
-    if( err == ESP_OK ) {
-      LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "HTTP request was performed");
-      int status_code = esp_http_client_get_status_code(http_client);
-      LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "HTTP status code" + std::to_string(status_code));
-    } else {
-      LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "HTTP request failed");
-    }
-    esp_http_client_cleanup(http_client);
-}
-
+char response_buffer[MAX_HTTP_OUTPUT_BUFFER] = {0};
 
 
 static esp_err_t http_event_handler(esp_http_client_event_t *evt)
@@ -273,86 +46,127 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
     return ESP_OK;
 }
 
-void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC) {
-    char response_buffer[MAX_HTTP_OUTPUT_BUFFER] = {0};
-    esp_http_client_config_t http_config = {
-       .user_agent = "ESP32 Meter reader",
-       .method = HTTP_METHOD_POST,
-       .event_handler = http_event_handler,
-       .buffer_size = MAX_HTTP_OUTPUT_BUFFER,
-       .user_data = response_buffer
-    };
 
-    if (_influxDBUser.length() && _influxDBPassword.length()){
-       http_config.username = _influxDBUser.c_str();
-       http_config.password = _influxDBPassword.c_str();
-       http_config.auth_type = HTTP_AUTH_TYPE_BASIC;
+
+    void InfluxDB::InfluxDBInitV1(std::string _influxDBURI, std::string _database, std::string _user, std::string _password) {
+        version = INFLUXDB_V1;
+        influxDBURI = _influxDBURI;
+        database = _database;
+        user = _user;
+        password = _password;
     }
 
-    std::string payload;
-    char nowTimestamp[21];
-
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDBPublish - Key: " + _key + ", Content: " + _content + ", timeUTC: " + std::to_string(_timeUTC));
-
-    if (_timeUTC > 0)
-    {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp (UTC): " + std::to_string(_timeUTC));
-        sprintf(nowTimestamp,"%ld000000000", _timeUTC);           // UTC
-        payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
-    }
-    else
-    {
-        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "no timestamp given");
-        payload = _measurement + " " + _key + "=" + _content;
+    void InfluxDB::InfluxDBInitV2(std::string _influxDBURI, std::string _bucket, std::string _org, std::string _token) {
+        version = INFLUXDB_V2;
+        influxDBURI = _influxDBURI;
+        bucket = _bucket;
+        org = _org;
+        token = _token;
     }
 
-    payload.shrink_to_fit();
+    void InfluxDB::connectHTTP() {
+        esp_http_client_config_t config = {};
 
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "sending line to influxdb:" + payload);
+        config.url = influxDBURI.c_str();
+        config.event_handler = http_event_handler;
+        config.buffer_size = MAX_HTTP_OUTPUT_BUFFER;
+        config.user_data = response_buffer;
 
 
-    // use the default retention policy of the bucket
-    std::string apiURI = _influxDBURI + "/write?db=" + _influxDBDatabase;
-//    std::string apiURI = _influxDBURI + "/api/v2/write?bucket=" + _influxDBDatabase + "/";
+        switch (version) {
+            case INFLUXDB_V1:
+                config.auth_type = HTTP_AUTH_TYPE_BASIC;
+                config.username = user.c_str();
+                config.password = password.c_str();
+                break;
+            case INFLUXDB_V2:
+                break;
+        }
 
-    apiURI.shrink_to_fit();
-    http_config.url = apiURI.c_str();
-
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "API URI: " + apiURI);
-
-    esp_http_client_handle_t http_client = esp_http_client_init(&http_config);
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "client is initialized");
-
-    esp_http_client_set_header(http_client, "Content-Type", "text/plain");
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "header is set");
-
-    ESP_ERROR_CHECK(esp_http_client_set_post_field(http_client, payload.c_str(), payload.length()));
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "post payload is set");
-
-    esp_err_t err = ESP_ERROR_CHECK_WITHOUT_ABORT(esp_http_client_perform(http_client));
-
-    if( err == ESP_OK ) {
-      LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "HTTP request was performed");
-      int status_code = esp_http_client_get_status_code(http_client);
-      LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "HTTP status code" + std::to_string(status_code));
-    } else {
-      LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "HTTP request failed");
+        InfluxDBdestroy();
+        httpClient = esp_http_client_init(&config);
+        if (!httpClient) {
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to initialize HTTP client");
+        } else {
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "HTTP client initialized successfully");
+        }
     }
-    esp_http_client_cleanup(http_client);
-}
 
 
-void InfluxDBInit(std::string _uri, std::string _database, std::string _user, std::string _password){
-    _influxDBURI = _uri;
-    _influxDBDatabase = _database;
-    _influxDBUser = _user;
-    _influxDBPassword = _password;
- 
-}
+    // Destroy the InfluxDB connection
+    void InfluxDB::InfluxDBdestroy() {
+        if (httpClient) {
+            esp_http_client_cleanup(httpClient);
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "HTTP client cleaned up");
+            httpClient = NULL;
+        }
+    }
 
-void InfluxDBdestroy() {
-}
+    // Publish data to the InfluxDB server
+    void InfluxDB::InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC) {
+        std::string apiURI;        
+        std::string payload;
+        char nowTimestamp[21];
 
-*/
+        connectHTTP();
+
+
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "InfluxDBPublish - Key: " + _key + ", Content: " + _content + ", timeUTC: " + std::to_string(_timeUTC));
+
+        if (_timeUTC > 0)
+        {
+            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Timestamp (UTC): " + std::to_string(_timeUTC));
+            sprintf(nowTimestamp,"%ld000000000", _timeUTC);           // UTC
+            payload = _measurement + " " + _key + "=" + _content + " " + nowTimestamp;
+        }
+        else
+        {
+            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "no timestamp given");
+            payload = _measurement + " " + _key + "=" + _content;
+        }
+
+        payload.shrink_to_fit();
+        LogFile.WriteToFile(ESP_LOG_INFO, TAG, "sending line to influxdb:" + payload);
+
+        esp_err_t err;
+
+        switch (version) {
+            case INFLUXDB_V1: 
+                apiURI = influxDBURI + "/write?db=" + database;
+                apiURI.shrink_to_fit();
+
+                esp_http_client_set_url(httpClient, apiURI.c_str());
+                esp_http_client_set_method(httpClient, HTTP_METHOD_POST);
+                esp_http_client_set_header(httpClient, "Content-Type", "text/plain");
+                esp_http_client_set_post_field(httpClient, payload.c_str(), payload.length());
+
+                err = esp_http_client_perform(httpClient);
+                if (err == ESP_OK) {
+                    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Data published successfully: " + payload);
+                } else {
+                    LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to publish data: " + std::string(esp_err_to_name(err)));
+                }
+                break;
+
+            case INFLUXDB_V2:        
+                apiURI = influxDBURI + "/api/v2/write?org=" + org + "&bucket=" + bucket;
+                apiURI.shrink_to_fit();
+                LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "apiURI: " + apiURI);
+
+                esp_http_client_set_url(httpClient, apiURI.c_str());
+                esp_http_client_set_method(httpClient, HTTP_METHOD_POST);
+                esp_http_client_set_header(httpClient, "Content-Type", "text/plain");
+                std::string _zw = "Token " + token;
+                esp_http_client_set_header(httpClient, "Authorization", _zw.c_str());
+                esp_http_client_set_post_field(httpClient, payload.c_str(), payload.length());
+                err = ESP_ERROR_CHECK_WITHOUT_ABORT(esp_http_client_perform(httpClient));
+                if (err == ESP_OK) {
+                    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Data published successfully: " + payload);
+                } else {
+                    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Failed to publish data: " + std::string(esp_err_to_name(err)));
+                }
+            break;
+        }
+    }
 
 #endif //ENABLE_INFLUXDB

--- a/code/components/jomjol_influxdb/interface_influxdb.cpp
+++ b/code/components/jomjol_influxdb/interface_influxdb.cpp
@@ -39,9 +39,9 @@ std::string _influxDB_V2_Org;
 
         httpClient = esp_http_client_init(&config);
         if (!httpClient) {
-            ESP_LOGE("InfluxDBV1", "Failed to initialize HTTP client");
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to initialize HTTP client (V1)");
         } else {
-            ESP_LOGI("InfluxDBV2", "HTTP client initialized successfully");
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "HTTP client initialized successfully (V1)");
         }
     }
 
@@ -58,9 +58,9 @@ std::string _influxDB_V2_Org;
 
         httpClient = esp_http_client_init(&config);
         if (!httpClient) {
-            ESP_LOGE("InfluxDBV2", "Failed to initialize HTTP client");
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to initialize HTTP client (V2)");
         } else {
-            ESP_LOGI("InfluxDBV2", "HTTP client initialized successfully");
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "HTTP client initialized successfully (V2)");
         }
     }
 
@@ -69,26 +69,26 @@ std::string _influxDB_V2_Org;
     void InfluxDB::InfluxDBdestroy() {
         if (httpClient) {
             esp_http_client_cleanup(httpClient);
-            ESP_LOGI("InfluxDB", "HTTP client cleaned up");
+            LogFile.WriteToFile(ESP_LOG_INFO, TAG, "HTTP client cleaned up");
         }
     }
 
     // Publish data to the InfluxDB server
     void InfluxDB::InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC) {
         if (!httpClient) {
-            ESP_LOGE("InfluxDB", "HTTP client not initialized, try to initialize it.");
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "HTTP client not initialized, try to initialize it.");
             switch (version) {
                 case INFLUXDB_V1:
                     InfluxDBInitV1(influxDBURI, database, user, password);
                     if (!httpClient) {
-                        ESP_LOGE("InfluxDBV1", "HTTP client couldl not be not initialized");
+                        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "HTTP client couldl not be not initialized");
                         return;
                     }
                     break;
                 case INFLUXDB_V2:
                     InfluxDBInitV2(influxDBURI, bucket, org, token);
                     if (!httpClient) {
-                        ESP_LOGE("InfluxDBV2", "HTTP client couldl not be not initialized");
+                        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "HTTP client couldl not be not initialized");
                         return;
                     }
                     break;
@@ -134,9 +134,9 @@ std::string _influxDB_V2_Org;
 
             err = esp_http_client_perform(httpClient);
             if (err == ESP_OK) {
-                ESP_LOGI("InfluxDBV1", "Data published successfully: %s", payload.c_str());
+                LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Data published successfully: " + payload);
             } else {
-                ESP_LOGE("InfluxDBV1", "Failed to publish data: %s", esp_err_to_name(err));
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to publish data: " + std::string(esp_err_to_name(err)));
             }
             break;
         case INFLUXDB_V2:
@@ -152,9 +152,9 @@ std::string _influxDB_V2_Org;
 
             err = esp_http_client_perform(httpClient);
             if (err == ESP_OK) {
-                ESP_LOGI("InfluxDBV2", "Data published successfully: %s", payload.c_str());
+                LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Data published successfully: " + payload);
             } else {
-                ESP_LOGE("InfluxDBV2", "Failed to publish data: %s", esp_err_to_name(err));
+                LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to publish data: " + std::string(esp_err_to_name(err)));
             }
         break;
     }

--- a/code/components/jomjol_influxdb/interface_influxdb.h
+++ b/code/components/jomjol_influxdb/interface_influxdb.h
@@ -34,20 +34,22 @@ enum InfluxDBVersion {
 class InfluxDB {
 private:
     // Information for InfluxDB v1.x
-    std::string influxDBURI;
+    std::string influxDBURI = "";
     // Information for InfluxDB v1.x
-    std::string database;
-    std::string user;
-    std::string password;
+    std::string database = "";
+    std::string user = "";
+    std::string password = "";
 
     // Information for InfluxDB v2.x
-    std::string bucket;
-    std::string org;
-    std::string token;
+    std::string bucket = "";
+    std::string org = "";
+    std::string token = "";
 
     InfluxDBVersion version;
 
-    esp_http_client_handle_t httpClient;
+    esp_http_client_handle_t httpClient = NULL;
+
+    void connectHTTP();
 
 public:
     // Initialize the InfluxDB connection parameters

--- a/code/components/jomjol_influxdb/interface_influxdb.h
+++ b/code/components/jomjol_influxdb/interface_influxdb.h
@@ -8,6 +8,12 @@
 #include <map>
 #include <functional>
 
+
+#include <string>
+#include "esp_http_client.h"
+#include "esp_log.h"
+
+
 // Interface to InfluxDB v1.x
 void InfluxDBInit(std::string _influxDBURI, std::string _database, std::string _user, std::string _password);
 void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC);
@@ -19,6 +25,32 @@ void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string
 
 
 void InfluxDBdestroy();
+
+
+class InfluxDB {
+private:
+    std::string influxDBURI;
+    std::string database;
+//    std::string measurement;
+    std::string user;
+    std::string password;
+    esp_http_client_handle_t httpClient;
+
+public:
+    // Initialize the InfluxDB connection parameters
+    void InfluxDBInit(std::string _influxDBURI, std::string _database, std::string _user, std::string _password);
+    // Destroy the InfluxDB connection
+    void InfluxDBdestroy();
+    // Publish data to the InfluxDB server
+    void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC);
+};
+
+// Usage example:
+// InfluxDB influxDB;
+// influxDB.InfluxDBInit("http://your-influxdb-url", "your-database", "your-measurement", "user", "password");
+// influxDB.InfluxDBPublish("key", "content", "timestamp");
+// influxDB.InfluxDBdestroy();
+
 
 #endif //INTERFACE_INFLUXDB_H
 #endif //ENABLE_INFLUXDB

--- a/code/components/jomjol_influxdb/interface_influxdb.h
+++ b/code/components/jomjol_influxdb/interface_influxdb.h
@@ -15,30 +15,45 @@
 
 
 // Interface to InfluxDB v1.x
-void InfluxDBInit(std::string _influxDBURI, std::string _database, std::string _user, std::string _password);
-void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC);
+// void InfluxDBInit(std::string _influxDBURI, std::string _database, std::string _user, std::string _password);
+// void InfluxDBPublish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC);
 
 // Interface to InfluxDB v2.x
-void InfluxDB_V2_Init(std::string _uri, std::string _bucket, std::string _org, std::string _token);
-void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC);
+// void InfluxDB_V2_Init(std::string _uri, std::string _bucket, std::string _org, std::string _token);
+// void InfluxDB_V2_Publish(std::string _measurement, std::string _key, std::string _content, long int _timeUTC);
 
 
 
 void InfluxDBdestroy();
 
+enum InfluxDBVersion {
+    INFLUXDB_V1,
+    INFLUXDB_V2
+};
 
 class InfluxDB {
 private:
+    // Information for InfluxDB v1.x
     std::string influxDBURI;
+    // Information for InfluxDB v1.x
     std::string database;
-//    std::string measurement;
     std::string user;
     std::string password;
+
+    // Information for InfluxDB v2.x
+    std::string bucket;
+    std::string org;
+    std::string token;
+
+    InfluxDBVersion version;
+
     esp_http_client_handle_t httpClient;
 
 public:
     // Initialize the InfluxDB connection parameters
-    void InfluxDBInit(std::string _influxDBURI, std::string _database, std::string _user, std::string _password);
+    void InfluxDBInitV1(std::string _influxDBURI, std::string _database, std::string _user, std::string _password);
+    void InfluxDBInitV2(std::string _influxDBURI, std::string _bucket, std::string _org, std::string _token);
+
     // Destroy the InfluxDB connection
     void InfluxDBdestroy();
     // Publish data to the InfluxDB server

--- a/code/dependencies.lock
+++ b/code/dependencies.lock
@@ -10,6 +10,6 @@ dependencies:
     source:
       type: idf
     version: 5.3.1
-manifest_hash: 7350b157da8e1eb3cf21d0ea99443ec18c94cb2e0b22af07e20f286a9d15ec7a
+manifest_hash: f88c9e5c2d75a9d5d6968fc67a90ef0cd7146dd6a3905a79c4dfcfc3b4fe6731
 target: esp32
 version: 1.0.0


### PR DESCRIPTION
This update does not contain new features, but rewrites the InfluxDB interface (v1, v2) by converting the code to an interface class. It mainly replaces the commit #774 