### PR TITLE
Add mac address to mqtt device connections

### DIFF
--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -154,6 +154,7 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
 
     payload += string("\"device\": {")  +
         "\"identifiers\": [\"" + maintopic + "\"],"  +
+        "\"connections\": [[\"mac\", \"" + getMac() + "\"]],"  +
         "\"name\": \"" + maintopic + "\","  +
         "\"model\": \"Meter Digitizer\","  +
         "\"manufacturer\": \"AI on the Edge Device\","  +


### PR DESCRIPTION
If the same device is added to Home Assistant by multiple integrations, HA can merge these devices into one based on the information these devices provide. I added the devices mac address to the auto discovery messages as described in https://www.home-assistant.io/integrations/sensor.mqtt/#device :
```json
{
  "device": {
    "identifiers": ["watermeter"],
    "connections": [["mac", "A1:B2:C3:D4:E5:F6"]],
    "name": "watermeter",
    "model": "Meter Digitizer",
    "manufacturer": "AI on the Edge Device",
    "sw_version": "main (a1ccda2)",
    "configuration_url": "http://192.168.47.78"
  }
}

```

My FritzBox router has an integration that adds all connected devices to HA. Initially I had two devices in HA, one from my FritzBox and one from MQTT (AI-on-the-edge-device). With this change these devices get merged into one:
<img width="327" height="394" alt="screenshot" src="https://github.com/user-attachments/assets/b3a3f30e-0f54-473a-8f39-c1572c842cdc" />

With this I also think we don't need the mac address as a seperate entity/topic anymore, but I don't know if people want/need this for their setups 🤔.