### PR TITLE
Add option for `gal/min` rate for Home Assistant MQTT Autodiscovery

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -162,7 +162,7 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, string& aktparamgraph)
                 mqttServer_setMeterType("water", "gal", "h", "gal/h");
             }
             else if (toUpper(splitted[1]) == "WATER_GAL_MIN") {
-                mqttServer_setMeterType("water", "gal", "min", "gal/min");
+                mqttServer_setMeterType("water", "gal", "min", "gal/min"); // min = Minutes
             }
             else if (toUpper(splitted[1]) == "GAS_M3") {
                 mqttServer_setMeterType("gas", "m³", "h", "m³/h");

--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -161,6 +161,9 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, string& aktparamgraph)
             else if (toUpper(splitted[1]) == "WATER_GAL") {
                 mqttServer_setMeterType("water", "gal", "h", "gal/h");
             }
+            else if (toUpper(splitted[1]) == "WATER_GAL_MIN") {
+                mqttServer_setMeterType("water", "gal", "min", "gal/min");
+            }
             else if (toUpper(splitted[1]) == "GAS_M3") {
                 mqttServer_setMeterType("gas", "m³", "h", "m³/h");
             }

--- a/param-docs/parameter-pages/MQTT/MeterType.md
+++ b/param-docs/parameter-pages/MQTT/MeterType.md
@@ -11,8 +11,8 @@ List of supported options:
 
 - `other`
 - `water_m3` (uses `m^3/h` as rate)
-- `water_l`  (uses `l/h` as rate, not officially supported by Homeassistant!)
-- `water_gal`  (uses `gal/h` as rate, not officially supported by Homeassistant!)
+- `water_l`  (uses `l/h` as rate) **⚠️ Not supported by Homeassistant 2025.7 and later! ⚠️**
+- `water_gal`  (uses `gal/h` as rate) **⚠️ Not supported by Homeassistant 2025.7 and later! ⚠️**
 - `water_gal_min`  (uses `gal/min` as rate)
 - `water_ft3` (uses `ft^3/min` as rate)
 - `gas_m3` (uses `m^3/h` as rate)
@@ -20,10 +20,13 @@ List of supported options:
 - `energy_wh` (uses `W` as rate)
 - `energy_kwh` (uses `KW` as rate)
 - `energy_mwh` (uses `MW` as rate)
-- `energy_gj`  (uses `GJ/h` as rate, not officially supported by Homeassistant!)
+- `energy_gj`  (uses `GJ/h` as rate) **⚠️ Not supported by Homeassistant 2025.7 and later! ⚠️**
 - `temperature_c` (uses `+C/min` as rate)
 - `temperature_f` (uses `°F/min` as rate)
 - `temperature_k` (uses `K/min` as rate)
 
 !!! Note
     Not all options are supported by Homeassistant, see `SensorDeviceClass.VOLUME_FLOW_RATE` in [https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes)!
+    
+!!! Warning
+    Since Homeassistant 2025.7, the unsupported values no longer will work, see change in Homeassistant: [Ensure MQTT sensor has a valid native unit of measurement](https://github.com/home-assistant/core/pull/146722).

--- a/param-docs/parameter-pages/MQTT/MeterType.md
+++ b/param-docs/parameter-pages/MQTT/MeterType.md
@@ -29,4 +29,4 @@ List of supported options:
     Not all options are supported by Homeassistant, see `SensorDeviceClass.VOLUME_FLOW_RATE` in [https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes)!
     
 !!! Warning
-    Since Homeassistant 2025.7, the unsupported values no longer will work, see change in Homeassistant: [Ensure MQTT sensor has a valid native unit of measurement](https://github.com/home-assistant/core/pull/146722).
+    Since Homeassistant 2025.7, the unsupported options will no longer work, see change in Homeassistant: [Ensure MQTT sensor has a valid native unit of measurement](https://github.com/home-assistant/core/pull/146722).

--- a/param-docs/parameter-pages/MQTT/MeterType.md
+++ b/param-docs/parameter-pages/MQTT/MeterType.md
@@ -13,6 +13,7 @@ List of supported options:
 - `water_m3` (uses `m^3/h` as rate)
 - `water_l`  (uses `l/h` as rate, not officially supported by Homeassistant!)
 - `water_gal`  (uses `gal/h` as rate, not officially supported by Homeassistant!)
+- `water_gal_min`  (uses `gal/min` as rate)
 - `water_ft3` (uses `ft^3/min` as rate)
 - `gas_m3` (uses `m^3/h` as rate)
 - `gas_ft3` (uses `ft^3/min` as rate)

--- a/sd-card/html/edit_config_template.html
+++ b/sd-card/html/edit_config_template.html
@@ -1185,7 +1185,7 @@
                     <option value="water_m3">Watermeter (Value: m³, Rate: m³/h)</option>
                     <option value="water_l">Watermeter (Value: l, Rate: l/h) *Not officially supported by Homeassistant!*</option>
                     <option value="water_gal">Watermeter (Value: gal, Rate: gal/h) *Not officially supported by Homeassistant!*</option>
-		    <option value="water_gal_min">Watermeter (Value: gal, Rate: gal/min)</option>
+                    <option value="water_gal_min">Watermeter (Value: gal, Rate: gal/min)</option>
                     <option value="water_ft3">Watermeter (Value: ft³, Rate: ft³/min)</option>
                     <option value="gas_m3">Gasmeter (Value: m³, Rate: m³/h)</option>
                     <option value="gas_ft3">Gasmeter (Value: ft³, Rate: ft³/min)</option>

--- a/sd-card/html/edit_config_template.html
+++ b/sd-card/html/edit_config_template.html
@@ -1185,6 +1185,7 @@
                     <option value="water_m3">Watermeter (Value: m³, Rate: m³/h)</option>
                     <option value="water_l">Watermeter (Value: l, Rate: l/h) *Not officially supported by Homeassistant!*</option>
                     <option value="water_gal">Watermeter (Value: gal, Rate: gal/h) *Not officially supported by Homeassistant!*</option>
+		    <option value="water_gal_min">Watermeter (Value: gal, Rate: gal/min)</option>
                     <option value="water_ft3">Watermeter (Value: ft³, Rate: ft³/min)</option>
                     <option value="gas_m3">Gasmeter (Value: m³, Rate: m³/h)</option>
                     <option value="gas_ft3">Gasmeter (Value: ft³, Rate: ft³/min)</option>

--- a/sd-card/html/edit_config_template.html
+++ b/sd-card/html/edit_config_template.html
@@ -1183,8 +1183,8 @@
                 <select class="select_large" id="MQTT_MeterType_value1"> <!-- See https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes -->
                     <option value="other" selected>Other (no Units)</option>
                     <option value="water_m3">Watermeter (Value: m³, Rate: m³/h)</option>
-                    <option value="water_l">Watermeter (Value: l, Rate: l/h) *Not officially supported by Homeassistant!*</option>
-                    <option value="water_gal">Watermeter (Value: gal, Rate: gal/h) *Not officially supported by Homeassistant!*</option>
+                    <option value="water_l">Watermeter (Value: l, Rate: l/h)    ⚠️ Not supported by Homeassistant 2025.7 and later! ⚠️</option>
+                    <option value="water_gal">Watermeter (Value: gal, Rate: gal/h)    ⚠️ Not supported by Homeassistant 2025.7 and later! ⚠️</option>
                     <option value="water_gal_min">Watermeter (Value: gal, Rate: gal/min)</option>
                     <option value="water_ft3">Watermeter (Value: ft³, Rate: ft³/min)</option>
                     <option value="gas_m3">Gasmeter (Value: m³, Rate: m³/h)</option>
@@ -1192,7 +1192,7 @@
                     <option value="energy_wh">Energymeter (Value: Wh, Rate: W)</option>
                     <option value="energy_kwh">Energymeter (Value: kWh, Rate: kW)</option>
                     <option value="energy_mwh">Energymeter (Value: MWh, Rate: MW)</option>
-                    <option value="energy_gj">Energymeter (Value: GJ, Rate: GJ/h) *Not officially supported by Homeassistant!*</option>
+                    <option value="energy_gj">Energymeter (Value: GJ, Rate: GJ/h)    ⚠️ Not supported by Homeassistant 2025.7 and later! ⚠️</option>
                     <option value="temperature_c">Thermometer (Value: °C, Rate: °C/min)</option>
                     <option value="temperature_c">Thermometer (Value: °F, Rate: °F/min)</option>
                     <option value="temperature_c">Thermometer (Value: K, Rate: K/min)</option>


### PR DESCRIPTION
This adds an option to the Home Assistant MQTT Autodiscovery meter types for `value: gal` with `rate: gal/min`. This is needed because `gal/h` is an unsupported rate, and with HA version 2025.7 (PR https://github.com/home-assistant/core/pull/146722) the sensor will no longer be created if the units are invalid for the device class used. 
