### PR TITLE
Remove HTML directory on update

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_ota.cpp
+++ b/code/components/jomjol_fileserver_ota/server_ota.cpp
@@ -84,6 +84,8 @@ void task_do_Update_ZIP(void *pvParameter)
         out = "/sdcard/html";
         outbin = "/sdcard/firmware";
 
+        delete_all_in_directory(out);
+
         retfirmware = unzip_new(_file_name_update, out+"/", outbin+"/", "/sdcard/", initial_setup);
     	LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Files unzipped.");
 
@@ -433,7 +435,6 @@ esp_err_t handler_ota_update(httpd_req_t *req)
             httpd_resp_sendstr_chunk(req, NULL);  
             return ESP_OK;        
         }
-
 
         if ((filetype == "TFLITE") || (filetype == "TFL"))
         {


### PR DESCRIPTION
remove all HTML files (and images and other files) on an update.
They are no longer needed.