### PR TITLE
Fix crash when webhook enabled without configured URL

### DIFF
--- a/code/components/jomjol_flowcontroll/ClassFlowWebhook.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowWebhook.cpp
@@ -118,10 +118,19 @@ bool ClassFlowWebhook::ReadParameter(FILE* pfile, string& aktparamgraph)
     }
     
     WebhookInit(uri,apikey);
-    WebhookEnable = true;
-    LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Webhook Enabled for Uri " + uri);
 
-    printf("uri:         %s\n", uri.c_str());   
+    if (uri.empty())
+    {
+        WebhookEnable = false;
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Webhook not enabled: no Uri configured");
+    }
+    else
+    {
+        WebhookEnable = true;
+        LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Webhook Enabled for Uri " + uri);
+    }
+
+    printf("uri:         %s\n", uri.c_str());
     return true;
 }
 

--- a/code/components/jomjol_webhook/interface_webhook.cpp
+++ b/code/components/jomjol_webhook/interface_webhook.cpp
@@ -28,6 +28,12 @@ void WebhookInit(std::string _uri, std::string _apiKey)
 
 bool WebhookPublish(std::vector<NumberPost*>* numbers)
 {
+    if (_webhookURI.empty())
+    {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "WebhookPublish aborted: no Uri configured");
+        return false;
+    }
+
     bool numbersWithError = false;
     cJSON *jsonArray = cJSON_CreateArray();
 
@@ -76,6 +82,14 @@ bool WebhookPublish(std::vector<NumberPost*>* numbers)
 
     esp_http_client_handle_t http_client = esp_http_client_init(&http_config);
 
+    if (!http_client)
+    {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "WebhookPublish: failed to initialize HTTP client for Uri " + _webhookURI);
+        cJSON_Delete(jsonArray);
+        free(jsonString);
+        return numbersWithError;
+    }
+
     esp_http_client_set_header(http_client, "Content-Type", "application/json");
     esp_http_client_set_header(http_client, "APIKEY", _webhookApiKey.c_str());
 
@@ -98,6 +112,12 @@ bool WebhookPublish(std::vector<NumberPost*>* numbers)
 }
 
 void WebhookUploadPic(ImageData *Img) {
+    if (_webhookURI.empty())
+    {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "WebhookUploadPic aborted: no Uri configured");
+        return;
+    }
+
     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Starting WebhookUploadPic");
 
     std::string fullURI = _webhookURI + "?timestamp=" + std::to_string(_lastTimestamp);
@@ -112,6 +132,12 @@ void WebhookUploadPic(ImageData *Img) {
     };
 
     esp_http_client_handle_t http_client = esp_http_client_init(&http_config);
+
+    if (!http_client)
+    {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "WebhookUploadPic: failed to initialize HTTP client for Uri " + fullURI);
+        return;
+    }
 
     esp_http_client_set_header(http_client, "Content-Type", "image/jpeg");
     esp_http_client_set_header(http_client, "APIKEY", _webhookApiKey.c_str());


### PR DESCRIPTION
WebhookEnable was set unconditionally whenever a [Webhook] section was present, even with an empty Uri. WebhookPublish/WebhookUploadPic then passed the empty URL to esp_http_client_init(), which returns NULL on failed URL parsing; the NULL handle was used unchecked in esp_http_client_set_header(), crashing the device.