### PR TITLE
Meter Type for pressure

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowMQTT.cpp
@@ -191,6 +191,15 @@ bool ClassFlowMQTT::ReadParameter(FILE* pfile, string& aktparamgraph)
             else if (toUpper(splitted[1]) == "TEMPERATURE_K") {
                 mqttServer_setMeterType("temperature", "K", "min", "K/m"); // min = Minutes
             }
+            else if (toUpper(splitted[1]) == "PRESSURE_BAR") {
+                mqttServer_setMeterType("pressure", "bar", "min", "bar/m"); // min = Minutes
+            }
+            else if (toUpper(splitted[1]) == "PRESSURE_MBAR") {
+                mqttServer_setMeterType("pressure", "mbar", "min", "mbar/m"); // min = Minutes
+            }
+            else if (toUpper(splitted[1]) == "PRESSURE_PSI") {
+                mqttServer_setMeterType("pressure", "psi", "min", "psi/m"); // min = Minutes
+            }
         }
 
         if ((toUpper(_param) == "CLIENTID") && (splitted.size() > 1))

--- a/param-docs/parameter-pages/MQTT/MeterType.md
+++ b/param-docs/parameter-pages/MQTT/MeterType.md
@@ -24,6 +24,9 @@ List of supported options:
 - `temperature_c` (uses `+C/min` as rate)
 - `temperature_f` (uses `°F/min` as rate)
 - `temperature_k` (uses `K/min` as rate)
+- `pressure_bar` (uses `bar/min` as rate)
+- `pressure_mbar` (uses `mbar/min` as rate)
+- `pressure_psi` (uses `psi/min` as rate)
 
 !!! Note
     Not all options are supported by Homeassistant, see `SensorDeviceClass.VOLUME_FLOW_RATE` in [https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes)!

--- a/sd-card/html/edit_config_template.html
+++ b/sd-card/html/edit_config_template.html
@@ -1196,6 +1196,9 @@
                     <option value="temperature_c">Thermometer (Value: °C, Rate: °C/min)</option>
                     <option value="temperature_c">Thermometer (Value: °F, Rate: °F/min)</option>
                     <option value="temperature_c">Thermometer (Value: K, Rate: K/min)</option>
+                    <option value="pressure_bar">Manometer (Value: bar, Rate: bar/min)</option>
+                    <option value="pressure_mbar">Manometer (Value: mbar, Rate: mbar/min)</option>
+                    <option value="pressure_psi">Manometer (Value: psi, Rate: psi/min)</option>
                 </select>
             </td>
             <td>$TOOLTIP_MQTT_MeterType</td>


### PR DESCRIPTION
Add Meter Type to support pressure (with unit bar)

I have setup a AI on the Edge Device to digitize a manometer (pressure gauge) like in issue https://github.com/jomjol/AI-on-the-edge-device/issues/2954. It work's correctly, but in Home Assistant I'm seeing this error:


> ERROR (MainThread) [homeassistant.components.mqtt.entity] Error 'The unit of measurement Unit/Minute is not valid together with device class volume_flow_rate' when processing MQTT discovery message topic: 'homeassistant/sensor/soledruck/rate_per_time_unit/config', message: '{'unique_id': '/wpe/soledruck-rate_per_time_unit', 'object_id': '/wpe/soledruck_rate_per_time_unit', 'default_entity_id': 'sensor./wpe/soledruck_rate_per_time_unit', 'icon': 'mdi:swap-vertical', 'state_topic': '/wpe/soledruck/main/rate_per_time_unit', 'device_class': 'volume_flow_rate', 'state_class': 'measurement', 'availability_topic': '/wpe/soledruck/connection', 'payload_available': 'connected', 'payload_not_available': 'connection lost', 'device': {'identifiers': ['/wpe/soledruck'], 'model': 'Meter Digitizer', 'manufacturer': 'AI on the Edge Device', 'sw_version': 'v16.1.0', 'configuration_url': 'http://....', 'name': '/wpe/soledruck'}, 'unit_of_measurement': 'Unit/Minute', 'name': 'Rate (Unit/Minute)'}'