### PR TITLE
Fix checkDigitConsistency corrupting sub-digits of large readings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# [Unreleased]
+
+### Core Changes and Bug fixes
+- Fixed `checkDigitConsistency` corrupting the sub-digit part of large readings: it computed in `double` but returned `float`, so once a meter passed ~1,000,000 (7+ significant digits) the narrowing to 32-bit float mangled the decimals (e.g. a reading of `…691.67` was published as `…691.75`). The function now returns `double` and uses a `double` working variable throughout.
+
+
 # [16.1.0] - 2026-01-11
 
 For a full list of changes see [Full list of changes](https://github.com/jomjol/AI-on-the-edge-device/compare/v16.0.0...v16.1.0)

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.cpp
@@ -1106,11 +1106,11 @@ string ClassFlowPostProcessing::ErsetzteN(string input, double _prevalue) {
     return input;
 }
 
-float ClassFlowPostProcessing::checkDigitConsistency(double input, int _decilamshift, bool _isanalog, double _preValue) {
+double ClassFlowPostProcessing::checkDigitConsistency(double input, int _decilamshift, bool _isanalog, double _preValue) {
     int aktdigit, olddigit;
     int aktdigit_before, olddigit_before;
     int pot, pot_max;
-    float zw;
+    double zw;
     bool no_nulldurchgang = false;
 
     pot = _decilamshift;
@@ -1142,13 +1142,13 @@ float ClassFlowPostProcessing::checkDigitConsistency(double input, int _decilams
 
         if (no_nulldurchgang) {
             if (aktdigit != olddigit) {
-                input = input + ((float) (olddigit - aktdigit)) * pow(10, pot);     // New Digit is replaced by old Digit;
+                input = input + ((double) (olddigit - aktdigit)) * pow(10, pot);     // New Digit is replaced by old Digit;
             }
         }
         else {
             // despite zero crossing, digit was not incremented --> add 1
             if (aktdigit == olddigit) {
-                input = input + ((float) (1)) * pow(10, pot);   // add 1 at the point
+                input = input + ((double) (1)) * pow(10, pot);   // add 1 at the point
             }
         }
 			

--- a/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
+++ b/code/components/jomjol_flowcontroll/ClassFlowPostProcessing.h
@@ -30,7 +30,7 @@ protected:
     string ShiftDecimal(string in, int _decShift);
 
     string ErsetzteN(string, double _prevalue);
-    float checkDigitConsistency(double input, int _decilamshift, bool _isanalog, double _preValue);
+    double checkDigitConsistency(double input, int _decilamshift, bool _isanalog, double _preValue);
 
     void InitNUMBERS();
 	


### PR DESCRIPTION
`checkDigitConsistency` takes a `double` and does all arithmetic in
`double`, but was declared to return `float`. Once a reading exceeds
~1,000,000 the whole-number part alone consumes 32-bit float's ~7-digit
precision budget, so the implicit narrowing at `return` mangles the
sub-digit decimals — no rounding rule involved, simply out of mantissa bits.

Observed on a water meter at 2116691.67, published as **2116691.75**: a
0.08 L error on every round, recurring for as long as the meter stays past
1M. Affects any user past ~1,000,000 with `CheckDigitIncreaseConsistency`
enabled.

Returns `double` and widens the working variable, matching the `double`
precision used throughout the rest of post-processing. Verified on-device:
raw `.78` now publishes as `.78` instead of being corrupted.