### PR TITLE
[Experimental, not stable] webhook ImageBasis instead of AlgRoi

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowWebhook.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowWebhook.cpp
@@ -161,7 +161,7 @@ bool ClassFlowWebhook::doFlow(string zwtime)
 
         #ifdef ALGROI_LOAD_FROM_MEM_AS_JPG
             if ((WebhookUploadImg == 1 || (WebhookUploadImg != 0 && numbersWithError)) && flowAlignment && flowAlignment->AlgROI) {
-                WebhookUploadPic(flowAlignment->AlgROI);
+                WebhookUploadPic(flowAlignment->ImageBasis); //AlgROI);
             }
         #endif
     }


### PR DESCRIPTION
serve ImageBasis instead of algRoi for webhook image upload. 

This is for testing the collect image function https://github.com/jomjol/AI-on-the-edge-device/discussions/3551

The AlgRoi image is not suitable to train an AI model
