### PR TITLE
add ExtendedResolutionInvert for manual direction of the digits

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.cpp
@@ -35,14 +35,18 @@ ClassFlowCNNGeneral::ClassFlowCNNGeneral(ClassFlowAlignment *_flowalign, t_CNNTy
     imagesRetention = 5;
 }
 
-string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution, int prev, float _before_narrow_Analog, float AnalogToDigitTransitionStart) {
+string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution, int prev, float _before_narrow_Analog,
+                                       float AnalogToDigitTransitionStart, bool _extendedResolutionInverted) {
     string result = "";    
 
     if (GENERAL[_analog]->ROI.size() == 0) {
         return result;
     }
     
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout _analog=" + std::to_string(_analog) + ", _extendedResolution=" + std::to_string(_extendedResolution) + ", prev=" + std::to_string(prev));
+    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "getReadout _analog=" + std::to_string(_analog) +
+                                                ", _extendedResolution=" + std::to_string(_extendedResolution) +
+                                                ", _extendedResolutionInverted=" + std::to_string(_extendedResolutionInverted) +
+                                                ", prev=" + std::to_string(prev));
  
     if (CNNType == Analogue || CNNType == Analogue100) {
         float number = GENERAL[_analog]->ROI[GENERAL[_analog]->ROI.size() - 1]->result_float;
@@ -82,6 +86,9 @@ string ClassFlowCNNGeneral::getReadout(int _analog = 0, bool _extendedResolution
             // is only set if it is the first digit (no analogue before!)
             if (_extendedResolution) {
                 int result_after_decimal_point = ((int) floor(number * 10)) % 10;
+                if (_extendedResolutionInverted) {
+                    result_after_decimal_point = (10 - result_after_decimal_point) % 10;
+                }
                 int result_before_decimal_point = ((int) floor(number)) % 10;
 
                 result = std::to_string(result_before_decimal_point) + std::to_string(result_after_decimal_point);

--- a/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowCNNGeneral.h
@@ -52,7 +52,8 @@ public:
     bool doFlow(string time);
 
     string getHTMLSingleStep(string host);
-    string getReadout(int _analog, bool _extendedResolution = false, int prev = -1, float _before_narrow_Analog = -1, float AnalogToDigitTransitionStart=9.2); 
+    string getReadout(int _analog, bool _extendedResolution = false, int prev = -1, float _before_narrow_Analog = -1,
+                      float AnalogToDigitTransitionStart=9.2, bool _extendedResolutionInverted = false);
 
     string getReadoutRawString(int _analog);  
 
@@ -76,4 +77,3 @@ public:
 };
 
 #endif
-

--- a/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
@@ -75,6 +75,7 @@ struct NumberPost {
     string MeasurementV2;       // influxdbMeasurementName_v2; Name of the Measurement in InfluxDBv2
 
     bool isExtendedResolution;  // extendResolution; Adds the decimal place of the least significant analog ROI to the value
+    bool isExtendedResolutionInverted;  // For meters that roll the opposite way, flip the derived fractional digit
 
     general *digit_roi;         // digitRoi; set of digit ROIs for the sequence
     general *analog_roi;        // analogRoi; set of analog ROIs for the sequence

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -352,6 +352,26 @@ void ClassFlowPostProcessing::handleDecimalExtendedResolution(string _decsep, st
     }
 }
 
+void ClassFlowPostProcessing::handleDecimalExtendedResolutionInverted(string _decsep, string _value) {
+    string _digit;
+    int _pospunkt = _decsep.find_first_of(".");
+
+    if (_pospunkt > -1) {
+        _digit = _decsep.substr(0, _pospunkt);
+    }
+    else {
+        _digit = "default";
+    }
+
+    for (int j = 0; j < NUMBERS.size(); ++j) {
+        bool _zwdc = alphanumericToBoolean(_value);
+
+        if ((_digit == "default") || (NUMBERS[j]->name == _digit)) {
+            NUMBERS[j]->isExtendedResolutionInverted = _zwdc;
+        }
+    }
+}
+
 void ClassFlowPostProcessing::handleDecimalSeparator(string _decsep, string _value) {
     string _digit, _decpos;
     int _pospunkt = _decsep.find_first_of(".");
@@ -580,6 +600,10 @@ bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, string& aktparamgraph) 
             handleDecimalExtendedResolution(splitted[0], splitted[1]);
         }
 
+        if ((toUpper(_param) == "EXTENDEDRESOLUTIONINVERT") && (splitted.size() > 1)) {
+            handleDecimalExtendedResolutionInverted(splitted[0], splitted[1]);
+        }
+
         if ((toUpper(_param) == "DECIMALSHIFT") && (splitted.size() > 1)) {
             handleDecimalSeparator(splitted[0], splitted[1]);
         }
@@ -693,6 +717,7 @@ void ClassFlowPostProcessing::InitNUMBERS() {
         _number->DecimalShift = 0;
         _number->DecimalShiftInitial = 0;
         _number->isExtendedResolution = false;
+        _number->isExtendedResolutionInverted = false;
         _number->AnalogToDigitTransitionStart=9.2;
         _number->ChangeRateThreshold = 2;
 
@@ -815,7 +840,8 @@ bool ClassFlowPostProcessing::doFlow(string zwtime) {
                 NUMBERS[j]->ReturnRawValue = flowDigit->getReadout(j, false, previous_value, NUMBERS[j]->analog_roi->ROI[0]->result_float, NUMBERS[j]->AnalogToDigitTransitionStart) + NUMBERS[j]->ReturnRawValue;
             }
             else {
-                NUMBERS[j]->ReturnRawValue = flowDigit->getReadout(j, NUMBERS[j]->isExtendedResolution, previous_value);        // Extended Resolution only if there are no analogue digits
+                NUMBERS[j]->ReturnRawValue = flowDigit->getReadout(j, NUMBERS[j]->isExtendedResolution, previous_value,
+                                                                   -1, NUMBERS[j]->AnalogToDigitTransitionStart, NUMBERS[j]->isExtendedResolutionInverted); // Extended Resolution only if there are no analogue digits
             }
         }
 	    

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
@@ -37,6 +37,7 @@ protected:
     void handleDecimalSeparator(string _decsep, string _value);
     void handleMaxRateValue(string _decsep, string _value);
     void handleDecimalExtendedResolution(string _decsep, string _value); 
+    void handleDecimalExtendedResolutionInverted(string _decsep, string _value);
     void handleMaxRateType(string _decsep, string _value);
     void handleAnalogToDigitTransitionStart(string _decsep, string _value);
     void handleAllowNegativeRate(string _decsep, string _value);

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.cpp
@@ -146,6 +146,15 @@ void setExtendedResolution(UnderTestPost* _underTestPost, bool _extendedResoluti
     }
 }
 
+void setExtendedResolutionInvert(UnderTestPost* _underTestPost, bool _extendedResolutionInvert) {
+    if (_extendedResolutionInvert) {
+        std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();
+        for (int _n = 0; _n < (*NUMBERS).size(); ++_n) {
+            (*NUMBERS)[_n]->isExtendedResolutionInverted = true;
+        }
+    }
+}
+
 void setDecimalShift(UnderTestPost* _underTestPost, int _decimal_shift) {
     if (_decimal_shift!=0) {
         std::vector<NumberPost*>* NUMBERS = _underTestPost->GetNumbers();    

--- a/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
+++ b/code/test/components/jomjol-flowcontroll/test_flow_postrocess_helper.h
@@ -90,6 +90,14 @@ void setPreValue(UnderTestPost* _UnderTestPost, double _preValue);
 void setExtendedResolution(UnderTestPost* _UnderTestPost, bool _extendedResolution);
 
 /**
+ * @brief Toggle extended-resolution inversion on the test object.
+ *
+ * @param _UnderTestPost Object under test.
+ * @param _extendedResolutionInvert True to invert the derived fractional digit.
+ */
+void setExtendedResolutionInvert(UnderTestPost* _UnderTestPost, bool _extendedResolutionInvert);
+
+/**
  * @brief Set the Decimal Shift (Nachkomma)
  * 
  * @param _UnderTestPost the testobject  

--- a/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
+++ b/code/test/components/jomjol-flowcontroll/test_flowpostprocessing.cpp
@@ -542,4 +542,31 @@ void test_doFlowPP4() {
 
 }
 
+void test_doFlowPPExtendedResolutionInvert() {
+        std::vector<float> digits = { 3.0, 2.0, 2.0, 8.0, 9.0, 4.0, 1.7, 9.8 };
+        std::vector<float> analogs = {};
+
+        UnderTestPost* undertestPost = init_do_flow(analogs, digits, Digit100, false, true, -3);
+        std::string result = process_doFlow(undertestPost);
+        TEST_ASSERT_EQUAL_STRING("32289.4198", result.c_str());
+        delete undertestPost;
+
+        undertestPost = init_do_flow(analogs, digits, Digit100, false, true, -3);
+        setExtendedResolutionInvert(undertestPost, true);
+        result = process_doFlow(undertestPost);
+        TEST_ASSERT_EQUAL_STRING("32289.4192", result.c_str());
+        delete undertestPost;
+
+        digits = { 1.0, 2.0, 3.0 };
+        undertestPost = init_do_flow(analogs, digits, Digit100, false, true, 0);
+        result = process_doFlow(undertestPost);
+        TEST_ASSERT_EQUAL_STRING("123.0", result.c_str());
+        delete undertestPost;
+
+        undertestPost = init_do_flow(analogs, digits, Digit100, false, true, 0);
+        setExtendedResolutionInvert(undertestPost, true);
+        result = process_doFlow(undertestPost);
+        TEST_ASSERT_EQUAL_STRING("123.0", result.c_str());
+        delete undertestPost;
+}
 

--- a/code/test/test_suite_flowcontroll.cpp
+++ b/code/test/test_suite_flowcontroll.cpp
@@ -139,6 +139,8 @@ void task_UnityTesting(void *pvParameter)
         RUN_TEST(test_doFlowPP3);
         printf("---------------------------------------------------------------------------\n");
         RUN_TEST(test_doFlowPP4);
+        printf("---------------------------------------------------------------------------\n");
+        RUN_TEST(test_doFlowPPExtendedResolutionInvert);
     UNITY_END();
 
     while(1);
@@ -165,6 +167,7 @@ extern "C" void app_main()
     RUN_TEST(test_doFlowPP2);
     RUN_TEST(test_doFlowPP3);
     RUN_TEST(test_doFlowPP4);
+    RUN_TEST(test_doFlowPPExtendedResolutionInvert);
 
     // getReadoutRawString test
     RUN_TEST(test_getReadoutRawString);

--- a/param-docs/parameter-pages/PostProcessing/NUMBER.ExtendedResolution.md
+++ b/param-docs/parameter-pages/PostProcessing/NUMBER.ExtendedResolution.md
@@ -3,6 +3,8 @@ Default Value: `false`
 
 Use the decimal place of the last analog counter for increased accuracy.
 
+If the intermediate values run in the wrong direction on your meter, use [`NUMBER.ExtendedResolutionInvert`](NUMBER.ExtendedResolutionInvert) to flip the fractional digit mapping.
+
 !!! Note
     This parameter is only supported on the `*-class*` and `*-const` models! See [Choosing-the-Model](../Choosing-the-Model) for details.
 

--- a/param-docs/parameter-pages/PostProcessing/NUMBER.ExtendedResolutionInvert.md
+++ b/param-docs/parameter-pages/PostProcessing/NUMBER.ExtendedResolutionInvert.md
@@ -1,0 +1,19 @@
+# Parameter `ExtendedResolutionInvert`
+Default Value: `false`
+
+Inverts the extra fractional digit that is added by [`NUMBER.ExtendedResolution`](NUMBER.ExtendedResolution).
+Use this when your wheel transition direction is opposite and the intermediate values count in the wrong direction.
+
+Mapping:
+- `0 -> 0`
+- `1 <-> 9`
+- `2 <-> 8`
+- `3 <-> 7`
+- `4 <-> 6`
+- `5 -> 5`
+
+!!! Note
+    This parameter only affects the derived fractional digit that is added by `ExtendedResolution`.
+
+!!! Note
+    If you edit the config file manually, you must prefix this parameter with `<NUMBER>` followed by a dot (eg. `main.ExtendedResolutionInvert`). The reason is that this parameter is specific for each `<NUMBER>` (`<NUMBER>` is the name of the number sequence defined in the ROI's).


### PR DESCRIPTION
## Problem
`ExtendedResolution` can produce the extra decimal digit in the wrong direction on some meters (different wheel rotation direction).

## What this PR changes
- Adds a new per-number postprocessing option: `ExtendedResolutionInvert` (default: `false`)
- Parses config key `EXTENDEDRESOLUTIONINVERT` / `main.ExtendedResolutionInvert`
- Threads the flag into readout logic
- Inverts only the derived fractional digit when enabled
- Adds unit tests for normal vs inverted behavior
- Adds parameter docs for `NUMBER.ExtendedResolutionInvert`

## Why this is safe
- Default is `false`, so existing behavior is unchanged unless user enables it.

## Testing
- `pio test -e esp32cam --without-uploading --without-testing` ✅ (build/test compile pass)
- Hardware runtime test requires attached ESP32-CAM board (not available in this environment)

## Usage
Set in `config.ini` when needed:
- `main.ExtendedResolution = true`
- `main.ExtendedResolutionInvert = true` (only for meters with opposite intermediate direction)
