### PR TITLE
No deviceclass for rate when type temperatur

### DIFF
--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -218,7 +218,13 @@ bool MQTThomeassistantDiscovery(int qos) {
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "error",                      "Error",                                "alert-circle-outline",      "",                    "",                "",                 "diagnostic",     qos);
         /* Not announcing "rate" as it is better to use rate_per_time_unit resp. rate_per_digitization_round */
      // allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate",                       "Rate (Unit/Minute)",                   "swap-vertical",             "",                    "",                "",                 "",               qos); // Legacy, always Unit per Minute
-        allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate_per_time_unit",         "Rate (" + rateUnit + ")",              "swap-vertical",             rateUnit,              rate_device_class, "measurement",      "",               qos);
+        if (meterType == "temperature") {
+            allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate_per_time_unit",         "Rate (" + rateUnit + ")",              "swap-vertical",             rateUnit,              "",                "measurement",      "",               qos);
+        }
+        else {
+            allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate_per_time_unit",         "Rate (" + rateUnit + ")",              "swap-vertical",             rateUnit,              rate_device_class, "measurement",      "",               qos);
+        }
+
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "rate_per_digitization_round","Change since last Digitization round", "arrow-expand-vertical",     valueUnit,             "",                "measurement",      "",               qos); // correctly the Unit is Unit/Interval!
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "timestamp",                  "Timestamp",                            "clock-time-eight-outline",  "",                    "timestamp",       "",                 "diagnostic",     qos);
         allSendsSuccessed |= sendHomeAssistantDiscoveryTopic(group,   "json",                       "JSON",                                 "code-json",                 "",                    "",                "",                 "diagnostic",     qos);


### PR DESCRIPTION
Otherwise this error occurs and Sensor "Rate" is not available.

Changed code to adapt depending on meterType.

With this change, no longer error on temperatur-meter and Sensor Rate available.

Code was changed, compiled and ran successfull on esp32-cam.

Logger: homeassistant.components.mqtt.entity
Source: components/mqtt/entity.py:159
integration: MQTT (documentation, issues)
First occurred: 11:02:43 AM (2 occurrences)
Last logged: 9:41:52 PM

Error 'The unit of measurement `°C/min` is not valid together with device class `temperature`' when processing MQTT discovery message topic: 'homeassistant/sensor/ESPCamX/rate_per_time_unit/config', message: '{'unique_id': 'ESPCamX-rate_per_time_unit', 'object_id': 'ESPCamX_rate_per_time_unit', 'default_entity_id': 'sensor.ESPCamX_rate_per_time_unit', 'icon': 'mdi:swap-vertical', 'state_topic': 'ESPCamX/Vito161/rate_per_time_unit', 'device_class': 'temperature', 'state_class': 'measurement', 'availability_topic': 'ESPCamX/connection', 'payload_available': 'connected', 'payload_not_available': 'connection lost', 'device': {'identifiers': ['ESPCamX'], 'model': 'Meter Digitizer', 'manufacturer': 'AI on the Edge Device', 'sw_version': 'v16.1.0', 'configuration_url': 'http://192.168.178.100', 'name': 'ESPCamX'}, 'unit_of_measurement': '°C/min', 'name': 'Rate (°C/min)'}'
Error 'expected SensorDeviceClass or one of 'date', 'enum', 'timestamp', 'absolute_humidity', 'apparent_power', 'aqi', 'area', 'atmospheric_pressure', 'battery', 'blood_glucose_concentration', 'carbon_monoxide', 'carbon_dioxide', 'conductivity', 'current', 'data_rate', 'data_size', 'distance', 'duration', 'energy', 'energy_distance', 'energy_storage', 'frequency', 'gas', 'humidity', 'illuminance', 'irradiance', 'moisture', 'monetary', 'nitrogen_dioxide', 'nitrogen_monoxide', 'nitrous_oxide', 'ozone', 'ph', 'pm1', 'pm10', 'pm25', 'pm4', 'power_factor', 'power', 'precipitation', 'precipitation_intensity', 'pressure', 'reactive_energy', 'reactive_power', 'signal_strength', 'sound_pressure', 'speed', 'sulphur_dioxide', 'temperature', 'temperature_delta', 'volatile_organic_compounds', 'volatile_organic_compounds_parts', 'voltage', 'volume', 'volume_storage', 'volume_flow_rate', 'water', 'weight', 'wind_direction', 'wind_speed' for dictionary value @ data['device_class']' when processing MQTT discovery message topic: 'homeassistant/sensor/ESPCamX/rate_per_time_unit/config', message: '{'unique_id': 'ESPCamX-rate_per_time_unit', 'object_id': 'ESPCamX_rate_per_time_unit', 'default_entity_id': 'sensor.ESPCamX_rate_per_time_unit', 'icon': 'mdi:swap-vertical', 'state_topic': 'ESPCamX/Vito161/rate_per_time_unit', 'device_class': 'temperatur', 'state_class': 'measurement', 'availability_topic': 'ESPCamX/connection', 'payload_available': 'connected', 'payload_not_available': 'connection lost', 'device': {'identifiers': ['ESPCamX'], 'model': 'Meter Digitizer', 'manufacturer': 'AI on the Edge Device', 'sw_version': 'v16.1.0', 'configuration_url': 'http://192.168.178.100', 'name': 'ESPCamX'}, 'unit_of_measurement': '°C/min', 'name': 'Rate (°C/min)'}'