### PR TITLE
Add opt-in history-anchored post-processing reconciliation for premature dial transitions (#4112)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,6 +109,19 @@ jobs:
         cp -r ./sd-card/demo/* ./demo/
 
 #########################################################################################
+## Host unit tests (post-processing reconciliation logic)
+#########################################################################################
+  test-reconcile:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build & run reconciliation host unit tests
+      run: |
+        cd code/test/host
+        g++ -std=c++11 -Wall -Wextra -I ../../components/jomjol_flowcontroll test_meter_reconcile_host.cpp ../../components/jomjol_flowcontroll/MeterReconcile.cpp -o reconcile_test
+        ./reconcile_test
+
+#########################################################################################
 ## Pack for Update
 #########################################################################################
   pack-for-update:

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ### Core Changes and Bug fixes
 - Added opt-in history-anchored post-processing reconciliation (`HistoryReconcile`, with `HistoryMaxJump`) that fixes premature analog-dial transitions (single-frame ±1 dial flips) and values getting stuck at digit rollovers, by trusting the reading on unambiguous frames and gating a most-significant analog-dial carry on an observed wrap of the dial below it [#4112](https://github.com/jomjol/AI-on-the-edge-device/issues/4112)
+- `HistoryReconcile` is now preserved by the config editor (previously silently dropped on every ROI/alignment save) and is directly editable in the expert config page
 
 
 # [16.1.0] - 2026-01-11

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# [Unreleased]
+
+### Core Changes and Bug fixes
+- Added opt-in history-anchored post-processing reconciliation (`HistoryReconcile`, with `HistoryMaxJump`) that fixes premature analog-dial transitions (single-frame ±1 dial flips) and values getting stuck at digit rollovers, by trusting the reading on unambiguous frames and gating a most-significant analog-dial carry on an observed wrap of the dial below it [#4112](https://github.com/jomjol/AI-on-the-edge-device/issues/4112)
+
+
 # [16.1.0] - 2026-01-11
 
 For a full list of changes see [Full list of changes](https://github.com/jomjol/AI-on-the-edge-device/compare/v16.0.0...v16.1.0)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ### Core Changes and Bug fixes
 - Added opt-in history-anchored post-processing reconciliation (`HistoryReconcile`, with `HistoryMaxJump`) that fixes premature analog-dial transitions (single-frame ±1 dial flips) and values getting stuck at digit rollovers, by trusting the reading on unambiguous frames and gating a most-significant analog-dial carry on an observed wrap of the dial below it [#4112](https://github.com/jomjol/AI-on-the-edge-device/issues/4112)
 - `HistoryReconcile` is now preserved by the config editor (previously silently dropped on every ROI/alignment save) and is directly editable in the expert config page
+- `HistoryReconcile`: the stuck-recovery path is now limited to a single dial step, so a misread that merely stays clean and stable long enough (e.g. a digit reading one position ahead while the meter is idle) can no longer be re-anchored onto and put the total a whole digit out
 
 
 # [16.1.0] - 2026-01-11

--- a/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowDefineTypes.h
@@ -4,6 +4,7 @@
 #define CLASSFLOWDEFINETYPES_H
 
 #include "ClassFlowImage.h"
+#include "MeterReconcile.h"
 
 /**
  * Properties of one ROI
@@ -75,6 +76,12 @@ struct NumberPost {
     string MeasurementV2;       // influxdbMeasurementName_v2; Name of the Measurement in InfluxDBv2
 
     bool isExtendedResolution;  // extendResolution; Adds the decimal place of the least significant analog ROI to the value
+
+    // History-anchored reconciliation (issue #4112), opt-in via HistoryReconcile
+    bool useHistoryReconcile;               // enable the history-anchored reconciler for this sequence
+    meter::ReconcileState reconcileState;   // persistent per-sequence reconciliation state
+    meter::ReconcileParams reconcileParams; // tuning; msbStep/cleanBigDelta derived per frame
+    std::vector<float> prevAnalogDials;     // previous frame's analog dial floats (for wrap detection)
 
     general *digit_roi;         // digitRoi; set of digit ROIs for the sequence
     general *analog_roi;        // analogRoi; set of analog ROIs for the sequence

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -553,6 +553,53 @@ void ClassFlowPostProcessing::handlecheckDigitIncreaseConsistency(std::string _d
     }
 }
 
+void ClassFlowPostProcessing::handleHistoryReconcile(std::string _decsep, std::string _value)
+{
+    std::string _digit;
+    int _pospunkt = _decsep.find_first_of(".");
+
+    if (_pospunkt > -1) {
+        _digit = _decsep.substr(0, _pospunkt);
+    }
+    else {
+        _digit = "default";
+    }
+
+    for (int j = 0; j < NUMBERS.size(); ++j) {
+        bool _rt = alphanumericToBoolean(_value);
+
+        // Set to default first (if nothing else is set)
+        if ((_digit == "default") || (NUMBERS[j]->name == _digit)) {
+            NUMBERS[j]->useHistoryReconcile = _rt;
+        }
+    }
+}
+
+void ClassFlowPostProcessing::handleHistoryMaxJump(std::string _decsep, std::string _value)
+{
+    std::string _digit;
+    int _pospunkt = _decsep.find_first_of(".");
+
+    if (_pospunkt > -1) {
+        _digit = _decsep.substr(0, _pospunkt);
+    }
+    else {
+        _digit = "default";
+    }
+
+    for (int j = 0; j < NUMBERS.size(); ++j) {
+        if (!isStringNumeric(_value)) {
+            continue;
+        }
+        float _zwdc = std::stof(_value);
+
+        // Set to default first (if nothing else is set)
+        if ((_digit == "default") || (NUMBERS[j]->name == _digit)) {
+            NUMBERS[j]->reconcileParams.maxJump = _zwdc;
+        }
+    }
+}
+
 bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, string& aktparamgraph) {
     std::vector<string> splitted;
     int _n;
@@ -606,6 +653,14 @@ bool ClassFlowPostProcessing::ReadParameter(FILE* pfile, string& aktparamgraph) 
 	    
         if ((toUpper(_param) == "CHECKDIGITINCREASECONSISTENCY") && (splitted.size() > 1)) {
             handlecheckDigitIncreaseConsistency(splitted[0], splitted[1]);
+        }
+
+        if ((toUpper(_param) == "HISTORYRECONCILE") && (splitted.size() > 1)) {
+            handleHistoryReconcile(splitted[0], splitted[1]);
+        }
+
+        if ((toUpper(_param) == "HISTORYMAXJUMP") && (splitted.size() > 1)) {
+            handleHistoryMaxJump(splitted[0], splitted[1]);
         }
 			
         if ((toUpper(_param) == "ALLOWNEGATIVERATES") && (splitted.size() > 1)) {
@@ -690,6 +745,8 @@ void ClassFlowPostProcessing::InitNUMBERS() {
         _number->MaxRateType = AbsoluteChange;
         _number->useMaxRateValue = false;
         _number->checkDigitIncreaseConsistency = false;
+        _number->useHistoryReconcile = false;
+        _number->prevAnalogDials.clear();
         _number->DecimalShift = 0;
         _number->DecimalShiftInitial = 0;
         _number->isExtendedResolution = false;
@@ -903,7 +960,65 @@ bool ClassFlowPostProcessing::doFlow(string zwtime) {
                 }
             }
 
-            if ((!NUMBERS[j]->AllowNegativeRates) && (NUMBERS[j]->Value < NUMBERS[j]->PreValue)) {
+            // --- History-anchored reconciliation (issue #4112), opt-in via HistoryReconcile ---
+            // Replaces the AllowNegativeRates / MaxRateValue guards when enabled. A carry of the
+            // most-significant analog dial is accepted only with wrap evidence from the dial
+            // below (observed transition or inferred from the sub-position); within-step motion
+            // is trusted on unambiguous frames; a stuck value recovers on a clean, stable frame.
+            // See MeterReconcile.h for the full design rationale.
+            if (NUMBERS[j]->useHistoryReconcile && NUMBERS[j]->analog_roi) {
+                std::vector<float> _dials;
+                for (int _d = 0; _d < NUMBERS[j]->analog_roi->ROI.size(); ++_d) {
+                    _dials.push_back(NUMBERS[j]->analog_roi->ROI[_d]->result_float);
+                }
+                bool _hadN = (findDelimiterPos(NUMBERS[j]->ReturnRawValue, "N") != std::string::npos);
+                bool _clean = !_hadN && meter::framesClean(_dials, NUMBERS[j]->reconcileParams.band);
+                bool _wrap = false;
+                if ((_dials.size() >= 2) && (NUMBERS[j]->prevAnalogDials.size() == _dials.size())) {
+                    _wrap = meter::dialWrapped(NUMBERS[j]->prevAnalogDials[1], _dials[1], NUMBERS[j]->reconcileParams.band);
+                }
+                // Place value (in displayed units) of one step of the most-significant analog dial
+                // (ROI[0]). ROI[0] is followed by (AnzahlAnalog-1) lower dials plus, if extended
+                // resolution is on, one extra appended digit; the least-significant displayed place
+                // is 10^-Nachkomma. This holds for digit+analog and analog-only, extended or not.
+                int _msbExp = NUMBERS[j]->AnzahlAnalog - 1 - NUMBERS[j]->Nachkomma
+                              + (NUMBERS[j]->isExtendedResolution ? 1 : 0);
+                NUMBERS[j]->reconcileParams.msbStep = pow(10, _msbExp);
+                // A single analog dial offers no evidence channel for its own carry: there is no
+                // dial below to observe wrapping, and without extended resolution no sub-position
+                // to infer one from. Disable the carry gate then (other guards remain) instead of
+                // holding every legitimate step of that dial.
+                if ((_dials.size() < 2) && !NUMBERS[j]->isExtendedResolution) {
+                    NUMBERS[j]->reconcileParams.msbStep = 0.0;
+                }
+                // Backward jitter tolerance scales with the displayed resolution (a couple of ULPs).
+                NUMBERS[j]->reconcileParams.noiseTol = 2.0 * pow(10, -NUMBERS[j]->Nachkomma);
+                // Gross-misread ceiling: derive from the dial scale unless explicitly configured.
+                if (NUMBERS[j]->reconcileParams.maxJump <= 0.0) {
+                    NUMBERS[j]->reconcileParams.maxJump = 100.0 * NUMBERS[j]->reconcileParams.msbStep;
+                }
+                NUMBERS[j]->reconcileState.confirmed = NUMBERS[j]->PreValue;
+                NUMBERS[j]->reconcileState.hasConfirmed = NUMBERS[j]->PreValueOkay;
+
+                meter::ReconcileResult _rr = meter::reconcileStep(NUMBERS[j]->reconcileState,
+                        NUMBERS[j]->Value, _clean, _wrap, NUMBERS[j]->reconcileParams);
+                NUMBERS[j]->prevAnalogDials = _dials;
+
+                if (_rr.action != meter::RA_ACCEPT) {
+                    NUMBERS[j]->ErrorMessageText = NUMBERS[j]->ErrorMessageText + "History hold - Raw: " + NUMBERS[j]->ReturnRawValue + " - Pre: " + RundeOutput(NUMBERS[j]->PreValue, NUMBERS[j]->Nachkomma) + " ";
+                    NUMBERS[j]->Value = NUMBERS[j]->PreValue;
+                    NUMBERS[j]->ReturnValue = "";
+                    NUMBERS[j]->ReturnRateValue = "";
+                    NUMBERS[j]->timeStampLastValue = imagetime;
+                    string _zwh = NUMBERS[j]->name + ": Raw: " + NUMBERS[j]->ReturnRawValue + ", Value: " + NUMBERS[j]->ReturnValue + ", Status: " + NUMBERS[j]->ErrorMessageText;
+                    LogFile.WriteToFile(ESP_LOG_WARN, TAG, _zwh);
+                    WriteDataLog(j);
+                    continue;
+                }
+                NUMBERS[j]->Value = _rr.value;
+            }
+
+            if ((!NUMBERS[j]->AllowNegativeRates) && (NUMBERS[j]->Value < NUMBERS[j]->PreValue) && !(NUMBERS[j]->useHistoryReconcile && NUMBERS[j]->analog_roi)) {
                 LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "handleAllowNegativeRate for device: " + NUMBERS[j]->name);
 					
                 if ((NUMBERS[j]->Value < NUMBERS[j]->PreValue)) {
@@ -935,7 +1050,7 @@ bool ClassFlowPostProcessing::doFlow(string zwtime) {
             NUMBERS[j]->FlowRateAct = (NUMBERS[j]->Value - NUMBERS[j]->PreValue) / LastPreValueTimeDifference;
             NUMBERS[j]->ReturnRateValue =  to_string(NUMBERS[j]->FlowRateAct);
 
-            if ((NUMBERS[j]->useMaxRateValue) && (NUMBERS[j]->Value != NUMBERS[j]->PreValue)) {
+            if ((NUMBERS[j]->useMaxRateValue) && (NUMBERS[j]->Value != NUMBERS[j]->PreValue) && !(NUMBERS[j]->useHistoryReconcile && NUMBERS[j]->analog_roi)) {
                 double _ratedifference;
 					
                 if (NUMBERS[j]->MaxRateType == RateChange) {

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
@@ -43,6 +43,8 @@ protected:
     void handleIgnoreLeadingNaN(string _decsep, string _value);
     void handleChangeRateThreshold(string _decsep, string _value);
     void handlecheckDigitIncreaseConsistency(std::string _decsep, std::string _value);
+    void handleHistoryReconcile(std::string _decsep, std::string _value);
+    void handleHistoryMaxJump(std::string _decsep, std::string _value);
 
     void WriteDataLog(int _index);
 

--- a/code/components/jomjol_flowcontroll/MeterReconcile.cpp
+++ b/code/components/jomjol_flowcontroll/MeterReconcile.cpp
@@ -1,0 +1,129 @@
+#include "MeterReconcile.h"
+#include <cmath>
+
+namespace meter {
+
+bool dialNearBoundary(float dialValue, float band) {
+    // distance to the nearest integer, treating the dial as a 0..10 ring (so 9.9 is near 0).
+    float frac = dialValue - std::floor(dialValue);     // 0 .. <1
+    float dist = frac < 0.5f ? frac : (1.0f - frac);    // distance to nearest integer in [0,0.5]
+    return dist <= band;
+}
+
+bool dialWrapped(float prevValue, float nowValue, float band) {
+    // Forward 9 -> 0 rollover: the dial was near the TOP of the 0..10 ring on the previous frame
+    // and dropped sharply to the bottom. We key on a genuine large high->low drop, NOT merely a
+    // high fractional part - so 0.9 -> 0.1 (low-integer jitter) is not a wrap, while 9.5 -> 0.5
+    // and 9.8 -> 1.2 (a fast rollover overshooting 1.0) are.
+    bool prevHigh = prevValue >= (9.0f - band);
+    bool nowLow   = nowValue  <= 3.0f;                   // a real rollover lands near 0 (generous for fast flow)
+    return prevHigh && nowLow && ((prevValue - nowValue) > 5.0f);
+}
+
+bool framesClean(const std::vector<float>& dials, float band) {
+    if (dials.empty()) return false;
+    for (size_t i = 0; i < dials.size(); ++i) {
+        if (dials[i] < 0.0f) return false;          // negative sentinel == unreadable (N)
+        if (dialNearBoundary(dials[i], band)) return false;
+    }
+    return true;
+}
+
+static ReconcileResult accept(ReconcileState& st, double v) {
+    st.confirmed = v;
+    st.held = 0;
+    ReconcileResult r; r.value = v; r.action = RA_ACCEPT; r.reAnchored = true;
+    return r;
+}
+
+static ReconcileResult hold(ReconcileState& st) {
+    st.held++;
+    ReconcileResult r; r.value = st.confirmed; r.action = RA_HOLD; r.reAnchored = false;
+    return r;
+}
+
+// Which most-significant-dial "bucket" does a value fall in? A small relative epsilon absorbs
+// floating-point error in (value / msbStep) at bucket boundaries (msbStep may be fractional, e.g.
+// 0.1, while values are large), so a value sitting exactly on a boundary is not flickered into the
+// wrong bucket by rounding noise.
+static long stepBucket(double value, double step) {
+    double q = value / step;
+    return (long) std::floor(q + (std::fabs(q) + 1.0) * 1e-9);
+}
+
+ReconcileResult reconcileStep(ReconcileState& st, double candidate,
+                              bool clean, bool lowerDialWrapped,
+                              const ReconcileParams& p) {
+    // Cold start: no anchor yet -> trust the reading.
+    if (!st.hasConfirmed) {
+        st.hasConfirmed = true;
+        return accept(st, candidate);
+    }
+
+    const double delta = candidate - st.confirmed;
+
+    // Stability of the recognition itself: is this frame's candidate (essentially) the same as
+    // the previous frame's? Used to bound the stuck-recovery path below.
+    const bool stable = st.hasLast && std::fabs(candidate - st.lastCandidate) <= p.noiseTol;
+    st.lastCandidate = candidate;
+    st.hasLast = true;
+
+    // Arm / age the wrap window. A lower-dial wrap and the valid single-step carry it justifies
+    // can land on *different* frames (e.g. the wrap frame is itself a misread), so remember an
+    // observed wrap for a few frames rather than only on the exact frame it is seen.
+    if (lowerDialWrapped) st.wrapArmed = p.wrapWindow;
+    else if (st.wrapArmed > 0) st.wrapArmed--;
+
+    // Physically impossible single-frame jump -> never accept (gross misread).
+    if (p.maxJump > 0.0 && std::fabs(delta) > p.maxJump) {
+        return hold(st);
+    }
+
+    // Does the candidate cross a most-significant-dial step vs. the confirmed value?
+    long steps = 0;
+    bool subWrapped = false;
+    if (p.msbStep > 0.0) {
+        steps = stepBucket(candidate, p.msbStep) - stepBucket(st.confirmed, p.msbStep);
+
+        // Wrap INFERENCE from the values themselves: a genuine carry always passes the
+        // sub-position (the part below one msb step, i.e. the dials underneath) through zero,
+        // while a premature msb-dial flip leaves it unchanged. So "sub-position decreased
+        // decisively" is evidence of a real wrap even if the observed dial-below transition was
+        // missed (misread wrap frame, gap in frames, or no second dial at all). The margin must
+        // exceed the dial-below reading scatter (~band of its step = band/10 of msbStep), so
+        // ordinary backward jitter of the dial below cannot fake wrap evidence.
+        double subConf = st.confirmed - (double) stepBucket(st.confirmed, p.msbStep) * p.msbStep;
+        double subNow  = candidate    - (double) stepBucket(candidate,    p.msbStep) * p.msbStep;
+        subWrapped = subNow < (subConf - 0.1 * p.msbStep);
+    }
+
+    if (steps != 0) {
+        // Carry. Legitimate only as a single forward step justified by a wrap of the dial below,
+        // either observed (recently, within the wrap window) or inferred from the sub-position --
+        // enforced on clean AND ambiguous frames, so a dial misread ~half a step off (not near an
+        // integer, hence "clean") cannot sneak a premature carry through.
+        if (steps == 1 && delta > 0.0 && (st.wrapArmed > 0 || subWrapped)) {
+            st.wrapArmed = 0;                 // one wrap justifies exactly one carry
+            return accept(st, candidate);
+        }
+        // Recovery: if the value has been held for a sustained stretch it was genuinely stuck
+        // (not flickering), so on a clean frame with a stable recognition trust the reading and
+        // re-anchor across the carry (handles multi-step catch-up and wrong-anchor healing).
+        if (clean && stable && st.held >= p.recoverHolds) {
+            return accept(st, candidate);
+        }
+        return hold(st);
+    }
+
+    // No carry (candidate is in the same most-significant-dial bucket as confirmed).
+    if (clean) {
+        return accept(st, candidate);       // absolute reading is trustworthy this frame
+    }
+    // Ambiguous, no carry: forward motion ok; tolerate only sub-noise backward jitter.
+    if (delta >= -p.noiseTol) {
+        return accept(st, candidate);
+    }
+    return hold(st);
+}
+
+} // namespace meter

--- a/code/components/jomjol_flowcontroll/MeterReconcile.cpp
+++ b/code/components/jomjol_flowcontroll/MeterReconcile.cpp
@@ -108,8 +108,16 @@ ReconcileResult reconcileStep(ReconcileState& st, double candidate,
         }
         // Recovery: if the value has been held for a sustained stretch it was genuinely stuck
         // (not flickering), so on a clean frame with a stable recognition trust the reading and
-        // re-anchor across the carry (handles multi-step catch-up and wrong-anchor healing).
-        if (clean && stable && st.held >= p.recoverHolds) {
+        // re-anchor across the carry (heals an anchor left behind by a missed carry).
+        //
+        // Bounded by recoverMaxSteps: "clean and stable for a while" is NOT evidence that a
+        // far-away reading is right - a digit misread one position ahead sits perfectly clean and
+        // stable for as long as the meter is idle, and recovering onto it replaces a correct value
+        // with one a full digit out. Beyond the cap, keep holding: a frozen value is visible and
+        // costs nothing, a poisoned anchor silently corrupts every later total.
+        const long absSteps = steps < 0 ? -steps : steps;
+        if (clean && stable && st.held >= p.recoverHolds &&
+            (p.recoverMaxSteps <= 0 || absSteps <= (long) p.recoverMaxSteps)) {
             return accept(st, candidate);
         }
         return hold(st);

--- a/code/components/jomjol_flowcontroll/MeterReconcile.h
+++ b/code/components/jomjol_flowcontroll/MeterReconcile.h
@@ -1,0 +1,102 @@
+// MeterReconcile - history-anchored reconciliation of a mechanical-counter reading.
+//
+// PURE, dependency-free C++ (no ESP-IDF, no I/O, no globals, no clock calls) so it can be
+// unit-tested on the host. It turns the per-frame "candidate" value produced by the existing
+// recognition pipeline into a robust output, using four physical priors of the meter:
+//
+//   1. Monotonic        - the meter only counts up.
+//   2. Slow vs. frames  - real change between two frames is small; a large change is only
+//                         legitimate as a *catch-up* after a gap/stall.
+//   3. Absolute encoder - when no dial sits on a boundary, the reading itself is the truth.
+//   4. Over-determined  - a most-significant analog dial may only carry when the dial below
+//                         it wraps (9 -> 0), and a genuine wrap is visible twice: in the
+//                         dial-below transition AND in the value's sub-position passing zero.
+//
+// The reconciler therefore:
+//   - accepts a most-significant-dial *carry* only as a single forward step with wrap evidence
+//     from one of two independent channels: the dial-below transition observed in a recent frame
+//     (a short window, since the wrap and the valid carry may land on different frames), or
+//     inference from the value itself (a genuine carry passes the sub-position through zero,
+//     while a premature dial flip leaves it unchanged). The gate applies on BOTH ambiguous AND
+//     "clean" frames, because a dial can be misread ~half a step off its true position without
+//     landing near an integer - so a premature carry can otherwise masquerade as a trustworthy
+//     "clean" reading;
+//   - for non-carry motion (within the same most-significant-dial step) trusts a clean reading
+//     and, on an ambiguous frame, allows forward motion while tolerating only sub-noise backward;
+//   - re-anchors across a carry without wrap evidence only as *recovery*: after the value has
+//     been held for a sustained stretch on a clean frame with a stable recognition (genuinely
+//     stuck, not flickering or a wandering misread);
+//   - never accepts a physically impossible single-frame jump (maxJump); holds instead of guessing.
+//
+// This is an opt-in layer. The digit-chain zero-crossing handling (CheckDigitIncreaseConsistency)
+// is left in place; this adds the missing protection on the analog dial chain.
+
+#ifndef METER_RECONCILE_H
+#define METER_RECONCILE_H
+
+#include <vector>
+#include <cstddef>
+
+namespace meter {
+
+struct ReconcileParams {
+    double maxJump;       // hard ceiling on a single-frame change (value units); <= 0 disables the limit
+    double msbStep;       // value units represented by one full step of the most-significant analog dial
+    double noiseTol;      // small downward tolerance for jitter (value units); should scale with resolution
+    int    recoverHolds;  // consecutive holds before a clean, stable carry is accepted as stuck-recovery
+    int    wrapWindow;    // frames an observed lower-dial wrap keeps justifying a single-step carry
+    float  band;          // a dial within this distance of an integer is "near a boundary".
+                          // INVARIANT: keep >= the recognition chain's own ambiguity band
+                          // (Analog_error/10 in defines.h), so any frame the chain may have
+                          // "corrected" across a boundary is classified ambiguous here and can
+                          // never slip through the clean-recovery path.
+
+    // Defaults are conservative; the firmware derives msbStep / noiseTol / maxJump from the
+    // meter's decimal scaling each frame (see ClassFlowPostProcessing).
+    ReconcileParams()
+        : maxJump(-1.0), msbStep(0.0), noiseTol(0.0), recoverHolds(5), wrapWindow(3), band(0.30f) {}
+};
+
+struct ReconcileState {
+    bool   hasConfirmed;  // false until the first reading is anchored
+    double confirmed;     // last trusted value (mirrors PreValue)
+    int    held;          // consecutive holds since the last accept (drives stuck-recovery)
+    int    wrapArmed;     // frames remaining in which a recently-observed wrap justifies a carry
+    double lastCandidate; // previous frame's candidate (stability check for stuck-recovery)
+    bool   hasLast;
+
+    ReconcileState() : hasConfirmed(false), confirmed(0.0), held(0), wrapArmed(0),
+                       lastCandidate(0.0), hasLast(false) {}
+};
+
+enum ReconcileAction { RA_ACCEPT, RA_HOLD };
+
+struct ReconcileResult {
+    double          value;       // value to output this frame
+    ReconcileAction action;
+    bool            reAnchored;   // confirmed was updated from a trusted reading this frame
+};
+
+// Per-frame reconciliation.
+//   candidate           : value assembled by the existing pipeline this frame.
+//   clean               : true if NO dial is within `band` of an integer and no ROI was unreadable.
+//   lowerDialWrapped    : true if the dial just below the most-significant analog dial was observed
+//                         to wrap (high -> low) since the previous frame (justifies a carry).
+ReconcileResult reconcileStep(ReconcileState& st, double candidate,
+                              bool clean, bool lowerDialWrapped,
+                              const ReconcileParams& p);
+
+// --- helpers (also pure / testable), used by the firmware to derive the booleans above ---
+
+// Is a single analog dial reading within `band` of an integer boundary (incl. the 0/10 seam)?
+bool dialNearBoundary(float dialValue, float band);
+
+// Did a dial wrap forward (high -> low, a true 9->0 rollover) between the previous and current frame?
+bool dialWrapped(float prevValue, float nowValue, float band);
+
+// Are ALL dials clear of their boundaries (-> the absolute reading is trustworthy)?
+bool framesClean(const std::vector<float>& dials, float band);
+
+} // namespace meter
+
+#endif // METER_RECONCILE_H

--- a/code/components/jomjol_flowcontroll/MeterReconcile.h
+++ b/code/components/jomjol_flowcontroll/MeterReconcile.h
@@ -25,7 +25,9 @@
 //     and, on an ambiguous frame, allows forward motion while tolerating only sub-noise backward;
 //   - re-anchors across a carry without wrap evidence only as *recovery*: after the value has
 //     been held for a sustained stretch on a clean frame with a stable recognition (genuinely
-//     stuck, not flickering or a wandering misread);
+//     stuck, not flickering or a wandering misread) AND only across a bounded number of steps -
+//     staying clean and stable says nothing about a reading that is a whole digit out, and
+//     recovering onto one would replace a correct value with a badly wrong anchor;
 //   - never accepts a physically impossible single-frame jump (maxJump); holds instead of guessing.
 //
 // This is an opt-in layer. The digit-chain zero-crossing handling (CheckDigitIncreaseConsistency)
@@ -44,6 +46,14 @@ struct ReconcileParams {
     double msbStep;       // value units represented by one full step of the most-significant analog dial
     double noiseTol;      // small downward tolerance for jitter (value units); should scale with resolution
     int    recoverHolds;  // consecutive holds before a clean, stable carry is accepted as stuck-recovery
+    int    recoverMaxSteps; // most-significant-dial steps a stuck-recovery may re-anchor across; <= 0
+                          // disables the cap. Without it, a misread that merely stays clean and
+                          // stable long enough is re-anchored to NO MATTER HOW FAR it is wrong (up
+                          // to maxJump), which is how a stuck-but-correct value gets replaced by a
+                          // badly wrong one. Recovery exists to heal an anchor that is off by a
+                          // missed carry, so one step is enough; a value that is wrong by more is
+                          // left held (loud and harmless) for the PreValueAgeStartup re-seed or a
+                          // manual PreValue, rather than silently poisoning the total.
     int    wrapWindow;    // frames an observed lower-dial wrap keeps justifying a single-step carry
     float  band;          // a dial within this distance of an integer is "near a boundary".
                           // INVARIANT: keep >= the recognition chain's own ambiguity band
@@ -54,7 +64,8 @@ struct ReconcileParams {
     // Defaults are conservative; the firmware derives msbStep / noiseTol / maxJump from the
     // meter's decimal scaling each frame (see ClassFlowPostProcessing).
     ReconcileParams()
-        : maxJump(-1.0), msbStep(0.0), noiseTol(0.0), recoverHolds(5), wrapWindow(3), band(0.30f) {}
+        : maxJump(-1.0), msbStep(0.0), noiseTol(0.0), recoverHolds(5), recoverMaxSteps(1),
+          wrapWindow(3), band(0.30f) {}
 };
 
 struct ReconcileState {

--- a/code/test/host/.gitignore
+++ b/code/test/host/.gitignore
@@ -1,0 +1,3 @@
+reconcile_test
+reconcile_test.exe
+*.o

--- a/code/test/host/test_meter_reconcile_host.cpp
+++ b/code/test/host/test_meter_reconcile_host.cpp
@@ -1,0 +1,279 @@
+// Host-only unit test for the pure reconciliation core (no ESP-IDF needed).
+// Build & run (from this directory):
+//   g++ -std=c++11 -I../../components/jomjol_flowcontroll test_meter_reconcile_host.cpp ../../components/jomjol_flowcontroll/MeterReconcile.cpp -o reconcile_test
+//   ./reconcile_test
+//
+// The scenarios exercise the failure modes the reconciler is designed to handle. They use
+// generic numbers with a most-significant-dial step (msbStep) of 100, so a change of 100
+// represents one full step of the most-significant analog dial.
+
+#include "MeterReconcile.h"
+#include <cstdio>
+#include <cmath>
+#include <string>
+
+using namespace meter;
+
+static int g_pass = 0, g_fail = 0;
+
+static void check(const char* what, double got, double want) {
+    bool ok = std::fabs(got - want) < 0.05;
+    printf("  [%s] %-52s got=%.2f want=%.2f\n", ok ? "PASS" : "FAIL", what, got, want);
+    if (ok) g_pass++; else g_fail++;
+}
+static void checkAction(const char* what, ReconcileAction got, ReconcileAction want) {
+    bool ok = got == want;
+    printf("  [%s] %-52s action got=%d want=%d\n", ok ? "PASS" : "FAIL", what, (int)got, (int)want);
+    if (ok) g_pass++; else g_fail++;
+}
+
+static ReconcileParams stdParams() {
+    ReconcileParams p;
+    p.msbStep      = 100.0;   // one step of the most-significant analog dial
+    p.maxJump      = 5000.0;  // hard ceiling on a single-frame change
+    p.noiseTol     = 2.0;
+    p.recoverHolds = 5;       // clean carry accepted as recovery only after this many holds
+    p.band         = 0.30f;
+    return p;
+}
+
+static ReconcileState anchoredAt(double v, const ReconcileParams& p) {
+    ReconcileState st;
+    reconcileStep(st, v, /*clean*/true, /*wrap*/false, p);
+    return st;
+}
+
+int main() {
+    ReconcileParams p = stdParams();
+
+    printf("A: cold start, then normal clean forward motion is tracked\n");
+    {
+        ReconcileState st;
+        ReconcileResult r = reconcileStep(st, 500000.0, true, false, p);
+        check("cold start accepts", r.value, 500000.0);
+        checkAction("cold start -> ACCEPT", r.action, RA_ACCEPT);
+        r = reconcileStep(st, 500005.0, true, false, p);
+        check("small clean forward accepted", r.value, 500005.0);
+        r = reconcileStep(st, 500011.0, true, false, p);
+        check("continues to track", r.value, 500011.0);
+    }
+
+    printf("B: a premature carry on an AMBIGUOUS frame (no wrap) is held\n");
+    {
+        ReconcileState st = anchoredAt(500200.0, p);
+        for (int i = 0; i < 4; ++i) {
+            ReconcileResult r = reconcileStep(st, 500300.0, /*clean*/false, /*wrap*/false, p);
+            if (i == 0) { check("held at last good value", r.value, 500200.0);
+                          checkAction("-> HOLD", r.action, RA_HOLD); }
+        }
+    }
+
+    printf("C: a premature carry on a CLEAN frame (no wrap) is ALSO held  [key fix]\n");
+    {
+        // A dial misread ~a third of a step high sits at the band edge, so the frame can look
+        // 'clean' - but a carry without an observed wrap must still be rejected, not trusted.
+        ReconcileState st = anchoredAt(500200.0, p);
+        ReconcileResult r = reconcileStep(st, 500300.0, /*clean*/true, /*wrap*/false, p);
+        check("clean premature carry held (not accepted)", r.value, 500200.0);
+        checkAction("clean premature carry -> HOLD", r.action, RA_HOLD);
+    }
+
+    printf("D: a legitimate carry (observed wrap, single forward step) is accepted\n");
+    {
+        ReconcileState st = anchoredAt(500200.0, p);
+        ReconcileResult r = reconcileStep(st, 500305.0, /*clean*/false, /*wrap*/true, p);
+        check("carry with observed wrap accepted", r.value, 500305.0);
+        checkAction("legit carry -> ACCEPT", r.action, RA_ACCEPT);
+    }
+
+    printf("E: a backward carry is held even with an observed wrap\n");
+    {
+        ReconcileState st = anchoredAt(500300.0, p);
+        ReconcileResult r = reconcileStep(st, 500250.0, /*clean*/false, /*wrap*/true, p);
+        check("backward carry held", r.value, 500300.0);
+    }
+
+    printf("F: a multi-step carry is held even with a single observed wrap\n");
+    {
+        ReconcileState st = anchoredAt(500200.0, p);
+        ReconcileResult r = reconcileStep(st, 500450.0, /*clean*/false, /*wrap*/true, p); // 2 steps
+        check("two-step carry held (one wrap != two steps)", r.value, 500200.0);
+    }
+
+    printf("G: a physically impossible jump is rejected (and cannot be confirmed)\n");
+    {
+        ReconcileState st = anchoredAt(500000.0, p);
+        ReconcileResult r = reconcileStep(st, 600000.0, /*clean*/false, false, p); // +100000 > maxJump
+        check("gross misread held (ambiguous)", r.value, 500000.0);
+        r = reconcileStep(st, 600000.0, /*clean*/true, false, p);
+        check("gross misread held (clean)", r.value, 500000.0);
+        for (int i = 0; i < 8; ++i) reconcileStep(st, 600000.0, true, false, p); // beyond recoverHolds
+        r = reconcileStep(st, 600000.0, true, false, p);
+        check("still held (> maxJump beats recovery)", r.value, 500000.0);
+        r = reconcileStep(st, 500050.0, true, false, p);
+        check("a valid reading is still accepted afterwards", r.value, 500050.0);
+    }
+
+    printf("H: a clean carry is accepted only after a SUSTAINED hold (stuck-recovery)\n");
+    {
+        ReconcileState st = anchoredAt(500200.0, p);
+        ReconcileResult r;
+        for (int i = 0; i < p.recoverHolds; ++i) {                 // 5 ambiguous carry holds
+            r = reconcileStep(st, 500300.0, /*clean*/false, /*wrap*/false, p);
+        }
+        check("still held through the stall", r.value, 500200.0);
+        r = reconcileStep(st, 500300.0, /*clean*/true, /*wrap*/false, p);  // now clean -> recover
+        check("clean frame re-anchors after sustained holds", r.value, 500300.0);
+        checkAction("recovery -> ACCEPT", r.action, RA_ACCEPT);
+    }
+
+    printf("I: backward jitter beyond noise on an ambiguous (no-carry) frame is rejected\n");
+    {
+        ReconcileState st = anchoredAt(500050.0, p);
+        ReconcileResult r = reconcileStep(st, 500000.0, /*clean*/false, false, p); // -50, same bucket
+        check("ambiguous backward held", r.value, 500050.0);
+    }
+
+    printf("J: tiny sub-noise jitter on an ambiguous frame is accepted\n");
+    {
+        ReconcileState st = anchoredAt(500050.0, p);
+        ReconcileResult r = reconcileStep(st, 500049.0, /*clean*/false, false, p); // -1, within noiseTol
+        check("ambiguous sub-noise jitter accepted", r.value, 500049.0);
+    }
+
+    printf("K: forward sub-step motion on an ambiguous frame is accepted\n");
+    {
+        ReconcileState st = anchoredAt(500010.0, p);
+        ReconcileResult r = reconcileStep(st, 500030.0, /*clean*/false, false, p); // +20, no carry
+        check("ambiguous forward (no carry) accepted", r.value, 500030.0);
+    }
+
+    printf("L: a clean no-carry change is accepted immediately\n");
+    {
+        ReconcileState st = anchoredAt(500030.0, p);
+        ReconcileResult r = reconcileStep(st, 500045.0, /*clean*/true, false, p);
+        check("clean no-carry accepted", r.value, 500045.0);
+    }
+
+    printf("M: dial helper functions\n");
+    {
+        check("wrap 9.5 -> 0.5",                       dialWrapped(9.5f, 0.5f, 0.30f) ? 1 : 0, 1);
+        check("wrap 9.8 -> 1.2 (overshoots 1.0)",      dialWrapped(9.8f, 1.2f, 0.30f) ? 1 : 0, 1);
+        check("wrap 9.0 -> 0.1",                       dialWrapped(9.0f, 0.1f, 0.30f) ? 1 : 0, 1);
+        check("NOT wrap 0.9 -> 0.1 (low-int jitter)",  dialWrapped(0.9f, 0.1f, 0.30f) ? 1 : 0, 0);
+        check("NOT wrap 7.8 -> 0.1 (mid-dial)",        dialWrapped(7.8f, 0.1f, 0.30f) ? 1 : 0, 0);
+        check("near boundary 3.05",                    dialNearBoundary(3.05f, 0.30f) ? 1 : 0, 1);
+        check("near boundary 9.8 (0/10 seam)",         dialNearBoundary(9.8f,  0.30f) ? 1 : 0, 1);
+        check("NOT near boundary 3.5",                 dialNearBoundary(3.5f,  0.30f) ? 1 : 0, 0);
+        std::vector<float> clear_; clear_.push_back(3.5f); clear_.push_back(5.5f);
+        check("framesClean: all clear",                framesClean(clear_, 0.30f) ? 1 : 0, 1);
+        std::vector<float> near_; near_.push_back(3.5f); near_.push_back(9.95f);
+        check("framesClean: one near boundary",        framesClean(near_, 0.30f) ? 1 : 0, 0);
+        std::vector<float> nan_; nan_.push_back(3.5f); nan_.push_back(-1.0f);
+        check("framesClean: unreadable (N)",           framesClean(nan_, 0.30f) ? 1 : 0, 0);
+        std::vector<float> empty_;
+        check("framesClean: empty",                    framesClean(empty_, 0.30f) ? 1 : 0, 0);
+    }
+
+    printf("N: the carry gate is scale-invariant (small msbStep, FP-safe)\n");
+    {
+        ReconcileParams ps; ps.msbStep = 0.1; ps.maxJump = 50.0; ps.noiseTol = 0.02;
+        ps.recoverHolds = 5; ps.band = 0.30f;
+        ReconcileState st = anchoredAt(2000.0, ps);
+        ReconcileResult r = reconcileStep(st, 1999.5, /*clean*/false, false, ps);   // backward carry
+        check("small-scale backward held", r.value, 2000.0);
+        r = reconcileStep(st, 2000.05, /*clean*/false, false, ps);                  // forward sub-step, no FP carry
+        check("small-scale forward sub-step accepted", r.value, 2000.05);
+    }
+
+    printf("O: the reAnchored flag reflects whether confirmed was updated\n");
+    {
+        ReconcileState st = anchoredAt(500000.0, p);
+        ReconcileResult acc = reconcileStep(st, 500005.0, true, false, p);
+        check("accept sets reAnchored", acc.reAnchored ? 1 : 0, 1);
+        ReconcileResult hld = reconcileStep(st, 500300.0, /*clean*/true, /*wrap*/false, p);
+        check("hold clears reAnchored", hld.reAnchored ? 1 : 0, 0);
+    }
+
+    printf("P: msbStep == 0 disables the carry gate (struct default if not derived)\n");
+    {
+        ReconcileParams pt = stdParams(); pt.msbStep = 0.0;
+        ReconcileState st = anchoredAt(500200.0, pt);
+        ReconcileResult r = reconcileStep(st, 500300.0, /*clean*/false, /*wrap*/false, pt);
+        check("no carry gate -> ambiguous forward accepted", r.value, 500300.0);
+    }
+
+    printf("Q: maxJump <= 0 removes the ceiling but the carry gate still applies\n");
+    {
+        ReconcileParams pq = stdParams(); pq.maxJump = -1.0;
+        ReconcileState st = anchoredAt(500000.0, pq);
+        ReconcileResult r = reconcileStep(st, 900000.0, /*clean*/true, /*wrap*/false, pq); // huge carry
+        check("huge carry still held (gate applies)", r.value, 500000.0);
+        for (int i = 0; i < pq.recoverHolds; ++i) reconcileStep(st, 900000.0, false, false, pq);
+        r = reconcileStep(st, 900000.0, /*clean*/true, false, pq);   // sustained hold -> recover
+        check("recovery accepts once stuck (no ceiling)", r.value, 900000.0);
+    }
+
+    printf("R: a wrap seen one frame before the valid carry still accepts (sticky wrap)\n");
+    {
+        // Mirrors a cascade rollover: the dial-below wraps on a frame whose assembled value is a
+        // misread multi-step jump (held), then the valid single-step carry arrives next frame.
+        ReconcileState st = anchoredAt(500900.0, p);
+        ReconcileResult r = reconcileStep(st, 505900.0, /*clean*/false, /*wrap*/true, p); // +50 steps: misread
+        check("misread multi-step held despite wrap", r.value, 500900.0);
+        r = reconcileStep(st, 501005.0, /*clean*/false, /*wrap*/false, p);                // valid +1 step
+        check("valid carry accepted within wrap window", r.value, 501005.0);
+        checkAction("sticky-wrap carry -> ACCEPT", r.action, RA_ACCEPT);
+    }
+
+    printf("S: the wrap window expires (a carry long after a wrap, no new wrap, is held)\n");
+    {
+        ReconcileState st = anchoredAt(500900.0, p);
+        reconcileStep(st, 505900.0, /*clean*/false, /*wrap*/true, p);                     // arm (held)
+        for (int i = 0; i < p.wrapWindow; ++i) reconcileStep(st, 500905.0, false, false, p); // age it out
+        ReconcileResult r = reconcileStep(st, 501005.0, /*clean*/false, /*wrap*/false, p);
+        check("carry held after wrap window expired", r.value, 500905.0);
+    }
+
+    printf("T: a valid carry with NO observed wrap is accepted via sub-position inference\n");
+    {
+        // Stopped-flow stall replay: the wrap frame was missed entirely; the candidate's
+        // sub-position (94 -> 35) proves the dial below passed through zero.
+        ReconcileState st = anchoredAt(500094.0, p);
+        ReconcileResult r = reconcileStep(st, 500135.0, /*clean*/false, /*wrap*/false, p);
+        check("carry accepted via inferred wrap", r.value, 500135.0);
+        checkAction("inferred wrap -> ACCEPT", r.action, RA_ACCEPT);
+    }
+
+    printf("U: a flip keeps the sub-position (increases) -> inference does NOT fire\n");
+    {
+        ReconcileState st = anchoredAt(500294.0, p);   // sub = 94
+        ReconcileResult r = reconcileStep(st, 500396.0, /*clean*/true, /*wrap*/false, p); // sub = 96
+        check("flip (sub increased) held", r.value, 500294.0);
+    }
+
+    printf("V: small backward jitter of the dial below cannot fake wrap evidence\n");
+    {
+        ReconcileState st = anchoredAt(500294.0, p);   // sub = 94
+        ReconcileResult r = reconcileStep(st, 500391.0, /*clean*/false, /*wrap*/false, p); // sub = 91
+        check("flip with jittered-low sub held (margin)", r.value, 500294.0);
+    }
+
+    printf("W: stuck-recovery additionally requires a STABLE recognition\n");
+    {
+        ReconcileState st = anchoredAt(500200.0, p);
+        ReconcileResult r;
+        for (int i = 0; i < 8; ++i) {   // clean carry frames, but the value flip-flops
+            double cand = (i % 2 == 0) ? 500320.0 : 500340.0;
+            r = reconcileStep(st, cand, /*clean*/true, /*wrap*/false, p);
+        }
+        check("unstable candidates never recover", r.value, 500200.0);
+        reconcileStep(st, 500320.0, /*clean*/true, /*wrap*/false, p);      // set lastCandidate
+        r = reconcileStep(st, 500320.0, /*clean*/true, /*wrap*/false, p);  // stable -> recover
+        check("stable candidate recovers", r.value, 500320.0);
+        checkAction("stable recovery -> ACCEPT", r.action, RA_ACCEPT);
+    }
+
+    printf("\n==== %d passed, %d failed ====\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/code/test/host/test_meter_reconcile_host.cpp
+++ b/code/test/host/test_meter_reconcile_host.cpp
@@ -209,9 +209,11 @@ int main() {
         ReconcileState st = anchoredAt(500000.0, pq);
         ReconcileResult r = reconcileStep(st, 900000.0, /*clean*/true, /*wrap*/false, pq); // huge carry
         check("huge carry still held (gate applies)", r.value, 500000.0);
+        // Removing the ceiling does NOT open the recovery path: recoverMaxSteps bounds it
+        // independently, so a wildly-off reading stays held however long it persists.
         for (int i = 0; i < pq.recoverHolds; ++i) reconcileStep(st, 900000.0, false, false, pq);
-        r = reconcileStep(st, 900000.0, /*clean*/true, false, pq);   // sustained hold -> recover
-        check("recovery accepts once stuck (no ceiling)", r.value, 900000.0);
+        r = reconcileStep(st, 900000.0, /*clean*/true, false, pq);   // sustained hold, still capped
+        check("no ceiling still does not uncap recovery", r.value, 500000.0);
     }
 
     printf("R: a wrap seen one frame before the valid carry still accepts (sticky wrap)\n");
@@ -272,6 +274,48 @@ int main() {
         r = reconcileStep(st, 500320.0, /*clean*/true, /*wrap*/false, p);  // stable -> recover
         check("stable candidate recovers", r.value, 500320.0);
         checkAction("stable recovery -> ACCEPT", r.action, RA_ACCEPT);
+    }
+
+    printf("X: stuck-recovery is bounded - a far-away clean, stable misread is not recovered onto\n");
+    {
+        // The field failure this guards (issue #4112): the last whole-unit digit reads one ahead,
+        // i.e. +1000 == 10 msb steps, and sits perfectly clean and stable for hours while the meter
+        // is idle. Well under maxJump, so only the step cap can reject it.
+        ReconcileState st = anchoredAt(500200.0, p);
+        ReconcileResult r;
+        for (int i = 0; i < 30; ++i) {              // far beyond recoverHolds
+            r = reconcileStep(st, 501200.0, /*clean*/true, /*wrap*/false, p);
+        }
+        check("digit-ahead misread never recovered onto", r.value, 500200.0);
+        checkAction("far misread -> HOLD", r.action, RA_HOLD);
+    }
+
+    printf("Y: the cap still allows the single-step healing that recovery exists for\n");
+    {
+        ReconcileState st = anchoredAt(500200.0, p);
+        ReconcileResult r;
+        for (int i = 0; i < 7; ++i) {
+            r = reconcileStep(st, 500320.0, /*clean*/true, /*wrap*/false, p);   // 1 step
+        }
+        check("one-step recovery still works", r.value, 500320.0);
+
+        ReconcileState st2 = anchoredAt(500200.0, p);
+        for (int i = 0; i < 7; ++i) {
+            r = reconcileStep(st2, 500420.0, /*clean*/true, /*wrap*/false, p);  // 2 steps
+        }
+        check("two-step recovery refused by default cap", r.value, 500200.0);
+    }
+
+    printf("Z: recoverMaxSteps <= 0 restores the unbounded behaviour\n");
+    {
+        ReconcileParams q = p;
+        q.recoverMaxSteps = 0;                      // cap disabled
+        ReconcileState st = anchoredAt(500200.0, q);
+        ReconcileResult r;
+        for (int i = 0; i < 7; ++i) {
+            r = reconcileStep(st, 501200.0, /*clean*/true, /*wrap*/false, q);
+        }
+        check("uncapped recovery accepts the far jump", r.value, 501200.0);
     }
 
     printf("\n==== %d passed, %d failed ====\n", g_pass, g_fail);

--- a/param-docs/parameter-pages/PostProcessing/NUMBER.HistoryMaxJump.md
+++ b/param-docs/parameter-pages/PostProcessing/NUMBER.HistoryMaxJump.md
@@ -1,0 +1,20 @@
+# Parameter `HistoryMaxJump`
+Default Value: `auto` (≈ 100 × the most-significant analog dial step)
+
+!!! Warning
+    This is an **Expert Parameter**! Only change it if you understand what it does!
+
+Upper bound (in the meter's value units, after `DecimalShift`) on how much the reading may change
+in a single cycle when `HistoryReconcile` is enabled. A change larger than this is treated as a
+gross misread (e.g. a whole leading digit recognised wrongly during a multi-dial cascade rollover)
+and is rejected; the previous value is held.
+
+If left unset, it is **derived automatically** from the dial scale (about 100 steps of the
+most-significant analog dial), so it adapts to your meter's unit and `DecimalShift`. Set an explicit
+value only to override: above the largest plausible real change between two cycles (consumption per
+cycle plus head-room for a few missed cycles), and well below the magnitude of a leading-digit misread.
+
+Only relevant when `HistoryReconcile` is `true`.
+
+!!! Note
+    If you edit the config file manually, you must prefix this parameter with `<NUMBER>` followed by a dot (eg. `main.HistoryMaxJump`). The reason is that this parameter is specific for each `<NUMBER>` (`<NUMBER>` is the name of the number sequence defined in the ROI's).

--- a/param-docs/parameter-pages/PostProcessing/NUMBER.HistoryReconcile.md
+++ b/param-docs/parameter-pages/PostProcessing/NUMBER.HistoryReconcile.md
@@ -1,0 +1,50 @@
+# Parameter `HistoryReconcile`
+Default Value: `false`
+
+!!! Warning
+    This is an **Expert Parameter**! Only change it if you understand what it does!
+
+History-anchored reconciliation of the reading. When enabled, the post-processing no longer
+relies on the fixed `MaxRateValue` / `AllowNegativeRates` guards for sequences that have analog
+ROIs. Instead it uses the physical properties of a mechanical counter to decide, every cycle,
+whether to accept the recognised value or hold the previous one:
+
+- A step across a most-significant analog-dial boundary (a *carry*) is accepted **only** with
+  evidence that the dial below it wrapped (9 → 0): either observed directly since a recent cycle,
+  or inferred from the reading itself (a genuine carry passes the sub-position through zero, while
+  a premature dial flip leaves it unchanged). This is enforced on **both** clean and ambiguous
+  frames, because a pointer can be misread part of a step off its true position without landing
+  near an integer (so a premature carry could otherwise look "clean"). Otherwise the previous
+  value is held. This is what blocks the premature/early dial transitions.
+- Motion *within* a dial step is trusted on a clean frame; on an ambiguous frame forward motion is
+  allowed while only sub-noise backward jitter is tolerated.
+- As recovery, a clean carry is accepted once the value has been held for a sustained stretch
+  (genuinely stuck, not merely flickering) — this self-heals a stuck value and absorbs a legitimate
+  catch-up after a gap.
+- A physically impossible single-cycle jump (see `HistoryMaxJump`) is never accepted.
+
+This is most useful for meters with "early transition" dials, where a pointer (or digit) flips
+ahead of the actual rollover. It complements `CheckDigitIncreaseConsistency`, which handles the
+digit chain; `HistoryReconcile` adds the equivalent protection on the analog dial chain.
+
+It has no effect on sequences without analog ROIs.
+
+!!! Note "Capture interval"
+    The logic assumes the typical consumption between two cycles stays well below one step of the
+    most-significant analog dial (e.g. well under 100 L per cycle on a meter whose top dial counts
+    ×0.1 m³). This holds comfortably for the usual 1–5 minute intervals. With much longer
+    intervals, heavy flow can exceed that per-cycle step: the value then holds during the flow
+    burst and catches up shortly after flow pauses — nothing is lost, but readings lag during the
+    burst.
+
+!!! Note "Recovery behaviour"
+    A held value re-anchors as soon as a cycle is *unambiguous* (no dial near a boundary) or a
+    genuine carry is observed, so it does not stay stuck once the dials move on. The thresholds
+    (`maxJump`, the backward-jitter tolerance, and the gross-misread ceiling) are derived from the
+    meter's decimal scaling, and the "near a boundary" margin is a built-in default sized to the
+    analog recognition scatter. As a final safety net, a value that is wrong by more than `maxJump`
+    (a rare gross corruption) is recovered by the normal `PreValueAgeStartup` re-seed rather than
+    silently persisting.
+
+!!! Note
+    If you edit the config file manually, you must prefix this parameter with `<NUMBER>` followed by a dot (eg. `main.HistoryReconcile`). The reason is that this parameter is specific for each `<NUMBER>` (`<NUMBER>` is the name of the number sequence defined in the ROI's).

--- a/param-docs/parameter-pages/PostProcessing/NUMBER.HistoryReconcile.md
+++ b/param-docs/parameter-pages/PostProcessing/NUMBER.HistoryReconcile.md
@@ -19,8 +19,10 @@ whether to accept the recognised value or hold the previous one:
 - Motion *within* a dial step is trusted on a clean frame; on an ambiguous frame forward motion is
   allowed while only sub-noise backward jitter is tolerated.
 - As recovery, a clean carry is accepted once the value has been held for a sustained stretch
-  (genuinely stuck, not merely flickering) — this self-heals a stuck value and absorbs a legitimate
-  catch-up after a gap.
+  (genuinely stuck, not merely flickering) — this self-heals a value left behind by a missed carry.
+  Recovery is limited to a single dial step: a reading that is further out than that is left held
+  instead, because staying clean and stable is no evidence that a reading a whole digit away is
+  correct.
 - A physically impossible single-cycle jump (see `HistoryMaxJump`) is never accepted.
 
 This is most useful for meters with "early transition" dials, where a pointer (or digit) flips
@@ -42,9 +44,14 @@ It has no effect on sequences without analog ROIs.
     genuine carry is observed, so it does not stay stuck once the dials move on. The thresholds
     (`maxJump`, the backward-jitter tolerance, and the gross-misread ceiling) are derived from the
     meter's decimal scaling, and the "near a boundary" margin is a built-in default sized to the
-    analog recognition scatter. As a final safety net, a value that is wrong by more than `maxJump`
-    (a rare gross corruption) is recovered by the normal `PreValueAgeStartup` re-seed rather than
-    silently persisting.
+    analog recognition scatter.
+
+    Recovery deliberately will **not** jump onto a reading that is more than one dial step away,
+    even if that reading looks clean and stays steady for hours — a digit that reads one position
+    ahead does exactly that while the meter is idle, and re-anchoring onto it would silently put the
+    total a whole digit out. Such a value keeps being held, which is visible (the reading stops
+    advancing and `value` diverges from `raw`) and harmless to the totals; it is then resolved by the
+    normal `PreValueAgeStartup` re-seed or by setting the pre-value from the meter face.
 
 !!! Note
     If you edit the config file manually, you must prefix this parameter with `<NUMBER>` followed by a dot (eg. `main.HistoryReconcile`). The reason is that this parameter is specific for each `<NUMBER>` (`<NUMBER>` is the name of the number sequence defined in the ROI's).

--- a/sd-card/html/edit_config_template.html
+++ b/sd-card/html/edit_config_template.html
@@ -1027,6 +1027,19 @@
             <td>$TOOLTIP_PostProcessing_NUMBER.CheckDigitIncreaseConsistency</td>
         </tr>
 
+        <tr class="expert" unused_id="ex1hist">
+            <td class="indent2">
+                <label><class id="PostProcessing_HistoryReconcile_text" style="color:black;">History Reconcile</class></label>
+            </td>
+            <td>
+                <select id="PostProcessing_HistoryReconcile_value1">
+                    <option value="true">enabled (true)</option>
+                    <option value="false" selected>disabled (false)</option>
+                </select>
+            </td>
+            <td>$TOOLTIP_PostProcessing_NUMBER.HistoryReconcile</td>
+        </tr>
+
         <!------------- MQTT ------------------>
         <tr style="border-bottom: 2px solid lightgray;">
             <td colspan="3" style="padding-left: 0px; padding-bottom: 3px;">
@@ -2257,6 +2270,7 @@ function UpdateInputIndividual(sel) {
         // ReadParameter(param, "PostProcessing", "IgnoreAllNaN", false, NUNBERSAkt);
         ReadParameter(param, "PostProcessing", "AllowNegativeRates", false, NUNBERSAkt);
         ReadParameter(param, "PostProcessing", "CheckDigitIncreaseConsistency", false, NUNBERSAkt);
+        ReadParameter(param, "PostProcessing", "HistoryReconcile", false, NUNBERSAkt);
         ReadParameter(param, "InfluxDB", "Field", true, NUNBERSAkt);
         ReadParameter(param, "InfluxDBv2", "Field", true, NUNBERSAkt);
         ReadParameter(param, "InfluxDB", "Measurement", true, NUNBERSAkt);
@@ -2277,6 +2291,7 @@ function UpdateInputIndividual(sel) {
     // WriteParameter(param, category, "PostProcessing", "IgnoreAllNaN", false, NUNBERSAkt);
     WriteParameter(param, category, "PostProcessing", "AllowNegativeRates", false, NUNBERSAkt);
     WriteParameter(param, category, "PostProcessing", "CheckDigitIncreaseConsistency", false, NUNBERSAkt);
+    WriteParameter(param, category, "PostProcessing", "HistoryReconcile", false, NUNBERSAkt);
     WriteParameter(param, category, "InfluxDB", "Field", true, NUNBERSAkt);
     WriteParameter(param, category, "InfluxDBv2", "Field", true, NUNBERSAkt);
     WriteParameter(param, category, "InfluxDB", "Measurement", true, NUNBERSAkt);

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -182,6 +182,7 @@ function ParseConfig() {
     // ParamAddValue(param, catname, "IgnoreAllNaN", 1, true, "false");
     ParamAddValue(param, catname, "ErrorMessage");
     ParamAddValue(param, catname, "CheckDigitIncreaseConsistency", 1, true, "false");
+    ParamAddValue(param, catname, "HistoryReconcile", 1, true, "false");
 
     var catname = "MQTT";
     category[catname] = new Object();


### PR DESCRIPTION
## Summary

Adds an **opt-in** history-anchored reconciliation layer to post-processing that fixes a class of wrong readings on meters with "early transition" analog dials, addressing #4112.

On such meters a pointer (or digit) flips ahead of the real rollover, so a single frame can be recognised as a value that is off by one dial step (e.g. ±100 L). The existing single-frame logic and the `MaxRateValue` / `AllowNegativeRates` guards can't distinguish such a premature — and often *stable* — misread from real flow, so it gets accepted and poisons `PreValue`; a tightened rate cap then rejects the legitimate catch-up and pins the reading. Config alone can't resolve this (the flip magnitude overlaps real flow; `Analog_error` is a compile-time constant).

Default-off, so existing installs are byte-for-byte unaffected.

## How it works

A new pure, dependency-free module (`MeterReconcile`, `code/components/jomjol_flowcontroll/MeterReconcile.{h,cpp}`) reconciles each frame's recognised value against the last trusted value using the meter's physical properties:

- **Carry gate.** A value crossing a most-significant-analog-dial step (a *carry*) is accepted only with evidence that the dial below actually wrapped 9→0, as a single forward step. This is enforced on **both** "clean" and ambiguous frames, because a pointer misread part of a step off its true position need not land near an integer — so a premature carry can otherwise masquerade as a trustworthy reading. Wrap evidence comes from three independent channels:
  1. the dial-below transition observed directly since the previous frame;
  2. a short "sticky" window, since the wrap and the valid carry can land on different frames (the wrap frame may itself be a misread);
  3. **inference from the value** — a genuine carry passes the sub-position (the part below one dial step) through zero, while a premature flip leaves it unchanged. This alone recovers a stalled reading with no observed wrap and no clean frame.
- **Within-step motion** is trusted on a clean frame; on an ambiguous frame forward motion is allowed while only sub-noise backward jitter is tolerated.
- **Stuck-recovery.** After the value has been held for a sustained, stable stretch, a clean frame re-anchors across a carry (heals a wrong anchor / absorbs catch-up).
- **Gross-misread ceiling.** A physically impossible single-frame jump is never accepted.

All thresholds (`msbStep`, `noiseTol`, `maxJump`) are derived per-frame from the meter's decimal scaling, so it works for digit+analog and analog-only layouts, extended resolution or not. It complements `CheckDigitIncreaseConsistency` (which handles the digit chain) by adding the equivalent protection on the analog dial chain, and replaces the fixed rate guards only while enabled.

## Configuration

Two new per-`<NUMBER>` parameters (docs under `param-docs/`):

- `HistoryReconcile` (default `false`) — enable it.
- `HistoryMaxJump` (default: auto-derived from the dial scale) — optional gross-misread ceiling override.

No effect on sequences without analog ROIs.

## Testing

- **Host unit tests** (`code/test/host/`, 53 checks) cover the carry gate (all three evidence channels), premature-flip rejection on clean and ambiguous frames, backward/multi-step carry rejection, gross-misread rejection, scale invariance, floating-point boundary safety, and stability-bounded recovery. A CI job compiles and runs them on every push (can be dropped if you'd prefer not to touch the workflow).
- **Firmware build + packaging** pass in CI.
- **Validated on a real early-transition meter for ~1 week**, including the exact failures from #4112:
  - premature ±100 L dial flips — **held**, no longer poison `PreValue`;
  - the ±900 L 0/9-seam flicker (`ana1` read as 9.x while just past 0) — **rejected** every frame while genuine flow between them is still tracked;
  - a full multi-dial cascade rollover (`ana1` 9→0 + thousands digit + `dig5`=`N`) — **crossed cleanly in real time, zero hold frames** (the case that previously stalled for ~50 min);
  - **zero accepted poison** over 3 continuous days; running total stays exact and HA long-term statistics stay clean.

## Notes

- Opt-in + default-off ⇒ no regression risk for existing users.
- Scoped to sequences **with analog ROIs** by design: the digit chain already has its
  history-anchored guard (`CheckDigitIncreaseConsistency`), and the reconciler's evidence signals
  (boundary-band cleanliness, wrap observation, sub-position inference) are properties of
  continuously rotating pointers — a digit wheel parks *at* integers, so the ambiguity model does
  not transfer. Extending it to digit-only meters with continuous digit models would be possible
  future work, but needs its own ambiguity model and validation.
- Operating assumption (documented): typical consumption between two cycles stays well below one
  most-significant-dial step. With very long capture intervals, heavy flow can exceed that
  per-cycle step; the value then holds during the burst and catches up shortly after flow pauses
  (nothing lost, but readings lag). A time-aware accept path for such multi-step catch-up would be
  possible future work.
- Recognition scatter is the root trigger; reducing it further (e.g. enabling `AntiAliasing` for the alignment rotation) lowers how often the guard has to engage — measured ~50 % less analog scatter on the test meter — but that's independent of this change.