### PR TITLE
Preserve AntiAliasing through the config editor, add GUI control

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# [Unreleased]
+
+### Core Changes and Bug fixes
+- The `AntiAliasing` alignment option is now preserved by the config editor (previously silently dropped on every ROI/alignment save) and is directly editable in the expert config page
+
+
 # [16.1.0] - 2026-01-11
 
 For a full list of changes see [Full list of changes](https://github.com/jomjol/AI-on-the-edge-device/compare/v16.0.0...v16.1.0)

--- a/param-docs/parameter-pages/Alignment/AntiAliasing.md
+++ b/param-docs/parameter-pages/Alignment/AntiAliasing.md
@@ -1,0 +1,14 @@
+# Parameter `AntiAliasing`
+Default Value: `false`
+
+!!! Warning
+    This is an **Expert Parameter**! Only change it if you understand what it does!
+
+Use bilinear interpolation instead of nearest-neighbor when rotating the image during
+alignment. This produces a sharper, less blocky aligned image, which reduces recognition
+scatter on analog dials - fewer borderline reads means fewer values held or corrected by
+post-processing.
+
+The nearest-neighbor rotation used when this is `false` is faster, but truncates each
+rotated pixel to its nearest source pixel, which can visibly soften/blur fine details such
+as pointer positions on analog dials.

--- a/sd-card/html/edit_config_template.html
+++ b/sd-card/html/edit_config_template.html
@@ -742,6 +742,19 @@
             <td>$TOOLTIP_Alignment_AlignmentAlgo</td>
         </tr>
 
+        <tr class="expert" unused_id="Alignment_AntiAliasing_ex8">
+            <td class="indent1">
+                <label><class id="Alignment_AntiAliasing_text" style="color:black;">Anti-Aliasing</class></label>
+            </td>
+            <td>
+                <select id="Alignment_AntiAliasing_value1">
+                    <option value="true">enabled (true)</option>
+                    <option value="false" selected>disabled (false)</option>
+                </select>
+            </td>
+            <td>$TOOLTIP_Alignment_AntiAliasing</td>
+        </tr>
+
         <tr unused_id="Alignment_InitialRotate_ex8">
             <td class="indent1">
                 <class id="Alignment_InitialRotate_text" style="color:black;">Rotation angle</class>
@@ -2344,7 +2357,8 @@ function UpdateInput() {
 	
     WriteParameter(param, category, "Alignment", "SearchFieldX", false);		
     WriteParameter(param, category, "Alignment", "SearchFieldY", false);		
-    WriteParameter(param, category, "Alignment", "AlignmentAlgo", true);			
+    WriteParameter(param, category, "Alignment", "AlignmentAlgo", true);
+    WriteParameter(param, category, "Alignment", "AntiAliasing", false);
     WriteParameter(param, category, "Alignment", "InitialRotate", false);
 
     WriteParameter(param, category, "Digits", "CNNGoodThreshold", true);
@@ -2512,6 +2526,7 @@ function ReadParameterAll() {
     ReadParameter(param, "Alignment", "SearchFieldX", false);	
     ReadParameter(param, "Alignment", "SearchFieldY", false);
     ReadParameter(param, "Alignment", "AlignmentAlgo", true);
+    ReadParameter(param, "Alignment", "AntiAliasing", false);
     ReadParameter(param, "Alignment", "InitialRotate", false);
 
     ReadParameter(param, "Digits", "Model", false);

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -143,6 +143,7 @@ function ParseConfig() {
     ParamAddValue(param, catname, "SearchFieldX");
     ParamAddValue(param, catname, "SearchFieldY");
     ParamAddValue(param, catname, "AlignmentAlgo");
+    ParamAddValue(param, catname, "AntiAliasing", 1, false, "false");
 
     var catname = "Digits";
     category[catname] = new Object();


### PR DESCRIPTION
The web config editor rebuilds `config.ini` from a hardcoded whitelist of
known keys (`readconfigparam.js`, `ParseConfig`/`WriteConfigININew`). Keys
not registered there are read correctly but silently omitted when the file
is rewritten.

`AntiAliasing` was never registered, so **every** save from any
ROI/alignment/digit/analog editor page (they all share the write path)
dropped it — silently reverting the meter to nearest-neighbor rotation.
Anyone who sets it by hand loses it on their next ROI edit.

Registers the parameter so its value survives saves, and adds a control to
the expert config page (mirroring `AlignmentAlgo`) so it's editable in the
UI instead of only by hand-editing `config.ini`. Includes a parameter doc
page for the tooltip.

No C++ change needed — the backend already parses it correctly.