### PR TITLE
Add `default_entity_id` to MQTT HA autodiscovery payload

### DIFF
--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -72,16 +72,16 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
     std::string topicFull;
     std::string configTopic;
     std::string payload;
-	std::string component;
+    std::string component;
 
     configTopic = field;
 
     if (group != "" && (*NUMBERS).size() > 1) { // There is more than one meter, prepend the group so we can differentiate them
         configTopic = group + "_" + field;
         name = group + " " + name;
-    } 
+    }
 
-	if (field == "problem") { // Special case: Binary sensor which is based on error topic
+    if (field == "problem") { // Special case: Binary sensor which is based on error topic
         component = "binary_sensor";
     }
     else if (field == "flowstart") { // Special case: Button
@@ -99,8 +99,8 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
     */
     std::string node_id = createNodeId(maintopic);
     topicFull = "homeassistant/" + component + "/" + node_id + "/" + configTopic + "/config";
-	
-	/* See https://www.home-assistant.io/docs/mqtt/discovery/ */
+    
+    /* See https://www.home-assistant.io/docs/mqtt/discovery/ */
     payload = string("{")  +
         "\"~\": \"" + maintopic + "\","  +
         "\"unique_id\": \"" + maintopic + "-" + configTopic + "\","  +


### PR DESCRIPTION
Add `default_entity_id` to the HA autodiscovery payload to address a deprecation (warning starting with HA 2025.11 and causing an error starting with HA 2026.4).

Addresses issue #3932 

If desired, the `object_id` (line 107) can be removed after April 2026.