### PR TITLE
Add support for ESP32CAM S014TF board

### DIFF
--- a/code/include/defines.h
+++ b/code/include/defines.h
@@ -267,6 +267,42 @@
     #define USE_PWM_LEDFLASH                    // if __LEDGLOBAL is defined, a global variable is used for LED control, otherwise locally and each time a new
 
 
+#elif defined(BOARD_ESP32CAM_S014TF) // ESP32Cam S014TF PIN Map
+    #define __SD_USE_SPI_MODE__                 // only SPI mode is supported on this board
+
+    #define GPIO_SDCARD_CLK  GPIO_NUM_4
+    #define GPIO_SDCARD_CMD  GPIO_NUM_21
+    #define GPIO_SDCARD_D0   GPIO_NUM_13
+    #define GPIO_SDCARD_D1   GPIO_NUM_NC
+    #define GPIO_SDCARD_D2   GPIO_NUM_NC
+    #define GPIO_SDCARD_D3   GPIO_NUM_19
+
+    #define CAM_PIN_PWDN     GPIO_NUM_NC
+    #define CAM_PIN_RESET    GPIO_NUM_5
+    #define CAM_PIN_XCLK     GPIO_NUM_15
+    #define CAM_PIN_SIOD     GPIO_NUM_22
+    #define CAM_PIN_SIOC     GPIO_NUM_23
+
+    #define CAM_PIN_D7       GPIO_NUM_39
+    #define CAM_PIN_D6       GPIO_NUM_34
+    #define CAM_PIN_D5       GPIO_NUM_33
+    #define CAM_PIN_D4       GPIO_NUM_27
+    #define CAM_PIN_D3       GPIO_NUM_12
+    #define CAM_PIN_D2       GPIO_NUM_35
+    #define CAM_PIN_D1       GPIO_NUM_14
+    #define CAM_PIN_D0       GPIO_NUM_2
+    #define CAM_PIN_VSYNC    GPIO_NUM_18
+    #define CAM_PIN_HREF     GPIO_NUM_36
+    #define CAM_PIN_PCLK     GPIO_NUM_26
+
+    //Statusled + ClassControllCamera
+    #define BLINK_GPIO GPIO_NUM_25              // PIN for red board LED
+
+    //ClassControllCamera
+    // NOTE: GPIOs 38 and 37 are inputs only
+    #define FLASH_GPIO GPIO_NUM_32              // PIN for flashlight LED
+    #define USE_PWM_LEDFLASH                    // if __LEDGLOBAL is defined, a global variable is used for LED control, otherwise locally and each time a new
+
 #elif defined(BOARD_ESP32CAM_AITHINKER) // ESP32Cam (AiThinker) PIN Map
 	// SD card (operated with SDMMC peripheral)
 	//-------------------------------------------------

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -72,6 +72,30 @@ build_flags =
 board_build.partitions = partitions.csv
 monitor_speed = 115200
 
+; M5stack ESP32cam env
+[env:esp32cam-s014tf]
+extends = common:esp32-idf
+board = esp32cam
+framework = espidf
+build_flags = 
+    ; ### common imported : 
+    ${common:esp32-idf.build_flags}
+	${flags:runtime.build_flags}
+    ; ### Sofware options : (can be set in defines.h)
+    -D BOARD_ESP32CAM_S014TF
+    -D ENABLE_MQTT
+    ;-D MQTT_PROTOCOL_311
+    -D MQTT_ENABLE_SSL
+    ;-D MQTT_ENABLE_WS
+    ;-D MQTT_ENABLE_WSS
+    -D MQTT_SUPPORTED_FEATURE_SKIP_CRT_CMN_NAME_CHECK
+    ;-D MQTT_SUPPORTED_FEATURE_CRT_CMN_NAME
+    ;-D MQTT_SUPPORTED_FEATURE_CLIENT_KEY_PASSWORD
+    -D ENABLE_INFLUXDB
+    -D ENABLE_WEBHOOK
+    -D ENABLE_SOFTAP 
+board_build.partitions = partitions.csv
+monitor_speed = 115200
 
 ; full standalone dev mode
 ; As sample, the board is nod32s instead of esp32cam (do not change nothing in fact :)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/50c91867-1b48-4505-88e9-cc9aa5973f2b)

This variant of [ESP32cam (model number S014TF)](https://www.aliexpress.com/item/1005004521039608.html) has autofocus AF-VDD and AF-GND already connected. This is good because there is no need to manually solder wires on the CSI connector. This board also has a 90% efficiency 5V to 3.3V DCDC replacing the original ESP32cam's 3.3V LDO that generates a lot of heat. The biggest downside to this board is the SD card must run in SPI mode rather than MMC mode and SPI is way slower.

The board seems to work for me, except for OTA upgrading the firmware and html files via a ZIP file. Unzipping the file appears to cause stack overflow. I haven't tracked that issue down yet.